### PR TITLE
Add --talk-name=org.freedesktop.Flatpak

### DIFF
--- a/org.gnu.emacs.json
+++ b/org.gnu.emacs.json
@@ -14,7 +14,8 @@
         "--socket=x11",
         "--filesystem=host",
         "--filesystem=/tmp",
-        "--filesystem=/var/tmp"
+        "--filesystem=/var/tmp",
+        "--talk-name=org.freedesktop.Flatpak"
     ],
     "modules": [
         {


### PR DESCRIPTION
This addresses #14 by making the org.freedesktop.Flatpak name
available to Emacs. This weakens the sandbox by making the
flatpak-spawn --host command work from within Emacs. This is expected
to not be harmful, because Emacs would typically have full access to
practically all the files of the user in any case.