### PR TITLE
Switch to using a fixed mirror

### DIFF
--- a/org.gnu.emacs.json
+++ b/org.gnu.emacs.json
@@ -22,7 +22,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://ftpmirror.gnu.org/emacs/emacs-26.1.tar.xz",
+                    "url": "http://www.nic.funet.fi/pub/gnu/ftp.gnu.org/pub/gnu/emacs/emacs-26.1.tar.xz",
                     "sha256": "1cf4fc240cd77c25309d15e18593789c8dbfba5c2b44d8f77c886542300fd32c"
                 },
                 {


### PR DESCRIPTION
There seems to be an issue with flathub builds not finding the source
when the central download link is used. This should still get us the
same source and is only slightly less reliable due to requiring that
this single mirror is up when the build is run.

This change can later be reverted when the issue with downloading from
that official URL in flathub build infra is fixed.