### PR TITLE
Add Jansson dependency

### DIFF
--- a/org.gnu.emacs.json
+++ b/org.gnu.emacs.json
@@ -18,6 +18,17 @@
     ],
     "modules": [
         {
+            "name": "jansson",
+            "buildsystem": "autotools",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://digip.org/jansson/releases/jansson-2.13.1.tar.gz",
+                    "sha256": "f4f377da17b10201a60c1108613e78ee15df6b12016b116b6de42209f47a474f"
+                }
+            ]
+        },
+        {
             "name": "emacs",
             "buildsystem": "autotools",
             "config-opts": [

--- a/org.gnu.emacs.json
+++ b/org.gnu.emacs.json
@@ -32,7 +32,8 @@
                 "/bin",
                 "/share",
                 "/lib/pkgconfig",
-                "/lib/*.la"
+                "/lib/*.la",
+                "/app/lib/libjansson.a"
             ]
         },
         {

--- a/org.gnu.emacs.json
+++ b/org.gnu.emacs.json
@@ -33,7 +33,7 @@
                 "/share",
                 "/lib/pkgconfig",
                 "/lib/*.la",
-                "/app/lib/libjansson.a"
+                "/lib/libjansson.a"
             ]
         },
         {

--- a/org.gnu.emacs.json
+++ b/org.gnu.emacs.json
@@ -26,6 +26,13 @@
                     "url": "https://digip.org/jansson/releases/jansson-2.13.1.tar.gz",
                     "sha256": "f4f377da17b10201a60c1108613e78ee15df6b12016b116b6de42209f47a474f"
                 }
+            ],
+            "cleanup": [
+                "/include",
+                "/bin",
+                "/share",
+                "/lib/pkgconfig",
+                "/lib/*.la"
             ]
         },
         {


### PR DESCRIPTION
Emacs 27.1 uses this library if available.

Fixes #35