### PR TITLE
Update the launchable element in appdata

### DIFF
--- a/appdata-launchable.patch
+++ b/appdata-launchable.patch
@@ -1,0 +1,25 @@
+From 74f1ee89c23e84f267e3b4c965f60f777ba16117 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joonas=20Saraj=C3=A4rvi?= <muep@iki.fi>
+Date: Thu, 31 May 2018 21:59:22 +0300
+Subject: [PATCH] appdata: Update the launchable id
+
+---
+ etc/emacs.appdata.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/etc/emacs.appdata.xml b/etc/emacs.appdata.xml
+index ac63add275..e582eadbb0 100644
+--- a/etc/emacs.appdata.xml
++++ b/etc/emacs.appdata.xml
+@@ -28,7 +28,7 @@
+   <image type="source" width="632" height="354">https://www.gnu.org/software/emacs/images/appdata.png</image>
+  </screenshot>
+  </screenshots>
+- <launchable type="desktop-id">emacs</launchable>
++ <launchable type="desktop-id">org.gnu.emacs.desktop</launchable>
+  <url type="homepage">https://www.gnu.org/software/emacs</url>
+  <update_contact>emacs-devel_AT_gnu.org</update_contact>
+  <project_group>GNU</project_group>
+-- 
+2.14.3
+

--- a/appdata-releases.patch
+++ b/appdata-releases.patch
@@ -1,25 +1,24 @@
-From e9d8ade2f30d4458cef1671a5366a5d1691fe450 Mon Sep 17 00:00:00 2001
-From: Zach Oglesby <zach@oglesby.co>
-Date: Mon, 28 May 2018 10:56:47 -0400
-Subject: [PATCH 2/2] added release date to appdata
+From b8e845d75f264faf33e595426ddba07b73496ccb Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joonas=20Saraj=C3=A4rvi?= <muep@iki.fi>
+Date: Tue, 17 Apr 2018 21:58:19 +0300
+Subject: [PATCH] Add releases element to appdata.xml
 
 ---
- etc/emacs.appdata.xml | 5 ++++-
- 1 file changed, 4 insertions(+), 1 deletion(-)
+ etc/emacs.appdata.xml | 3 +++
+ 1 file changed, 3 insertions(+)
 
 diff --git a/etc/emacs.appdata.xml b/etc/emacs.appdata.xml
-index c39668c635..4fca9b50b1 100644
+index c39668c635..ac63add275 100644
 --- a/etc/emacs.appdata.xml
 +++ b/etc/emacs.appdata.xml
-@@ -31,5 +31,8 @@
-  <launchable type="desktop-id">emacs</launchable>
+@@ -32,4 +32,7 @@
   <url type="homepage">https://www.gnu.org/software/emacs</url>
   <update_contact>emacs-devel_AT_gnu.org</update_contact>
-- <project_group>GNU</project_group>
-+ <project_group>GNU</project_group>
+  <project_group>GNU</project_group>
 + <releases>
-+ <release date="2018-05-28" version="26.1"/>
++   <release date="2018-05-28" version="26.1"/>
 + </releases>
  </component>
 -- 
-2.17.0
+2.14.3
+

--- a/org.gnu.emacs.json
+++ b/org.gnu.emacs.json
@@ -29,6 +29,10 @@
                 {
                     "type": "patch",
                     "path": "appdata-releases.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "appdata-launchable.patch"
                 }
             ],
             "cleanup": [


### PR DESCRIPTION
In the responses to issue #410 of flathub/flathub [1], it is suggested
that the value of the launchable element is not correct. Indeed in
appstream documentation [2] it is described as holding a desktop-file
id which in turn in simple cases is documented to basically be the
exact file name of the desktop file [3].

This commit just changes the launchable id to match the file name that
is used in the flatpak, org.gnu.emacs.desktop, which happens to differ
from the simple emacs.desktop name that is still used by
upstream. Ideally this should be cleaned up so that this patching is
not needed.

[1] https://github.com/flathub/flathub/issues/410
[2] https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-launchable
[3] https://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#desktop-file-id