### PR TITLE
Enable TLS support

### DIFF
--- a/org.gnu.emacs.json
+++ b/org.gnu.emacs.json
@@ -20,6 +20,9 @@
         {
             "name": "emacs",
             "buildsystem": "autotools",
+            "config-opts": [
+                "--with-gnutls"
+            ],
             "sources": [
                 {
                     "type": "archive",


### PR DESCRIPTION
This is a requirement for the spacemacs develop branch.
See also: https://github.com/syl20bnr/spacemacs/issues/11585
Fixes #19