### PR TITLE
Mount /var/tmp into the sandbox

### DIFF
--- a/org.gnu.emacs.json
+++ b/org.gnu.emacs.json
@@ -13,7 +13,8 @@
         "--socket=pulseaudio",
         "--socket=x11",
         "--filesystem=host",
-        "--filesystem=/tmp"
+        "--filesystem=/tmp",
+        "--filesystem=/var/tmp"
     ],
     "modules": [
         {


### PR DESCRIPTION
This is required at least by sudo -e. Also some other tools that work
with the same logic might choose to use /var/tmp as the location for
the temporary copy.