### PR TITLE
Clear out content rating items

### DIFF
--- a/appdata-content-rating.patch
+++ b/appdata-content-rating.patch
@@ -11,19 +11,12 @@ diff --git a/etc/emacs.appdata.xml b/etc/emacs.appdata.xml
 index abd545f85d..0794ce9ab6 100644
 --- a/etc/emacs.appdata.xml
 +++ b/etc/emacs.appdata.xml
-@@ -37,4 +37,14 @@
+@@ -37,4 +37,7 @@
     <release date="2019-04-12" version="26.2"/>
     <release date="2018-05-28" version="26.1"/>
   </releases>
 + <content_rating type="oars-1.0">
-+   <content_attribute id="drugs-alcohol">mild</content_attribute>
-+   <content_attribute id="drugs-narcotics">mild</content_attribute>
-+   <content_attribute id="drugs-tobacco">mild</content_attribute>
-+   <content_attribute id="sex-themes">mild</content_attribute>
-+   <content_attribute id="language-profanity">mild</content_attribute>
-+   <content_attribute id="language-humor">moderate</content_attribute>
 +   <content_attribute id="social-chat">intense</content_attribute>
-+   <content_attribute id="social-contacts">intense</content_attribute>
 + </content_rating>
  </component>
 -- 


### PR DESCRIPTION
Based on discussion at [1], it is felt that non-empty ratings were
previously given too easily.

The social-chat rating is still kept, because Emacs does provide
access to unmoderated online discussion.

[1] https://github.com/flathub/org.gnu.emacs/issues/41