### PR TITLE
Switch to the 18.08 version of the FDO runtime

### DIFF
--- a/org.gnu.emacs.json
+++ b/org.gnu.emacs.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnu.emacs",
     "runtime": "org.freedesktop.Sdk",
-    "runtime-version": "1.6",
+    "runtime-version": "18.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "emacs",
     "rename-icon": "emacs",


### PR DESCRIPTION
Seems like there are few or no downsides to using more recent libraries and suchlike, so let's upgrade.