### PR TITLE
Add some support for SDK extensions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "wrapper"]
+	path = wrapper
+	url = https://github.com/gasinvein/vscode-flatpak-wrapper.git

--- a/emacs-first-run.txt
+++ b/emacs-first-run.txt
@@ -1,0 +1,31 @@
+
+https://www.flathub.org
+
+------------------------------------------------------------------------------------
+| Warning: You are running an unofficial Flatpak version of @EDITOR_TITLE@ !!! |
+------------------------------------------------------------------------------------
+
+Please open issues under: https://github.com/flathub/@FLATPAK_ID@/issues
+
+
+This version is running inside a container and is therefore not able
+to access SDKs on your host system!
+
+This flatpak provides a standard development environment (gcc, python, etc).
+To see what's available:
+
+  $ flatpak run --command=sh @FLATPAK_ID@
+  $ ls /usr/bin (shared runtime)
+  $ ls /app/bin (bundled with this flatpak)
+
+To get support for additional languages, you have to install SDK extensions, e.g.
+
+  $ flatpak install flathub org.freedesktop.Sdk.Extension.dotnet
+  $ flatpak install flathub org.freedesktop.Sdk.Extension.golang
+  $ FLATPAK_ENABLE_SDK_EXT=dotnet,golang flatpak run @FLATPAK_ID@
+
+You can use
+
+  $ flatpak search <TEXT>
+
+to find others.

--- a/emacs.desktop-exec-wrapper.patch
+++ b/emacs.desktop-exec-wrapper.patch
@@ -1,0 +1,27 @@
+From 26b756f1ab5b22fd117e036144d4821febc95a09 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joonas=20Saraj=C3=A4rvi?= <muep@iki.fi>
+Date: Sat, 20 Feb 2021 21:29:25 +0200
+Subject: [PATCH] Execute emacs-wrapper instead of emacs
+
+This is needed in the flatpak-based distribution, so that invocations
+using the .desktop file will also go through the wrapper.
+---
+ etc/emacs.desktop | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/etc/emacs.desktop b/etc/emacs.desktop
+index 2e6496e58c..a518ec4a29 100644
+--- a/etc/emacs.desktop
++++ b/etc/emacs.desktop
+@@ -3,7 +3,7 @@ Name=Emacs
+ GenericName=Text Editor
+ Comment=Edit text
+ MimeType=text/english;text/plain;text/x-makefile;text/x-c++hdr;text/x-c++src;text/x-chdr;text/x-csrc;text/x-java;text/x-moc;text/x-pascal;text/x-tcl;text/x-tex;application/x-shellscript;text/x-c;text/x-c++;
+-Exec=emacs %F
++Exec=emacs-wrapper %F
+ Icon=emacs
+ Type=Application
+ Terminal=false
+-- 
+2.20.1
+

--- a/org.gnu.emacs.json
+++ b/org.gnu.emacs.json
@@ -3,7 +3,7 @@
     "runtime": "org.freedesktop.Sdk",
     "runtime-version": "20.08",
     "sdk": "org.freedesktop.Sdk",
-    "command": "emacs",
+    "command": "emacs-wrapper",
     "rename-icon": "emacs",
     "rename-appdata-file": "emacs.appdata.xml",
     "rename-desktop-file": "emacs.desktop",
@@ -50,6 +50,10 @@
                 },
                 {
                     "type": "patch",
+                    "path": "emacs.desktop-exec-wrapper.patch"
+                },
+                {
+                    "type": "patch",
                     "path": "appdata-releases.patch"
                 },
                 {
@@ -69,6 +73,27 @@
                 "/share/icons/hicolor/scalable/apps/emacs.ico",
                 "/share/icons/hicolor/scalable/mimetypes/emacs-document.svg",
                 "/share/icons/hicolor/scalable/mimetypes/emacs-document23.svg"
+            ]
+        },
+        {
+            "name": "wrapper",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "dir",
+                    "path": "wrapper"
+                },
+                {
+                    "type": "file",
+                    "path": "emacs-first-run.txt"
+                }
+            ],
+            "config-opts": [
+                "-Deditor_binary=/app/bin/emacs",
+                "-Dprogram_name=emacs-wrapper",
+                "-Deditor_title=GNU Emacs",
+                "-Dflagfile_prefix=flatpak-emacs",
+                "-Dfirst_run_template=emacs-first-run.txt"
             ]
         }
     ]


### PR DESCRIPTION
This fixes issue #31 by initially launching a wrapper script that
first adjusts our environment, and then launches the actual Emacs
executable.

The wrapper script is taken from the vscode-flatpak-wrapper
repository. Despite the name, this utility is suitable for other IDEs
as well.

Note: In this specific version, the wrapper submodule is taken from
my personal fork. This is intended to be pointed at the module
upstream once its pull request has been merged.