### PR TITLE
Updated for 26.1

### DIFF
--- a/appdata-releases.patch
+++ b/appdata-releases.patch
@@ -1,24 +1,27 @@
-From c7fc3ce6063a3f1a4daffb6abb9397277211ef6c Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?Joonas=20Saraj=C3=A4rvi?= <muep@iki.fi>
-Date: Tue, 17 Apr 2018 21:58:19 +0300
-Subject: [PATCH] Add releases element to appdata.xml
+From e9d8ade2f30d4458cef1671a5366a5d1691fe450 Mon Sep 17 00:00:00 2001
+From: Zach Oglesby <zach@oglesby.co>
+Date: Mon, 28 May 2018 10:56:47 -0400
+Subject: [PATCH 2/2] added release date to appdata
 
 ---
- etc/emacs.appdata.xml | 3 +++
- 1 file changed, 3 insertions(+)
+ etc/emacs.appdata.xml | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/etc/emacs.appdata.xml b/etc/emacs.appdata.xml
-index 0ba305c452..1dd4775460 100644
+index c39668c635..4fca9b50b1 100644
 --- a/etc/emacs.appdata.xml
 +++ b/etc/emacs.appdata.xml
-@@ -30,4 +30,7 @@
-  <url type="homepage">http://www.gnu.org/software/emacs</url>
-  <updatecontact>emacs-devel_at_gnu.org</updatecontact>
-  <project_group>GNU</project_group>
+@@ -31,6 +31,9 @@
+  <launchable type="desktop-id">emacs</launchable>
+  <url type="homepage">https://www.gnu.org/software/emacs</url>
+  <update_contact>emacs-devel_AT_gnu.org</update_contact>
+- <project_group>GNU</project_group>
++ <project_group>GNU</project_group>
 + <releases>
-+   <release date="2017-09-11" version="25.3"/>
++ <release date="2018-05-28" version="26.1"/>
 + </releases>
- </application>
++ 
+ </component>
 -- 
-2.14.3
+2.17.0
 

--- a/org.gnu.emacs.json
+++ b/org.gnu.emacs.json
@@ -18,15 +18,12 @@
     "modules": [
         {
             "name": "emacs",
+            "buildsystem": "autotools",
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://www.nic.funet.fi/pub/gnu/ftp.gnu.org/pub/gnu/emacs/emacs-25.3.tar.xz",
-                    "sha256": "253ac5e7075e594549b83fd9ec116a9dc37294d415e2f21f8ee109829307c00b"
-                },
-                {
-                    "type": "patch",
-                    "path": "locale-fixup.patch"
+                    "url": "http://ftpmirror.gnu.org/emacs/emacs-26.1.tar.xz",
+                    "sha256": "1cf4fc240cd77c25309d15e18593789c8dbfba5c2b44d8f77c886542300fd32c"
                 },
                 {
                     "type": "patch",


### PR DESCRIPTION
Updated for 26.1, changed source type to git tag to help deal some concerns people had with security of source.