### PR TITLE
Emacs 28.2 and CVE-2022-45939

### DIFF
--- a/emacs-fixed-ctags-local-command-execute-vulnerability.patch
+++ b/emacs-fixed-ctags-local-command-execute-vulnerability.patch
@@ -1,0 +1,9293 @@
+From d48bb4874bc6cd3e69c7a15fc3c91cc141025c51 Mon Sep 17 00:00:00 2001
+From: lu4nx <lx@shellcodes.org>
+Date: Fri, 25 Nov 2022 14:38:29 +0800
+Subject: [PATCH] Fixed ctags local command execute vulnerability
+
+* lib-src/etags.c:
+
+(clean_matched_file_tag): New function
+(do_move_file): New function
+(readline_internal):
+Add `leave_cr` parameter, if true, include the \r character
+
+* test/manual/etags/CTAGS.good_crlf: New file
+* test/manual/etags/CTAGS.good_update: New file
+* test/manual/etags/crlf: New file
+* test/manual/etags/Makefile: Add `ctags -u` test cases
+---
+ lib-src/etags.c                     |  149 +-
+ test/manual/etags/CTAGS.good_crlf   | 4484 +++++++++++++++++++++++++++
+ test/manual/etags/CTAGS.good_update | 4483 ++++++++++++++++++++++++++
+ test/manual/etags/Makefile          |   11 +
+ test/manual/etags/crlf              |    2 +
+ 5 files changed, 9093 insertions(+), 36 deletions(-)
+ create mode 100644 test/manual/etags/CTAGS.good_crlf
+ create mode 100644 test/manual/etags/CTAGS.good_update
+ create mode 100644 test/manual/etags/crlf
+
+diff --git a/lib-src/etags.c b/lib-src/etags.c
+index 3107c7b380..b6f51dfa83 100644
+--- a/lib-src/etags.c
++++ b/lib-src/etags.c
+@@ -375,7 +375,7 @@ #define xrnew(op, n, m) ((op) = xnrealloc (op, n, (m) * sizeof *(op)))
+ 
+ static language *get_language_from_langname (const char *);
+ static void readline (linebuffer *, FILE *);
+-static ptrdiff_t readline_internal (linebuffer *, FILE *, char const *);
++static ptrdiff_t readline_internal (linebuffer *, FILE *, char const *, const bool);
+ static bool nocase_tail (const char *);
+ static void get_tag (char *, char **);
+ static void get_lispy_tag (char *);
+@@ -399,7 +399,9 @@ #define xrnew(op, n, m) ((op) = xnrealloc (op, n, (m) * sizeof *(op)))
+ static void pfnote (char *, bool, char *, ptrdiff_t, intmax_t, intmax_t);
+ static void invalidate_nodes (fdesc *, node **);
+ static void put_entries (node *);
++static void clean_matched_file_tag (char const * const, char const * const);
+ 
++static void do_move_file (const char *, const char *);
+ static char *concat (const char *, const char *, const char *);
+ static char *skip_spaces (char *);
+ static char *skip_non_spaces (char *);
+@@ -1332,7 +1334,7 @@ main (int argc, char **argv)
+ 		  if (parsing_stdin)
+ 		    fatal ("cannot parse standard input "
+ 			   "AND read file names from it");
+-		  while (readline_internal (&filename_lb, stdin, "-") > 0)
++		  while (readline_internal (&filename_lb, stdin, "-", false) > 0)
+ 		    process_file_name (filename_lb.buffer, lang);
+ 		}
+ 	      else
+@@ -1380,9 +1382,6 @@ main (int argc, char **argv)
+   /* From here on, we are in (CTAGS && !cxref_style) */
+   if (update)
+     {
+-      char *cmd =
+-	xmalloc (strlen (tagfile) + whatlen_max +
+-		 sizeof "mv..OTAGS;grep -Fv '\t\t' OTAGS >;rm OTAGS");
+       for (i = 0; i < current_arg; ++i)
+ 	{
+ 	  switch (argbuffer[i].arg_type)
+@@ -1393,17 +1392,8 @@ main (int argc, char **argv)
+ 	    default:
+ 	      continue;		/* the for loop */
+ 	    }
+-	  char *z = stpcpy (cmd, "mv ");
+-	  z = stpcpy (z, tagfile);
+-	  z = stpcpy (z, " OTAGS;grep -Fv '\t");
+-	  z = stpcpy (z, argbuffer[i].what);
+-	  z = stpcpy (z, "\t' OTAGS >");
+-	  z = stpcpy (z, tagfile);
+-	  strcpy (z, ";rm OTAGS");
+-	  if (system (cmd) != EXIT_SUCCESS)
+-	    fatal ("failed to execute shell command");
++          clean_matched_file_tag (tagfile, argbuffer[i].what);
+ 	}
+-      free (cmd);
+       append_to_tagfile = true;
+     }
+ 
+@@ -1448,6 +1438,51 @@ main (int argc, char **argv)
+   return EXIT_SUCCESS;
+ }
+ 
++/*
++ * Equivalent to: mv tags OTAGS;grep -Fv ' filename ' OTAGS >tags;rm OTAGS
++ */
++static void
++clean_matched_file_tag (const char* tagfile, const char* match_file_name)
++{
++  FILE *otags_f = fopen ("OTAGS", "wb");
++  FILE *tag_f = fopen (tagfile, "rb");
++
++  if (otags_f == NULL)
++    pfatal ("OTAGS");
++
++  if (tag_f == NULL)
++    pfatal (tagfile);
++
++  int buf_len = strlen (match_file_name) + sizeof ("\t\t ") + 1;
++  char *buf = xmalloc (buf_len);
++  snprintf (buf, buf_len, "\t%s\t", match_file_name);
++
++  linebuffer line;
++  linebuffer_init (&line);
++  while (readline_internal (&line, tag_f, tagfile, true) > 0)
++    {
++      if (ferror (tag_f))
++        pfatal (tagfile);
++
++      if (strstr (line.buffer, buf) == NULL)
++        {
++          fprintf (otags_f, "%s\n", line.buffer);
++          if (ferror (tag_f))
++            pfatal (tagfile);
++        }
++    }
++  free (buf);
++  free (line.buffer);
++
++  if (fclose (otags_f) == EOF)
++    pfatal ("OTAGS");
++
++  if (fclose (tag_f) == EOF)
++    pfatal (tagfile);
++
++  do_move_file ("OTAGS", tagfile);
++  return;
++}
+ 
+ /*
+  * Return a compressor given the file name.  If EXTPTR is non-zero,
+@@ -1831,7 +1866,7 @@ find_entries (FILE *inf)
+ 
+   /* Else look for sharp-bang as the first two characters. */
+   if (parser == NULL
+-      && readline_internal (&lb, inf, infilename) > 0
++      && readline_internal (&lb, inf, infilename, false) > 0
+       && lb.len >= 2
+       && lb.buffer[0] == '#'
+       && lb.buffer[1] == '!')
+@@ -6878,7 +6913,7 @@ analyze_regex (char *regex_arg)
+ 	if (regexfp == NULL)
+ 	  pfatal (regexfile);
+ 	linebuffer_init (&regexbuf);
+-	while (readline_internal (&regexbuf, regexfp, regexfile) > 0)
++	while (readline_internal (&regexbuf, regexfp, regexfile, false) > 0)
+ 	  analyze_regex (regexbuf.buffer);
+ 	free (regexbuf.buffer);
+ 	if (fclose (regexfp) != 0)
+@@ -7226,11 +7261,13 @@ get_lispy_tag (register char *bp)
+ 
+ /*
+  * Read a line of text from `stream' into `lbp', excluding the
+- * newline or CR-NL, if any.  Return the number of characters read from
+- * `stream', which is the length of the line including the newline.
++ * newline or CR-NL (if `leave_cr` is false), if any.  Return the
++ * number of characters read from `stream', which is the length
++ * of the line including the newline.
+  *
+- * On DOS or Windows we do not count the CR character, if any before the
+- * NL, in the returned length; this mirrors the behavior of Emacs on those
++ * On DOS or Windows, if `leave_cr` is false, we do not count the
++ * CR character, if any before the NL, in the returned length;
++ * this mirrors the behavior of Emacs on those
+  * platforms (for text files, it translates CR-NL to NL as it reads in the
+  * file).
+  *
+@@ -7238,7 +7275,7 @@ get_lispy_tag (register char *bp)
+  * appended to `filebuf'.
+  */
+ static ptrdiff_t
+-readline_internal (linebuffer *lbp, FILE *stream, char const *filename)
++readline_internal (linebuffer *lbp, FILE *stream, char const *filename, const bool leave_cr)
+ {
+   char *buffer = lbp->buffer;
+   char *p = lbp->buffer;
+@@ -7268,19 +7305,19 @@ readline_internal (linebuffer *lbp, FILE *stream, char const *filename)
+ 	  break;
+ 	}
+       if (c == '\n')
+-	{
+-	  if (p > buffer && p[-1] == '\r')
+-	    {
+-	      p -= 1;
+-	      chars_deleted = 2;
+-	    }
+-	  else
+-	    {
+-	      chars_deleted = 1;
+-	    }
+-	  *p = '\0';
+-	  break;
+-	}
++        {
++          if (!leave_cr && p > buffer && p[-1] == '\r')
++            {
++              p -= 1;
++              chars_deleted = 2;
++            }
++          else
++            {
++              chars_deleted = 1;
++            }
++          *p = '\0';
++          break;
++        }
+       *p++ = c;
+     }
+   lbp->len = p - buffer;
+@@ -7311,7 +7348,7 @@ readline_internal (linebuffer *lbp, FILE *stream, char const *filename)
+ readline (linebuffer *lbp, FILE *stream)
+ {
+   linecharno = charno;		/* update global char number of line start */
+-  ptrdiff_t result = readline_internal (lbp, stream, infilename);
++  ptrdiff_t result = readline_internal (lbp, stream, infilename, false);
+   lineno += 1;			/* increment global line number */
+   charno += result;		/* increment global char number */
+ 
+@@ -7669,6 +7706,46 @@ etags_mktmp (void)
+   return templt;
+ }
+ 
++static void
++do_move_file(const char *src_file, const char *dst_file)
++{
++  if (rename (src_file, dst_file) == 0)
++    return;
++
++  FILE *src_f = fopen (src_file, "rb");
++  FILE *dst_f = fopen (dst_file, "wb");
++
++  if (src_f == NULL)
++    pfatal (src_file);
++
++  if (dst_f == NULL)
++    pfatal (dst_file);
++
++  int c;
++  while ((c = fgetc (src_f)) != EOF)
++    {
++      if (ferror (src_f))
++        pfatal (src_file);
++
++      if (ferror (dst_f))
++        pfatal (dst_file);
++
++      if (fputc (c, dst_f) == EOF)
++        pfatal ("cannot write");
++    }
++
++  if (fclose (src_f) == EOF)
++    pfatal (src_file);
++
++  if (fclose (dst_f) == EOF)
++    pfatal (dst_file);
++
++  if (unlink (src_file) == -1)
++    pfatal ("unlink error");
++
++  return;
++}
++
+ /* Return a newly allocated string containing the file name of FILE
+    relative to the absolute directory DIR (which should end with a slash). */
+ static char *
+diff --git a/test/manual/etags/CTAGS.good_crlf b/test/manual/etags/CTAGS.good_crlf
+new file mode 100644
+index 0000000000..52bd564d6c
+--- /dev/null
++++ b/test/manual/etags/CTAGS.good_crlf
+@@ -0,0 +1,4484 @@
++($_,$flag,$opt,$f,$r,@temp	perl-src/yagrip.pl	8
++$0x80	c-src/sysdep.h	32
++${CHECKOBJS}	make-src/Makefile	/^${CHECKOBJS}: CFLAGS=-g3 -DNULLFREECHECK=0$/
++$domain	php-src/lce_functions.php	175
++$filename	php-src/lce_functions.php	174
++$ignore_ws	php-src/lce_functions.php	171
++$memassign	php-src/ptest.php	9
++$memassign_space	php-src/ptest.php	10
++$member	php-src/ptest.php	8
++$msgid_lc	php-src/lce_functions.php	113
++$msgid	php-src/lce_functions.php	107
++$msgid	php-src/lce_functions.php	165
++$msgstr_lc	php-src/lce_functions.php	114
++$msgstr	php-src/lce_functions.php	108
++$msgstr	php-src/lce_functions.php	166
++$po_entries	php-src/lce_functions.php	172
++$poe_num	php-src/lce_functions.php	173
++$por_a	php-src/lce_functions.php	500
++$prefix	php-src/lce_functions.php	72
++($prog,$_,@list	perl-src/yagrip.pl	39
++$state	php-src/lce_functions.php	170
++($string,$flag,@string,@temp,@last	perl-src/yagrip.pl	40
++$sys_comment_lc	php-src/lce_functions.php	116
++$sys_comment	php-src/lce_functions.php	110
++$sys_comment	php-src/lce_functions.php	168
++$SYS_##syscall_na	c-src/sysdep.h	31
++$test	php-src/ptest.php	12
++$unk_comment_lc	php-src/lce_functions.php	117
++$unk_comment	php-src/lce_functions.php	111
++$unk_comment	php-src/lce_functions.php	169
++$user_comment_lc	php-src/lce_functions.php	115
++$user_comment	php-src/lce_functions.php	109
++$user_comment	php-src/lce_functions.php	167
++2const	forth-src/test-forth.fth	/^3 4 2constant 2const$/
++2val	forth-src/test-forth.fth	/^2const 2value 2val$/
++2var	forth-src/test-forth.fth	/^2variable 2var$/
++a0	c-src/emacs/src/lisp.h	/^      Lisp_Object (*a0) (void);$/
++a1	c-src/emacs/src/lisp.h	/^      Lisp_Object (*a1) (Lisp_Object);$/
++a2	c-src/emacs/src/lisp.h	/^      Lisp_Object (*a2) (Lisp_Object, Lisp_Object)/
++a3	c-src/emacs/src/lisp.h	/^      Lisp_Object (*a3) (Lisp_Object, Lisp_Object,/
++a4	c-src/emacs/src/lisp.h	/^      Lisp_Object (*a4) (Lisp_Object, Lisp_Object,/
++a5	c-src/emacs/src/lisp.h	/^      Lisp_Object (*a5) (Lisp_Object, Lisp_Object,/
++a6	c-src/emacs/src/lisp.h	/^      Lisp_Object (*a6) (Lisp_Object, Lisp_Object,/
++a7	c-src/emacs/src/lisp.h	/^      Lisp_Object (*a7) (Lisp_Object, Lisp_Object,/
++a8	c-src/emacs/src/lisp.h	/^      Lisp_Object (*a8) (Lisp_Object, Lisp_Object,/
++aaaaaa	c-src/h.h	111
++aaa	c.c	249
++aaa	c.c	269
++aa	c.c	269
++aa	c.c	279
++abbrev_all_caps	c-src/abbrev.c	58
++abbrev-expansion	c-src/abbrev.c	/^DEFUN ("abbrev-expansion", Fabbrev_expansion, Sabb/
++abbrevs_changed	c-src/abbrev.c	56
++abbrev-symbol	c-src/abbrev.c	/^DEFUN ("abbrev-symbol", Fabbrev_symbol, Sabbrev_sy/
++abc	c-src/h.h	33
++abc	c-src/h.h	37
++ABC	ruby-src/test1.ru	11
++Abort_Handler_Pointer/t	ada-src/2ataspri.ads	/^   type Abort_Handler_Pointer is access procedure /
++abort-recursive-edit	c-src/emacs/src/keyboard.c	/^DEFUN ("abort-recursive-edit", Fabort_recursive_ed/
++Abort_Task/p	ada-src/2ataspri.adb	/^   procedure Abort_Task (T : TCB_Ptr) is$/
++Abort_Task/p	ada-src/2ataspri.ads	/^   procedure Abort_Task (T : TCB_Ptr);$/
++Abort_Wrapper/p	ada-src/2ataspri.adb	/^   procedure Abort_Wrapper$/
++\aboveenvbreak	tex-src/texinfo.tex	/^\\def\\aboveenvbreak{{\\advance\\aboveenvskipamount by/
++abs/f	ada-src/etags-test-for.ada	/^   function "abs"   (Right : Complex) return Real'/
++absolute_dirname	c-src/etags.c	/^absolute_dirname (char *file, char *dir)$/
++absolute_filename	c-src/etags.c	/^absolute_filename (char *file, char *dir)$/
++abt	cp-src/c.C	55
++a	c.c	152
++A	c.c	162
++a	c.c	180
++a	c.c	/^a ()$/
++a	c.c	/^a()$/
++accent_key_syms	c-src/emacs/src/keyboard.c	4625
++access_keymap_keyremap	c-src/emacs/src/keyboard.c	/^access_keymap_keyremap (Lisp_Object map, Lisp_Obje/
++acc_pred_info	merc-src/accumulator.m	/^:- pred acc_pred_info(list(mer_type)::in, list(pro/
++acc_proc_info	merc-src/accumulator.m	/^:- pred acc_proc_info(list(prog_var)::in, prog_var/
++accu_assoc	merc-src/accumulator.m	/^:- pred accu_assoc(module_info::in, vartypes::in, /
++accu_assoc	merc-src/accumulator.m	/^:- type accu_assoc$/
++accu_base	merc-src/accumulator.m	/^:- type accu_base$/
++accu_before	merc-src/accumulator.m	/^:- pred accu_before(module_info::in, vartypes::in,/
++accu_case	merc-src/accumulator.m	/^:- type accu_case$/
++accu_construct_assoc	merc-src/accumulator.m	/^:- pred accu_construct_assoc(module_info::in, vart/
++accu_construct	merc-src/accumulator.m	/^:- pred accu_construct(module_info::in, vartypes::/
++accu_create_goal	merc-src/accumulator.m	/^:- pred accu_create_goal(accu_goal_id::in, list(pr/
++accu_divide_base_case	merc-src/accumulator.m	/^:- pred accu_divide_base_case(module_info::in, var/
++accu_goal_id	merc-src/accumulator.m	/^:- type accu_goal_id$/
++accu_goal_list	merc-src/accumulator.m	/^:- func accu_goal_list(list(accu_goal_id), accu_go/
++accu_goal_store	merc-src/accumulator.m	/^:- type accu_goal_store == goal_store(accu_goal_id/
++accu_has_heuristic	merc-src/accumulator.m	/^:- pred accu_has_heuristic(module_name::in, string/
++accu_heuristic	merc-src/accumulator.m	/^:- pred accu_heuristic(module_name::in, string::in/
++accu_is_associative	merc-src/accumulator.m	/^:- pred accu_is_associative(module_info::in, pred_/
++accu_is_update	merc-src/accumulator.m	/^:- pred accu_is_update(module_info::in, pred_id::i/
++acc_unification	merc-src/accumulator.m	/^:- pred acc_unification(pair(prog_var)::in, hlds_g/
++accu_process_assoc_set	merc-src/accumulator.m	/^:- pred accu_process_assoc_set(module_info::in, ac/
++accu_process_update_set	merc-src/accumulator.m	/^:- pred accu_process_update_set(module_info::in, a/
++accu_related	merc-src/accumulator.m	/^:- pred accu_related(module_info::in, vartypes::in/
++accu_rename	merc-src/accumulator.m	/^:- func accu_rename(list(accu_goal_id), accu_subst/
++accu_sets_init	merc-src/accumulator.m	/^:- pred accu_sets_init(accu_sets::out) is det.$/
++accu_sets	merc-src/accumulator.m	/^:- type accu_sets$/
++accu_stage1_2	merc-src/accumulator.m	/^:- pred accu_stage1_2(module_info::in, vartypes::i/
++accu_stage1	merc-src/accumulator.m	/^:- pred accu_stage1(module_info::in, vartypes::in,/
++accu_stage2	merc-src/accumulator.m	/^:- pred accu_stage2(module_info::in, proc_info::in/
++accu_stage3	merc-src/accumulator.m	/^:- pred accu_stage3(accu_goal_id::in, list(prog_va/
++accu_standardize	merc-src/accumulator.m	/^:- pred accu_standardize(hlds_goal::in, hlds_goal:/
++accu_store	merc-src/accumulator.m	/^:- pred accu_store(accu_case::in, hlds_goal::in,$/
++accu_subst	merc-src/accumulator.m	/^:- type accu_subst == map(prog_var, prog_var).$/
++accu_substs_init	merc-src/accumulator.m	/^:- pred accu_substs_init(list(prog_var)::in, prog_/
++accu_substs	merc-src/accumulator.m	/^:- type accu_substs$/
++accu_top_level	merc-src/accumulator.m	/^:- pred accu_top_level(top_level::in, hlds_goal::i/
++accu_transform_proc	merc-src/accumulator.m	/^:- pred accu_transform_proc(pred_proc_id::in, pred/
++accu_update	merc-src/accumulator.m	/^:- pred accu_update(module_info::in, vartypes::in,/
++accu_warning	merc-src/accumulator.m	/^:- type accu_warning$/
++acc_var_subst_init	merc-src/accumulator.m	/^:- pred acc_var_subst_init(list(prog_var)::in,$/
++/Acircumflex	ps-src/rfc1245.ps	/^\/Acircumflex \/Ecircumflex \/Aacute \/Edieresis \/Egra/
++A	cp-src/c.C	117
++a	cp-src/c.C	132
++A	cp-src/c.C	39
++A	cp-src/c.C	56
++A	cp-src/c.C	57
++A	cp-src/c.C	73
++~A	cp-src/c.C	/^A::~A() {}$/
++A	cp-src/c.C	/^void A::A() {}$/
++A	cp-src/fail.C	23
++A	cp-src/fail.C	7
++a	c-src/h.h	103
++a	c-src/h.h	40
++action	prol-src/natded.prolog	/^action(KeyVals):-$/
++\activedoublequote	tex-src/texinfo.tex	/^\\def\\activedoublequote{{\\tt \\char '042}}$/
++active_maps	c-src/emacs/src/keyboard.c	/^active_maps (Lisp_Object first_event)$/
++\activeparens	tex-src/texinfo.tex	/^\\def\\activeparens{%$/
++actout	prol-src/natded.prolog	/^actout('Text',Trees):-$/
++act	prol-src/natded.prolog	/^act(OutForm,OutSyn,Ws):-$/
++Ada_funcs	c-src/etags.c	/^Ada_funcs (FILE *inf)$/
++Ada_getit	c-src/etags.c	/^Ada_getit (FILE *inf, const char *name_qualifier)$/
++Ada_help	c-src/etags.c	475
++ADASRC	make-src/Makefile	/^ADASRC=etags-test-for.ada 2ataspri.adb 2ataspri.ad/
++Ada_suffixes	c-src/etags.c	473
++add_active	prol-src/natded.prolog	/^add_active([],Cat,Goal):-$/
++addArchs	objc-src/PackInsp.m	/^-(void)addArchs:(const char *)string$/
++add_command_key	c-src/emacs/src/keyboard.c	/^add_command_key (Lisp_Object key)$/
++add_edge	prol-src/natded.prolog	/^add_edge(Left,Right,Cat):-$/
++add_node	c-src/etags.c	/^add_node (node *np, node **cur_node_p)$/
++addnoise	html-src/algrthms.html	/^Adding Noise to the$/
++AddNullToNmStr	pas-src/common.pas	/^function AddNullToNmStr; (*($/
++addPOReader	php-src/lce_functions.php	/^      function addPOReader($d_name, &$por)$/
++add_regex	c-src/etags.c	/^add_regex (char *regexp_pattern, language *lang)$/
++ADDRESS	c-src/emacs/src/gmalloc.c	/^#define ADDRESS(B)	((void *) (((B) - 1) * BLOCKSIZ/
++Address_To_Call_State/f	ada-src/2ataspri.adb	/^      function Address_To_Call_State is new$/
++Address_To_TCB_Ptr/f	ada-src/2ataspri.ads	/^   function Address_To_TCB_Ptr is new$/
++address	y-src/cccp.y	113
++add_user_signal	c-src/emacs/src/keyboard.c	/^add_user_signal (int sig, const char *name)$/
++#a-defer-word	forth-src/test-forth.fth	/^defer #a-defer-word$/
++adjust_point_for_property	c-src/emacs/src/keyboard.c	/^adjust_point_for_property (ptrdiff_t last_pt, bool/
++Advanced usage	tex-src/gzip.texi	/^@node Advanced usage, Environment, Invoking gzip, /
++a-forth-constant!	forth-src/test-forth.fth	/^99 constant a-forth-constant!$/
++(a-forth-constant	forth-src/test-forth.fth	/^constant (a-forth-constant$/
++:a-forth-dictionary-entry	forth-src/test-forth.fth	/^create :a-forth-dictionary-entry$/
++a-forth-value?	forth-src/test-forth.fth	/^55 value a-forth-value?$/
++a-forth-word	forth-src/test-forth.fth	/^: a-forth-word ( a b c -- )$/
++a-forth-word	forth-src/test-forth.fth	/^: a-forth-word ( a b c -- a*b+c )  + * ;$/
++\afourpaper	tex-src/texinfo.tex	/^\\def\\afourpaper{$/
++\afterenvbreak	tex-src/texinfo.tex	/^\\def\\afterenvbreak{\\endgraf \\ifdim\\lastskip<\\above/
++agent	cp-src/clheir.hpp	75
++algorithms	html-src/algrthms.html	/^Description$/
++alias	c-src/emacs/src/lisp.h	688
++alignas	c-src/emacs/src/lisp.h	/^# define alignas(alignment) \/* empty *\/$/
++align	c-src/emacs/src/gmalloc.c	/^align (size_t size)$/
++aligned_alloc	c-src/emacs/src/gmalloc.c	1718
++aligned_alloc	c-src/emacs/src/gmalloc.c	71
++aligned_alloc	c-src/emacs/src/gmalloc.c	/^aligned_alloc (size_t alignment, size_t size)$/
++_aligned_blocks	c-src/emacs/src/gmalloc.c	1004
++_aligned_blocks_mutex	c-src/emacs/src/gmalloc.c	518
++Aligned_Cons	c-src/emacs/src/lisp.h	4670
++aligned	c-src/emacs/src/gmalloc.c	199
++Aligned_String	c-src/emacs/src/lisp.h	4676
++alignlist	c-src/emacs/src/gmalloc.c	196
++ALIGNOF_STRUCT_LISP_VECTOR	c-src/emacs/src/lisp.h	1378
++alive	cp-src/conway.hpp	7
++all_kboards	c-src/emacs/src/keyboard.c	86
++ALLOCATED_BEFORE_DUMPING	c-src/emacs/src/gmalloc.c	/^#define ALLOCATED_BEFORE_DUMPING(P) \\$/
++allocated	c-src/emacs/src/regex.h	344
++allocate_kboard	c-src/emacs/src/keyboard.c	/^allocate_kboard (Lisp_Object type)$/
++ALLOCATE_PSEUDOVECTOR	c-src/emacs/src/lisp.h	/^#define ALLOCATE_PSEUDOVECTOR(type, field, tag)			/
++ALLOCATE_ZEROED_PSEUDOVECTOR	c-src/emacs/src/lisp.h	/^#define ALLOCATE_ZEROED_PSEUDOVECTOR(type, field, /
++\alphaenumerate	tex-src/texinfo.tex	/^\\def\\alphaenumerate{\\enumerate{a}}$/
++aMANY	c-src/emacs/src/lisp.h	/^      Lisp_Object (*aMANY) (ptrdiff_t, Lisp_Object/
++analyze_regex	c-src/etags.c	/^analyze_regex (char *regex_arg)$/
++andkeyvalseq	prol-src/natded.prolog	/^andkeyvalseq(KeyVals) --> ['&'], keyvalseq(KeyVals/
++AND	y-src/cccp.c	11
++an_extern_linkage	c-src/h.h	44
++an_extern_linkage	c-src/h.h	56
++an_extern_linkage_ptr	c-src/h.h	43
++animals	cp-src/c.C	126
++animals	cp-src/c.C	130
++animals	c-src/h.h	81
++(another-forth-word)	forth-src/test-forth.fth	/^: (another-forth-word) ( -- )$/
++ANSIC	c-src/h.h	84
++ANSIC	c-src/h.h	85
++any_kboard_state	c-src/emacs/src/keyboard.c	/^any_kboard_state ()$/
++appDidInit	objcpp-src/SimpleCalc.M	/^- appDidInit:sender$/
++\appendixletter	tex-src/texinfo.tex	/^\\def\\appendixletter{\\char\\the\\appendixno}$/
++appendix_name	perl-src/htlmify-cystic	13
++\appendixnoderef	tex-src/texinfo.tex	/^\\def\\appendixnoderef{\\ifx\\lastnode\\relax\\else$/
++appendix	perl-src/htlmify-cystic	24
++\appendixsec	tex-src/texinfo.tex	/^\\outer\\def\\appendixsec{\\parsearg\\appendixsectionzz/
++\appendixsection	tex-src/texinfo.tex	/^\\outer\\def\\appendixsection{\\parsearg\\appendixsecti/
++\appendixsectionzzz	tex-src/texinfo.tex	/^\\def\\appendixsectionzzz #1{\\seccheck{appendixsecti/
++\appendixsetref	tex-src/texinfo.tex	/^\\def\\appendixsetref#1{%$/
++\appendixsubsec	tex-src/texinfo.tex	/^\\outer\\def\\appendixsubsec{\\parsearg\\appendixsubsec/
++\appendixsubseczzz	tex-src/texinfo.tex	/^\\def\\appendixsubseczzz #1{\\seccheck{appendixsubsec/
++\appendixsubsubsec	tex-src/texinfo.tex	/^\\outer\\def\\appendixsubsubsec{\\parsearg\\appendixsub/
++\appendixsubsubseczzz	tex-src/texinfo.tex	/^\\def\\appendixsubsubseczzz #1{\\seccheck{appendixsub/
++\appendix	tex-src/texinfo.tex	/^\\outer\\def\\appendix{\\parsearg\\appendixzzz}$/
++appendix_toc	perl-src/htlmify-cystic	16
++\appendixzzz	tex-src/texinfo.tex	/^\\def\\appendixzzz #1{\\seccheck{appendix}%$/
++append_list	prol-src/natded.prolog	/^append_list([],[]).$/
++append	prol-src/natded.prolog	/^append([],Xs,Xs).$/
++append_string	pas-src/common.pas	/^procedure append_string;(*($/
++AppendTextString	pas-src/common.pas	/^function AppendTextString;(*($/
++appendToDisplay	objcpp-src/SimpleCalc.M	/^- appendToDisplay:(const char *)theDigit$/
++append_tool_bar_item	c-src/emacs/src/keyboard.c	/^append_tool_bar_item (void)$/
++apply_modifiers	c-src/emacs/src/keyboard.c	/^apply_modifiers (int modifiers, Lisp_Object base)$/
++apply_modifiers_uncached	c-src/emacs/src/keyboard.c	/^apply_modifiers_uncached (int modifiers, char *bas/
++/A	ps-src/rfc1245.ps	/^\/A { $/
++aref_addr	c-src/emacs/src/lisp.h	/^aref_addr (Lisp_Object array, ptrdiff_t idx)$/
++AREF	c-src/emacs/src/lisp.h	/^AREF (Lisp_Object array, ptrdiff_t idx)$/
++arg	c-src/emacs/src/lisp.h	2961
++arg	c-src/emacs/src/lisp.h	2966
++arg	c-src/emacs/src/lisp.h	2971
++arg	c-src/h.h	13
++arglist	y-src/cccp.y	41
++argno	y-src/cccp.y	45
++args	c-src/emacs/src/lisp.h	2986
++args	c-src/h.h	30
++argsindent	tex-src/texinfo.tex	/^\\dimen1=\\hsize \\advance \\dimen1 by -\\defargsindent/
++argsindent	tex-src/texinfo.tex	/^\\newskip\\defargsindent \\defargsindent=50pt$/
++argsindent	tex-src/texinfo.tex	/^\\parshape 2 0in \\dimen0 \\defargsindent \\dimen1    /
++ARGS	make-src/Makefile	/^ARGS=- < srclist$/
++arg_type	c-src/etags.c	250
++argument	c-src/etags.c	253
++argvals	prol-src/natded.prolog	/^argvals([]) --> [].$/
++Arith_Comparison	c-src/emacs/src/lisp.h	3497
++ARITH_EQUAL	c-src/emacs/src/lisp.h	3498
++ARITH_GRTR	c-src/emacs/src/lisp.h	3501
++ARITH_GRTR_OR_EQUAL	c-src/emacs/src/lisp.h	3503
++ARITH_LESS	c-src/emacs/src/lisp.h	3500
++ARITH_LESS_OR_EQUAL	c-src/emacs/src/lisp.h	3502
++ARITH_NOTEQUAL	c-src/emacs/src/lisp.h	3499
++array	c.c	190
++ARRAYELTS	c-src/emacs/src/lisp.h	/^#define ARRAYELTS(arr) (sizeof (arr) \/ sizeof (arr/
++ARRAY_MARK_FLAG	c-src/emacs/src/lisp.h	768
++ARRAYP	c-src/emacs/src/lisp.h	/^ARRAYP (Lisp_Object x)$/
++A	ruby-src/test1.ru	/^class A$/
++a	ruby-src/test1.ru	/^ def a()$/
++A	ruby-src/test1.ru	/^module A$/
++ASCII_CHAR_P	c-src/emacs/src/lisp.h	/^#define ASCII_CHAR_P(c) UNSIGNED_CMP (c, <, 0x80)$/
++ascii	c-src/emacs/src/lisp.h	1598
++ASET	c-src/emacs/src/lisp.h	/^ASET (Lisp_Object array, ptrdiff_t idx, Lisp_Objec/
++\asis	tex-src/texinfo.tex	/^\\def\\asis#1{#1}$/
++ASIZE	c-src/emacs/src/lisp.h	/^ASIZE (Lisp_Object array)$/
++Asm_help	c-src/etags.c	504
++Asm_labels	c-src/etags.c	/^Asm_labels (FILE *inf)$/
++Asm_suffixes	c-src/etags.c	493
++asort	cp-src/functions.cpp	/^void asort(int *a, int num){$/
++ASRC	make-src/Makefile	/^ASRC=empty.zz empty.zz.gz$/
++assemby-code-word	forth-src/test-forth.fth	/^code assemby-code-word ( dunno what it does )$/
++assert	c-src/etags.c	135
++assert	c-src/etags.c	/^# define assert(x) ((void) 0)$/
++assign_neighbor	cp-src/clheir.hpp	/^    void assign_neighbor(int direction, location */
++associativity_assertion	merc-src/accumulator.m	/^:- pred associativity_assertion(module_info::in, l/
++assoc_list	merc-src/accumulator.m	/^:- import_module assoc_list.$/
++AST_Array::AST_Array	cp-src/c.C	/^AST_Array::AST_Array(UTL_ScopedName *n, unsigned l/
++AST_ConcreteType::AST_ConcreteType	cp-src/c.C	/^AST_ConcreteType::AST_ConcreteType(AST_Decl::NodeT/
++AST_Root	cp-src/c.C	92
++AT	cp-src/c.C	52
++at_end	c-src/etags.c	249
++at_filename	c-src/etags.c	247
++/atilde	ps-src/rfc1245.ps	/^\/atilde \/aring \/ccedilla \/eacute \/egrave \/ecircumf/
++at_language	c-src/etags.c	245
++at_least_one_member	prol-src/natded.prolog	/^at_least_one_member(X,[X|_]):-!.$/
++atom	prol-src/natded.prolog	/^atom(X) --> [X], {atomic(X)}.$/
++atomval	prol-src/natded.prolog	/^atomval(X) --> atom(X).$/
++at_regexp	c-src/etags.c	246
++at_stdin	c-src/etags.c	248
++AU	cp-src/c.C	53
++aultparindent\hang\textindent	tex-src/texinfo.tex	/^\\footstrut\\parindent=\\defaultparindent\\hang\\textin/
++aultparindent	tex-src/texinfo.tex	/^\\newdimen\\defaultparindent \\defaultparindent = 15p/
++aultparindent	tex-src/texinfo.tex	/^\\parindent = \\defaultparindent$/
++aUNEVALLED	c-src/emacs/src/lisp.h	/^      Lisp_Object (*aUNEVALLED) (Lisp_Object args)/
++\authorfont	tex-src/texinfo.tex	/^   \\def\\authorfont{\\authorrm \\normalbaselineskip =/
++\author	tex-src/texinfo.tex	/^   \\def\\author{\\parsearg\\authorzzz}%$/
++\authorzzz	tex-src/texinfo.tex	/^   \\def\\authorzzz##1{\\ifseenauthor\\else\\vskip 0pt /
++AUTO_CONS	c-src/emacs/src/lisp.h	/^#define AUTO_CONS(name, a, b) Lisp_Object name = A/
++AUTO_CONS_EXPR	c-src/emacs/src/lisp.h	/^#define AUTO_CONS_EXPR(a, b) \\$/
++auto_help	c-src/etags.c	699
++AUTO_LIST1	c-src/emacs/src/lisp.h	/^#define AUTO_LIST1(name, a)						\\$/
++AUTO_LIST2	c-src/emacs/src/lisp.h	/^#define AUTO_LIST2(name, a, b)						\\$/
++AUTO_LIST3	c-src/emacs/src/lisp.h	/^#define AUTO_LIST3(name, a, b, c)					\\$/
++AUTO_LIST4	c-src/emacs/src/lisp.h	/^#define AUTO_LIST4(name, a, b, c, d)					\\$/
++AUTOLOADP	c-src/emacs/src/lisp.h	/^AUTOLOADP (Lisp_Object x)$/
++AUTO_STRING	c-src/emacs/src/lisp.h	/^#define AUTO_STRING(name, str)						\\$/
++AVAIL_ALLOCA	c-src/emacs/src/lisp.h	/^#define AVAIL_ALLOCA(size) (sa_avail -= (size), al/
++backslash=0	tex-src/texinfo.tex	/^\\let\\indexbackslash=0  %overridden during \\printin/
++\balancecolumns	tex-src/texinfo.tex	/^\\def\\balancecolumns{%$/
++bar1	ruby-src/test1.ru	/^    attr_reader(:foo1, :bar1, # comment$/
++bar	c.c	143
++bar	cp-src/x.cc	/^XX::bar()$/
++bar	c-src/c.c	/^void bar() {while(0) {}}$/
++bar	c-src/h.h	19
++Bar	lua-src/test.lua	/^function Square.something:Bar ()$/
++Bar	perl-src/kai-test.pl	/^package Bar;$/
++Barrier_Function_Pointer/t	ada-src/etags-test-for.ada	/^   type Barrier_Function_Pointer is access$/
++bar=	ruby-src/test1.ru	/^    attr_writer :bar,$/
++_bar?	ruby-src/test1.ru	/^    def self._bar?(abc)$/
++base_case_ids	merc-src/accumulator.m	/^:- func base_case_ids(accu_goal_store) = list(accu/
++base_case_ids_set	merc-src/accumulator.m	/^:- func base_case_ids_set(accu_goal_store) = set(a/
++base	cp-src/c.C	/^double base (void) const { return rng_base;  }$/
++base	cp-src/Range.h	/^  double base (void) const { return rng_base;  }$/
++base	c-src/emacs/src/lisp.h	2188
++bas_syn	prol-src/natded.prolog	/^bas_syn(n(_)).$/
++baz=	ruby-src/test1.ru	/^                :baz,$/
++bbbbbb	c-src/h.h	113
++bbb	c.c	251
++bb	c.c	275
++b	c.c	180
++b	c.c	259
++b	c.c	260
++b	c.c	262
++b	c.c	/^b ()$/
++B	cp-src/c.C	122
++b	cp-src/c.C	132
++B	cp-src/c.C	54
++B	cp-src/c.C	56
++B	cp-src/c.C	74
++~B	cp-src/c.C	/^    ~B() {};$/
++B	cp-src/c.C	/^void B::B() {}$/
++B	cp-src/fail.C	24
++B	cp-src/fail.C	8
++b	c-src/h.h	103
++b	c-src/h.h	104
++b	c-src/h.h	41
++been_warned	c-src/etags.c	222
++before_command_echo_length	c-src/emacs/src/keyboard.c	130
++before_command_key_count	c-src/emacs/src/keyboard.c	129
++/BEGINBITMAP2BITc	ps-src/rfc1245.ps	/^\/BEGINBITMAP2BITc { $/
++/BEGINBITMAP2BIT	ps-src/rfc1245.ps	/^\/BEGINBITMAP2BIT { $/
++/BEGINBITMAPBWc	ps-src/rfc1245.ps	/^\/BEGINBITMAPBWc { $/
++/BEGINBITMAPBW	ps-src/rfc1245.ps	/^\/BEGINBITMAPBW { $/
++/BEGINBITMAPGRAYc	ps-src/rfc1245.ps	/^\/BEGINBITMAPGRAYc { $/
++/BEGINBITMAPGRAY	ps-src/rfc1245.ps	/^\/BEGINBITMAPGRAY { $/
++\begindoublecolumns	tex-src/texinfo.tex	/^\\def\\begindoublecolumns{\\begingroup$/
++/BEGINPRINTCODE	ps-src/rfc1245.ps	/^\/BEGINPRINTCODE { $/
++\begin	tex-src/texinfo.tex	/^\\outer\\def\\begin{\\parsearg\\beginxxx}$/
++\beginxxx	tex-src/texinfo.tex	/^\\def\\beginxxx #1{%$/
++begtoken	c-src/etags.c	/^#define	begtoken(c)	(_btk[CHAR (c)]) \/* c can star/
++behaviour_info	erl-src/gs_dialog.erl	/^behaviour_info(callbacks) ->$/
++BE_Node	cp-src/c.C	77
++BE_Node	cp-src/c.C	/^void BE_Node::BE_Node() {}$/
++bf=cmbx10	tex-src/texinfo.tex	/^\\font\\defbf=cmbx10 scaled \\magstep1 %was 1314$/
++/BF	ps-src/rfc1245.ps	/^\/BF { $/
++\bf	tex-src/texinfo.tex	/^\\def\\bf{\\realbackslash bf }%$/
++\bf	tex-src/texinfo.tex	/^\\def\\bf{\\realbackslash bf }$/
++Bidule/b	ada-src/etags-test-for.ada	/^  protected body Bidule is$/
++Bidule/b	ada-src/waroquiers.ada	/^  protected body Bidule is$/
++Bidule/t	ada-src/etags-test-for.ada	/^  protected Bidule is$/
++Bidule/t	ada-src/waroquiers.ada	/^  protected Bidule is$/
++bind_polling_period	c-src/emacs/src/keyboard.c	/^bind_polling_period (int n)$/
++bind	pyt-src/server.py	/^    def bind(self, key, action):$/
++/BITMAPCOLORc	ps-src/rfc1245.ps	/^\/BITMAPCOLORc { $/
++/BITMAPCOLOR	ps-src/rfc1245.ps	/^\/BITMAPCOLOR { $/
++/BITMAPGRAYc	ps-src/rfc1245.ps	/^\/BITMAPGRAYc { $/
++/BITMAPGRAY	ps-src/rfc1245.ps	/^\/BITMAPGRAY { $/
++BITS_PER_BITS_WORD	c-src/emacs/src/lisp.h	125
++BITS_PER_BITS_WORD	c-src/emacs/src/lisp.h	129
++BITS_PER_CHAR	c-src/emacs/src/lisp.h	136
++BITS_PER_EMACS_INT	c-src/emacs/src/lisp.h	139
++BITS_PER_LONG	c-src/emacs/src/lisp.h	138
++BITS_PER_SHORT	c-src/emacs/src/lisp.h	137
++bits_word	c-src/emacs/src/lisp.h	123
++bits_word	c-src/emacs/src/lisp.h	127
++BITS_WORD_MAX	c-src/emacs/src/lisp.h	124
++BITS_WORD_MAX	c-src/emacs/src/lisp.h	128
++bla	c.c	/^int bla ()$/
++BLACK	cp-src/screen.hpp	12
++blah	tex-src/testenv.tex	/^\\section{blah}$/
++bletch	el-src/TAGTEST.EL	/^(foo::defmumble bletch beuarghh)$/
++BLOCK	c-src/emacs/src/gmalloc.c	/^#define BLOCK(A)	(((char *) (A) - _heapbase) \/ BLO/
++BLOCKIFY	c-src/emacs/src/gmalloc.c	/^#define BLOCKIFY(SIZE)	(((SIZE) + BLOCKSIZE - 1) \//
++BLOCKLOG	c-src/emacs/src/gmalloc.c	125
++BLOCKSIZE	c-src/emacs/src/gmalloc.c	126
++/bl	ps-src/rfc1245.ps	/^\/bl { $/
++BLUE	cp-src/screen.hpp	13
++blv	c-src/emacs/src/lisp.h	689
++blv_found	c-src/emacs/src/lisp.h	/^blv_found (struct Lisp_Buffer_Local_Value *blv)$/
++bodyindent	tex-src/texinfo.tex	/^\\advance\\dimen2 by -\\defbodyindent$/
++bodyindent	tex-src/texinfo.tex	/^\\advance\\dimen3 by -\\defbodyindent$/
++bodyindent	tex-src/texinfo.tex	/^\\advance\\leftskip by -\\defbodyindent$/
++bodyindent	tex-src/texinfo.tex	/^\\advance\\leftskip by \\defbodyindent \\advance \\righ/
++bodyindent	tex-src/texinfo.tex	/^\\exdentamount=\\defbodyindent$/
++bodyindent	tex-src/texinfo.tex	/^\\newskip\\defbodyindent \\defbodyindent=.4in$/
++Body_Required/f	ada-src/etags-test-for.ada	/^   function Body_Required$/
++Boo::Boo	cp-src/c.C	/^Boo::Boo(Boo) :$/
++Boo	cp-src/c.C	129
++Boo	cp-src/c.C	/^    Boo(int _i, int _a, int _b) : i(_i), a(_a), b(/
++bool	c.c	222
++bool_header_size	c-src/emacs/src/lisp.h	1472
++bool	merc-src/accumulator.m	/^:- import_module bool.$/
++boolvar	c-src/emacs/src/lisp.h	2287
++bool_vector_bitref	c-src/emacs/src/lisp.h	/^bool_vector_bitref (Lisp_Object a, EMACS_INT i)$/
++BOOL_VECTOR_BITS_PER_CHAR	c-src/emacs/src/lisp.h	114
++BOOL_VECTOR_BITS_PER_CHAR	c-src/emacs/src/lisp.h	115
++bool_vector_bytes	c-src/emacs/src/lisp.h	/^bool_vector_bytes (EMACS_INT size)$/
++bool_vector_data	c-src/emacs/src/lisp.h	/^bool_vector_data (Lisp_Object a)$/
++BOOL_VECTOR_P	c-src/emacs/src/lisp.h	/^BOOL_VECTOR_P (Lisp_Object a)$/
++bool_vector_ref	c-src/emacs/src/lisp.h	/^bool_vector_ref (Lisp_Object a, EMACS_INT i)$/
++bool_vector_set	c-src/emacs/src/lisp.h	/^bool_vector_set (Lisp_Object a, EMACS_INT i, bool /
++bool_vector_size	c-src/emacs/src/lisp.h	/^bool_vector_size (Lisp_Object a)$/
++bool_vector_uchar_data	c-src/emacs/src/lisp.h	/^bool_vector_uchar_data (Lisp_Object a)$/
++bool_vector_words	c-src/emacs/src/lisp.h	/^bool_vector_words (EMACS_INT size)$/
++/B	ps-src/rfc1245.ps	/^\/B { $/
++bracelev	c-src/etags.c	2520
++/braceright	ps-src/rfc1245.ps	/^\/braceright \/asciitilde \/.notdef \/Adieresis \/Aring/
++/bracketright	ps-src/rfc1245.ps	/^\/bracketright \/asciicircum \/underscore \/grave \/a \//
++/breve	ps-src/rfc1245.ps	/^\/breve \/dotaccent \/ring \/cedilla \/hungarumlaut \/og/
++BROWN	cp-src/screen.hpp	18
++B	ruby-src/test1.ru	/^  class B$/
++b	ruby-src/test1.ru	/^ def b()$/
++bsp_DevId	c-src/h.h	25
++bt	c-src/emacs/src/lisp.h	2988
++\b	tex-src/texinfo.tex	/^\\def\\b#1{{\\bf #1}}$/
++\b	tex-src/texinfo.tex	/^\\def\\b##1{\\realbackslash b {##1}}%$/
++\b	tex-src/texinfo.tex	/^\\def\\b##1{\\realbackslash b {##1}}$/
++btowc	c-src/emacs/src/regex.h	/^# define btowc(c) c$/
++buffer	c-src/emacs/src/lisp.h	2000
++buffer	c-src/emacs/src/regex.h	341
++buffer	c-src/etags.c	238
++buffer	c-src/h.h	119
++BUFFER_OBJFWDP	c-src/emacs/src/lisp.h	/^BUFFER_OBJFWDP (union Lisp_Fwd *a)$/
++BUFFERP	c-src/emacs/src/lisp.h	/^BUFFERP (Lisp_Object a)$/
++BUFFERSIZE	objc-src/Subprocess.h	43
++buildact	prol-src/natded.prolog	/^buildact([SynIn],Right,RightPlus1):-$/
++build	prol-src/natded.prolog	/^build([],Left,Left).$/
++build_pure_c_string	c-src/emacs/src/lisp.h	/^build_pure_c_string (const char *str)$/
++build_string	c-src/emacs/src/lisp.h	/^build_string (const char *str)$/
++builtin_lisp_symbol	c-src/emacs/src/lisp.h	/^builtin_lisp_symbol (int index)$/
++\bullet	tex-src/texinfo.tex	/^\\def\\bullet{$\\ptexbullet$}$/
++burst	c-src/h.h	28
++busy	c-src/emacs/src/gmalloc.c	158
++ButtonBar	pyt-src/server.py	/^def ButtonBar(frame, legend, ref, alternatives, co/
++button_down_location	c-src/emacs/src/keyboard.c	5210
++button_down_time	c-src/emacs/src/keyboard.c	5218
++\bye	tex-src/texinfo.tex	/^\\outer\\def\\bye{\\pagealignmacro\\tracingstats=1\\ptex/
++bytecode_dest	c-src/emacs/src/lisp.h	3037
++bytecode_top	c-src/emacs/src/lisp.h	3036
++BYTE_MARK_STACK	c-src/emacs/src/lisp.h	3181
++bytepos	c-src/emacs/src/lisp.h	2016
++bytes_free	c-src/emacs/src/gmalloc.c	314
++_bytes_free	c-src/emacs/src/gmalloc.c	376
++byte_stack	c-src/emacs/src/lisp.h	3049
++bytes_total	c-src/emacs/src/gmalloc.c	310
++bytes_used	c-src/emacs/src/gmalloc.c	312
++_bytes_used	c-src/emacs/src/gmalloc.c	374
++caccacacca	c.c	/^caccacacca (a,b,c,d,e,f,g)$/
++cacheLRUEntry_s	c.c	172
++cacheLRUEntry_t	c.c	177
++calculate_goal_info	merc-src/accumulator.m	/^:- pred calculate_goal_info(hlds_goal_expr::in, hl/
++CALLMANY	c-src/emacs/src/lisp.h	/^#define CALLMANY(f, array) (f) (ARRAYELTS (array),/
++CALLN	c-src/emacs/src/lisp.h	/^#define CALLN(f, ...) CALLMANY (f, ((Lisp_Object [/
++calloc	c-src/emacs/src/gmalloc.c	1717
++calloc	c-src/emacs/src/gmalloc.c	66
++calloc	c-src/emacs/src/gmalloc.c	70
++calloc	c-src/emacs/src/gmalloc.c	/^calloc (size_t nmemb, size_t size)$/
++can_be_null	c-src/emacs/src/regex.h	370
++cancel_echoing	c-src/emacs/src/keyboard.c	/^cancel_echoing (void)$/
++canonicalize_filename	c-src/etags.c	/^canonicalize_filename (register char *fn)$/
++\capsenumerate	tex-src/texinfo.tex	/^\\def\\capsenumerate{\\enumerate{A}}$/
++CAR	c-src/emacs/src/lisp.h	/^CAR (Lisp_Object c)$/
++CAR_SAFE	c-src/emacs/src/lisp.h	/^CAR_SAFE (Lisp_Object c)$/
++\cartbot	tex-src/texinfo.tex	/^\\def\\cartbot{\\hbox to \\cartouter{\\hskip\\lskip$/
++\cartouche	tex-src/texinfo.tex	/^\\long\\def\\cartouche{%$/
++\carttop	tex-src/texinfo.tex	/^\\def\\carttop{\\hbox to \\cartouter{\\hskip\\lskip$/
++case_Lisp_Int	c-src/emacs/src/lisp.h	438
++cat_atoms	prol-src/natded.prolog	/^cat_atoms(A1,A2,A3):-$/
++CATCHER	c-src/emacs/src/lisp.h	3021
++cat	cp-src/c.C	126
++cat	cp-src/c.C	130
++cat	c-src/h.h	81
++cat	prol-src/natded.prolog	/^cat(A, Alpha@Beta, Ass3, Qs3, tree(fe,A:Alpha@Beta/
++C_AUTO	c-src/etags.c	2198
++\cbl	tex-src/texinfo.tex	/^\\def\\cbl{{\\circle\\char'012\\hskip -6pt}}$/
++\cbr	tex-src/texinfo.tex	/^\\def\\cbr{{\\hskip 6pt\\circle\\char'011}}$/
++c	c.c	180
++cccccccccc	c-src/h.h	115
++C	cp-src/fail.C	25
++C	cp-src/fail.C	9
++C	cp-src/fail.C	/^			   C(int i) {x = i;}$/
++c	c-src/h.h	106
++c	c-src/h.h	/^#define c() d$/
++%cdiff	make-src/Makefile	/^%cdiff: CTAGS% CTAGS ${infiles}$/
++cdr	c-src/emacs/src/lisp.h	1159
++CDR	c-src/emacs/src/lisp.h	/^CDR (Lisp_Object c)$/
++CDR_SAFE	c-src/emacs/src/lisp.h	/^CDR_SAFE (Lisp_Object c)$/
++cell	y-src/parse.y	279
++\center	tex-src/texinfo.tex	/^\\def\\center{\\parsearg\\centerzzz}$/
++\centerzzz	tex-src/texinfo.tex	/^\\def\\centerzzz #1{{\\advance\\hsize by -\\leftskip$/
++C_entries	c-src/etags.c	/^C_entries (int c_ext, FILE *inf)$/
++C_EXT	c-src/etags.c	2193
++c_ext	c-src/etags.c	2271
++CFLAGS	make-src/Makefile	/^CFLAGS=${WARNINGS} -ansi -g3 # -pg -O$/
++/cfs	ps-src/rfc1245.ps	/^\/cfs { $/
++cgrep	html-src/software.html	/^cgrep$/
++chain	c-src/emacs/src/lisp.h	1162
++chain	c-src/emacs/src/lisp.h	2206
++chain	c-src/emacs/src/lisp.h	2396
++chain_subst_2	merc-src/accumulator.m	/^:- pred chain_subst_2(list(A)::in, map(A, B)::in, /
++chain_subst	merc-src/accumulator.m	/^:- func chain_subst(accu_subst, accu_subst) = accu/
++ChangeFileType	pas-src/common.pas	/^function ChangeFileType; (*(FileName : NameString;/
++\chapbreak	tex-src/texinfo.tex	/^\\def\\chapbreak{\\dobreak \\chapheadingskip {-4000}}$/
++\chapentryfonts	tex-src/texinfo.tex	/^\\def\\chapentryfonts{\\secfonts \\rm}$/
++\chapentry	tex-src/texinfo.tex	/^\\def\\chapentry#1#2#3{\\dochapentry{#2\\labelspace#1}/
++\chapfonts	tex-src/texinfo.tex	/^\\def\\chapfonts{%$/
++\CHAPFopen	tex-src/texinfo.tex	/^\\def\\CHAPFopen{$/
++\CHAPFplain	tex-src/texinfo.tex	/^\\def\\CHAPFplain{$/
++\chapheading	tex-src/texinfo.tex	/^\\def\\chapheading{\\parsearg\\chapheadingzzz}$/
++\chapheadingzzz	tex-src/texinfo.tex	/^\\def\\chapheadingzzz #1{\\chapbreak %$/
++\chapoddpage	tex-src/texinfo.tex	/^\\def\\chapoddpage{\\chappager \\ifodd\\pageno \\else \\h/
++\chappager	tex-src/texinfo.tex	/^\\def\\chappager{\\par\\vfill\\supereject}$/
++\CHAPPAGodd	tex-src/texinfo.tex	/^\\def\\CHAPPAGodd{$/
++\CHAPPAGoff	tex-src/texinfo.tex	/^\\def\\CHAPPAGoff{$/
++\CHAPPAGon	tex-src/texinfo.tex	/^\\def\\CHAPPAGon{$/
++\chapternofonts	tex-src/texinfo.tex	/^\\def\\chapternofonts{%$/
++\chapter	tex-src/texinfo.tex	/^\\outer\\def\\chapter{\\parsearg\\chapterzzz}$/
++\chapterzzz	tex-src/texinfo.tex	/^\\def\\chapterzzz #1{\\seccheck{chapter}%$/
++CHARACTERBITS	c-src/emacs/src/lisp.h	2457
++CHAR_ALT	c-src/emacs/src/lisp.h	2445
++CHAR_BIT	c-src/emacs/src/lisp.h	2957
++CHAR_BIT	c-src/emacs/src/lisp.h	2959
++CHAR_BIT	c-src/emacs/src/lisp.h	2964
++CHAR_BIT	c-src/emacs/src/lisp.h	2969
++CHAR_BIT	c-src/emacs/src/lisp.h	2974
++CHAR_BIT	c-src/emacs/src/lisp.h	2978
++CHAR_BIT	c-src/emacs/src/lisp.h	2983
++char_bits	c-src/emacs/src/lisp.h	2443
++CHAR_CLASS_MAX_LENGTH	c-src/emacs/src/regex.h	593
++CHAR_CLASS_MAX_LENGTH	c-src/emacs/src/regex.h	597
++CHAR_CLASS_MAX_LENGTH	c-src/emacs/src/regex.h	605
++CHAR	c-src/etags.c	/^#define CHAR(x)		((unsigned int)(x) & (CHARS - 1))/
++CHAR_CTL	c-src/emacs/src/lisp.h	2449
++CHAR_HYPER	c-src/emacs/src/lisp.h	2447
++CHAR_META	c-src/emacs/src/lisp.h	2450
++CHAR_MODIFIER_MASK	c-src/emacs/src/lisp.h	2452
++charpos	c-src/emacs/src/lisp.h	2011
++CHARS	c-src/etags.c	157
++charset_unibyte	c-src/emacs/src/regex.h	410
++CHAR_SHIFT	c-src/emacs/src/lisp.h	2448
++CHAR_SUPER	c-src/emacs/src/lisp.h	2446
++CHAR_TABLE_EXTRA_SLOTS	c-src/emacs/src/lisp.h	/^CHAR_TABLE_EXTRA_SLOTS (struct Lisp_Char_Table *ct/
++CHAR_TABLE_P	c-src/emacs/src/lisp.h	/^CHAR_TABLE_P (Lisp_Object a)$/
++CHAR_TABLE_REF_ASCII	c-src/emacs/src/lisp.h	/^CHAR_TABLE_REF_ASCII (Lisp_Object ct, ptrdiff_t id/
++CHAR_TABLE_REF	c-src/emacs/src/lisp.h	/^CHAR_TABLE_REF (Lisp_Object ct, int idx)$/
++CHAR_TABLE_SET	c-src/emacs/src/lisp.h	/^CHAR_TABLE_SET (Lisp_Object ct, int idx, Lisp_Obje/
++char_table_specials	c-src/emacs/src/lisp.h	1692
++CHAR_TABLE_STANDARD_SLOTS	c-src/emacs/src/lisp.h	1697
++CHARTAB_SIZE_BITS_0	c-src/emacs/src/lisp.h	1567
++CHARTAB_SIZE_BITS_1	c-src/emacs/src/lisp.h	1568
++CHARTAB_SIZE_BITS_2	c-src/emacs/src/lisp.h	1569
++CHARTAB_SIZE_BITS_3	c-src/emacs/src/lisp.h	1570
++CHARTAB_SIZE_BITS	c-src/emacs/src/lisp.h	1565
++\char	tex-src/texinfo.tex	/^\\def\\char{\\realbackslash char}%$/
++\char	tex-src/texinfo.tex	/^\\def\\char{\\realbackslash char}$/
++chartonmstr	pas-src/common.pas	/^function chartonmstr; (*($/
++CHAR_TYPE_SIZE	y-src/cccp.y	87
++CHAR	y-src/cccp.c	7
++CHECK_ARRAY	c-src/emacs/src/lisp.h	/^CHECK_ARRAY (Lisp_Object x, Lisp_Object predicate)/
++CHECK_BOOL_VECTOR	c-src/emacs/src/lisp.h	/^CHECK_BOOL_VECTOR (Lisp_Object x)$/
++CHECK_BUFFER	c-src/emacs/src/lisp.h	/^CHECK_BUFFER (Lisp_Object x)$/
++CHECK_CONS	c-src/emacs/src/lisp.h	/^CHECK_CONS (Lisp_Object x)$/
++check_cons_list	c-src/emacs/src/lisp.h	/^#  define check_cons_list() lisp_h_check_cons_list/
++checker	make-src/Makefile	/^checker:$/
++CHECKFLAGS	make-src/Makefile	/^CHECKFLAGS=-DDEBUG -Wno-unused-function$/
++checkhdr	c-src/emacs/src/gmalloc.c	/^checkhdr (const struct hdr *hdr)$/
++checkiso	html-src/software.html	/^checkiso$/
++CHECK_LISP_OBJECT_TYPE	c-src/emacs/src/lisp.h	571
++CHECK_LISP_OBJECT_TYPE	c-src/emacs/src/lisp.h	572
++CHECK_LISP_OBJECT_TYPE	c-src/emacs/src/lisp.h	579
++CHECK_LIST_CONS	c-src/emacs/src/lisp.h	/^# define CHECK_LIST_CONS(x, y) lisp_h_CHECK_LIST_C/
++CHECK_LIST	c-src/emacs/src/lisp.h	/^CHECK_LIST (Lisp_Object x)$/
++CHECK_NATNUM	c-src/emacs/src/lisp.h	/^CHECK_NATNUM (Lisp_Object x)$/
++CHECK_NUMBER_CAR	c-src/emacs/src/lisp.h	/^CHECK_NUMBER_CAR (Lisp_Object x)$/
++CHECK_NUMBER_CDR	c-src/emacs/src/lisp.h	/^CHECK_NUMBER_CDR (Lisp_Object x)$/
++CHECK_NUMBER_COERCE_MARKER	c-src/emacs/src/lisp.h	/^#define CHECK_NUMBER_COERCE_MARKER(x)					\\$/
++CHECK_NUMBER	c-src/emacs/src/lisp.h	/^# define CHECK_NUMBER(x) lisp_h_CHECK_NUMBER (x)$/
++CHECK_NUMBER_OR_FLOAT_COERCE_MARKER	c-src/emacs/src/lisp.h	/^#define CHECK_NUMBER_OR_FLOAT_COERCE_MARKER(x)				/
++CHECK_NUMBER_OR_FLOAT	c-src/emacs/src/lisp.h	/^CHECK_NUMBER_OR_FLOAT (Lisp_Object x)$/
++CHECKOBJS	make-src/Makefile	/^CHECKOBJS=chkmalloc.o chkxm.o$/
++CHECK_PROCESS	c-src/emacs/src/lisp.h	/^CHECK_PROCESS (Lisp_Object x)$/
++checkQuotation	php-src/lce_functions.php	/^      function checkQuotation($str)$/
++CHECK_RANGED_INTEGER	c-src/emacs/src/lisp.h	/^#define CHECK_RANGED_INTEGER(x, lo, hi)					\\$/
++CHECK_STRING_CAR	c-src/emacs/src/lisp.h	/^CHECK_STRING_CAR (Lisp_Object x)$/
++CHECK_SYMBOL	c-src/emacs/src/lisp.h	/^# define CHECK_SYMBOL(x) lisp_h_CHECK_SYMBOL (x)$/
++CHECK_TYPE	c-src/emacs/src/lisp.h	/^# define CHECK_TYPE(ok, predicate, x) lisp_h_CHECK/
++CHECK_TYPE_RANGED_INTEGER	c-src/emacs/src/lisp.h	/^#define CHECK_TYPE_RANGED_INTEGER(type, x) \\$/
++CHECK_VECTOR	c-src/emacs/src/lisp.h	/^CHECK_VECTOR (Lisp_Object x)$/
++CHECK_VECTOR_OR_STRING	c-src/emacs/src/lisp.h	/^CHECK_VECTOR_OR_STRING (Lisp_Object x)$/
++CHECK_WINDOW	c-src/emacs/src/lisp.h	/^CHECK_WINDOW (Lisp_Object x)$/
++\chfopen	tex-src/texinfo.tex	/^\\def\\chfopen #1#2{\\chapoddpage {\\chapfonts$/
++\chfplain	tex-src/texinfo.tex	/^\\def\\chfplain #1#2{%$/
++childDidExit	objc-src/Subprocess.m	/^- childDidExit$/
++chunks_free	c-src/emacs/src/gmalloc.c	313
++_chunks_free	c-src/emacs/src/gmalloc.c	375
++chunks_used	c-src/emacs/src/gmalloc.c	311
++_chunks_used	c-src/emacs/src/gmalloc.c	373
++\cindexsub	tex-src/texinfo.tex	/^\\def\\cindexsub {\\begingroup\\obeylines\\cindexsub}$/
++\cindex	tex-src/texinfo.tex	/^\\def\\cindex {\\cpindex}$/
++Circle.getPos	lua-src/test.lua	/^function Circle.getPos ()$/
++\cite	tex-src/texinfo.tex	/^\\def\\cite##1{\\realbackslash cite {##1}}%$/
++\cite	tex-src/texinfo.tex	/^\\def\\cite##1{\\realbackslash cite {##1}}$/
++C_JAVA	c-src/etags.c	2197
++cjava	c-src/etags.c	2936
++Cjava_entries	c-src/etags.c	/^Cjava_entries (FILE *inf)$/
++Cjava_help	c-src/etags.c	551
++Cjava_suffixes	c-src/etags.c	549
++CK_ABS_C	y-src/parse.y	/^#define CK_ABS_C(x)	if((x)<MIN_COL || (x)>MAX_COL)/
++CK_ABS_R	y-src/parse.y	/^#define CK_ABS_R(x)	if((x)<MIN_ROW || (x)>MAX_ROW)/
++CK_REL_C	y-src/parse.y	/^#define CK_REL_C(x)	if(   ((x)>0 && MAX_COL-(x)<cu/
++CK_REL_R	y-src/parse.y	/^#define CK_REL_R(x)	if(   ((x)>0 && MAX_ROW-(x)<cu/
++ClassExample	ruby-src/test.rb	/^    class ClassExample$/
++classifyLine	php-src/lce_functions.php	/^      function classifyLine($line)$/
++class_method	ruby-src/test.rb	/^        def ClassExample.class_method$/
++clean	make-src/Makefile	/^clean:$/
++clear-abbrev-table	c-src/abbrev.c	/^DEFUN ("clear-abbrev-table", Fclear_abbrev_table, /
++clearAllKey	objcpp-src/SimpleCalc.M	/^- clearAllKey:sender$/
++clear	cp-src/conway.hpp	/^    void clear(void) { alive = 0; }$/
++clear_event	c-src/emacs/src/keyboard.c	/^clear_event (struct input_event *event)$/
++clear_input_pending	c-src/emacs/src/keyboard.c	/^clear_input_pending (void)$/
++clearKey	objcpp-src/SimpleCalc.M	/^- clearKey:sender$/
++clear_neighbors	cp-src/clheir.cpp	/^void discrete_location::clear_neighbors(void)$/
++Clear/p	ada-src/2ataspri.adb	/^   procedure Clear (Cell : in out TAS_Cell) is$/
++Clear/p	ada-src/2ataspri.ads	/^   procedure Clear        (Cell : in out TAS_Cell)/
++clear_screen	cp-src/screen.cpp	/^void clear_screen(void)$/
++\clear	tex-src/texinfo.tex	/^\\def\\clear{\\parsearg\\clearxxx}$/
++clear-this-command-keys	c-src/emacs/src/keyboard.c	/^DEFUN ("clear-this-command-keys", Fclear_this_comm/
++clear_waiting_for_input	c-src/emacs/src/keyboard.c	/^clear_waiting_for_input (void)$/
++\clearxxx	tex-src/texinfo.tex	/^\\def\\clearxxx #1{$/
++cmd_error	c-src/emacs/src/keyboard.c	/^cmd_error (Lisp_Object data)$/
++cmd_error_internal	c-src/emacs/src/keyboard.c	/^cmd_error_internal (Lisp_Object data, const char */
++cmpfn	c-src/emacs/src/lisp.h	/^  bool (*cmpfn) (struct hash_table_test *t, Lisp_O/
++cmt	prol-src/natded.prolog	/^cmt:-$/
++CMultiChannelCSC19_3D	cp-src/c.C	2
++cname	c-src/etags.c	2519
++CNL	c-src/etags.c	/^#define CNL()								\\$/
++CNL_SAVE_DEFINEDEF	c-src/etags.c	/^#define CNL_SAVE_DEFINEDEF()						\\$/
++cno	c-src/etags.c	224
++COBOLFLAGS	make-src/Makefile	/^COBOLFLAGS=--language=none --regex='\/.......[a-zA-/
++Cobol_help	c-src/etags.c	558
++Cobol_paragraphs	c-src/etags.c	/^Cobol_paragraphs (FILE *inf)$/
++Cobol_suffixes	c-src/etags.c	556
++\code	tex-src/texinfo.tex	/^\\def\\code##1{\\realbackslash code {##1}}%$/
++\code	tex-src/texinfo.tex	/^\\def\\code##1{\\realbackslash code {##1}}$/
++colori	cp-src/c.C	40
++COLORS	cp-src/screen.hpp	11
++__COLORS	cp-src/screen.hpp	9
++/colorsetup	ps-src/rfc1245.ps	/^\/colorsetup {$/
++commaargvals	prol-src/natded.prolog	/^commaargvals(Args) -->$/
++command	c-src/etags.c	187
++command-error-default-function	c-src/emacs/src/keyboard.c	/^DEFUN ("command-error-default-function", Fcommand_/
++command_loop_1	c-src/emacs/src/keyboard.c	/^command_loop_1 (void)$/
++command_loop_2	c-src/emacs/src/keyboard.c	/^command_loop_2 (Lisp_Object ignore)$/
++command_loop	c-src/emacs/src/keyboard.c	/^command_loop (void)$/
++command_loop_level	c-src/emacs/src/keyboard.c	195
++CommentAD	php-src/lce_functions.php	70
++CommentAD	php-src/lce_functions.php	/^      function CommentAD($/
++comment	php-src/lce_functions.php	/^      function comment($line, $class)$/
++\comment	tex-src/texinfo.tex	/^\\def\\comment{\\catcode 64=\\other \\catcode 123=\\othe/
++\commentxxx	tex-src/texinfo.tex	/^\\def\\commentxxx #1{\\catcode 64=0 \\catcode 123=1 \\c/
++/COMMONBITMAPc	ps-src/rfc1245.ps	/^\/COMMONBITMAPc { $/
++/COMMONBITMAP	ps-src/rfc1245.ps	/^\/COMMONBITMAP { $/
++commutativity_assertion	merc-src/accumulator.m	/^:- pred commutativity_assertion(module_info::in,li/
++COMPILED_ARGLIST	c-src/emacs/src/lisp.h	2431
++COMPILED_BYTECODE	c-src/emacs/src/lisp.h	2432
++COMPILED_CONSTANTS	c-src/emacs/src/lisp.h	2433
++COMPILED_DOC_STRING	c-src/emacs/src/lisp.h	2435
++COMPILED_INTERACTIVE	c-src/emacs/src/lisp.h	2436
++COMPILEDP	c-src/emacs/src/lisp.h	/^COMPILEDP (Lisp_Object a)$/
++COMPILED_STACK_DEPTH	c-src/emacs/src/lisp.h	2434
++compile_empty	prol-src/natded.prolog	/^compile_empty:-$/
++compile_lex	prol-src/natded.prolog	/^compile_lex(File):-$/
++complete	prol-src/natded.prolog	/^complete(Cat):-$/
++complete-tag	el-src/emacs/lisp/progmodes/etags.el	/^(defun complete-tag ()$/
++compressor	c-src/etags.c	188
++compressors	c-src/etags.c	457
++compute_next_state	cp-src/clheir.hpp	/^    virtual void compute_next_state(void) { }$/
++compute_next_state	cp-src/conway.hpp	/^    void compute_next_state(void)$/
++conalgorithm	html-src/algrthms.html	/^Convolutionally$/
++concat	c-src/etags.c	/^concat (const char *s1, const char *s2, const char/
++concatenatenamestrings	pas-src/common.pas	/^function concatenatenamestrings; (*($/
++ConcatT	pas-src/common.pas	/^function ConcatT;(*($/
++Concept Index	tex-src/gzip.texi	/^@node Concept Index, , Problems, Top$/
++CONDITION_CASE	c-src/emacs/src/lisp.h	3021
++Condition_Variable/t	ada-src/2ataspri.ads	/^   type Condition_Variable is$/
++Condition_Variable/t	ada-src/2ataspri.ads	/^   type Condition_Variable is private;$/
++Cond_Signal/p	ada-src/2ataspri.adb	/^   procedure Cond_Signal (Cond : in out Condition_/
++Cond_Signal/p	ada-src/2ataspri.ads	/^   procedure Cond_Signal (Cond : in out Condition_/
++Cond_Timed_Wait/p	ada-src/2ataspri.adb	/^   procedure Cond_Timed_Wait$/
++Cond_Timed_Wait/p	ada-src/2ataspri.ads	/^   procedure Cond_Timed_Wait$/
++Cond_Wait/p	ada-src/2ataspri.adb	/^   procedure Cond_Wait (Cond : in out Condition_Va/
++Cond_Wait/p	ada-src/2ataspri.ads	/^   procedure Cond_Wait (Cond : in out Condition_Va/
++Configure	pyt-src/server.py	/^class Configure(Frame, ControlEdit):$/
++ConfirmQuit	pyt-src/server.py	/^def ConfirmQuit(frame, context):$/
++consider_token	c-src/etags.c	/^consider_token (char *str, int len, int c, int *c_/
++CONSP	c-src/emacs/src/lisp.h	/^# define CONSP(x) lisp_h_CONSP (x)$/
++constant_args	c-src/h.h	27
++constant	c-src/emacs/src/lisp.h	668
++constant	c-src/h.h	29
++Constant	ruby-src/test1.ru	42
++constant	y-src/cccp.y	112
++CONS_TO_INTEGER	c-src/emacs/src/lisp.h	/^#define CONS_TO_INTEGER(cons, type, var)				\\$/
++constype	c-src/emacs/src/lisp.h	3739
++CONSTYPE_HEAP	c-src/emacs/src/lisp.h	3739
++CONSTYPE_PURE	c-src/emacs/src/lisp.h	3739
++consult_lex	prol-src/natded.prolog	/^consult_lex:-$/
++contents	c-src/emacs/src/lisp.h	1372
++contents	c-src/emacs/src/lisp.h	1600
++contents	c-src/emacs/src/lisp.h	1624
++\contents	tex-src/texinfo.tex	/^\\outer\\def\\contents{%$/
++ControlEdit	pyt-src/server.py	/^class ControlEdit(Frame):$/
++Controls	pyt-src/server.py	/^class Controls:$/
++CONVERT_CHARSTRING_TO_VALUE	pas-src/common.pas	/^procedure CONVERT_CHARSTRING_TO_VALUE;(*($/
++Copying	tex-src/gzip.texi	/^@node Copying, Overview, , Top$/
++\copyright	tex-src/texinfo.tex	/^\\def\\copyright{\\realbackslash copyright }%$/
++\copyright	tex-src/texinfo.tex	/^\\def\\copyright{\\realbackslash copyright}$/
++CopyTextString	pas-src/common.pas	/^function CopyTextString;(*($/
++count	c-src/emacs/src/lisp.h	1863
++counter	cp-src/c.C	33
++counter	cp-src/c.C	36
++count_layers	lua-src/allegro.lua	/^local function count_layers (layer)$/
++count_words	c-src/tab.c	/^static int		count_words(char *str, char delim)$/
++cow	cp-src/c.C	127
++cow	cp-src/c.C	131
++C_PLAIN	c-src/etags.c	2194
++C_PLPL	c-src/etags.c	2195
++cplpl	c-src/etags.c	2935
++Cplusplus_entries	c-src/etags.c	/^Cplusplus_entries (FILE *inf)$/
++Cplusplus_help	c-src/etags.c	540
++Cplusplus_suffixes	c-src/etags.c	535
++CPPFLAGS	make-src/Makefile	/^CPPFLAGS=${CHECKFLAGS} -DSTDC_HEADERS -DHAVE_GETCW/
++CPSRC	make-src/Makefile	/^CPSRC=c.C abstract.C abstract.H cfront.H burton.cp/
++/C	ps-src/rfc1245.ps	/^\/C { $/
++create_acc_call	merc-src/accumulator.m	/^:- func create_acc_call(hlds_goal::in(goal_plain_c/
++create_acc_goal	merc-src/accumulator.m	/^:- pred create_acc_goal(hlds_goal::in, accu_substs/
++create-bar	forth-src/test-forth.fth	/^: create-bar foo ;$/
++Create_LL_Task/p	ada-src/2ataspri.adb	/^   procedure Create_LL_Task$/
++Create_LL_Task/p	ada-src/2ataspri.ads	/^   procedure Create_LL_Task$/
++create_new_base_goals	merc-src/accumulator.m	/^:- func create_new_base_goals(set(accu_goal_id), a/
++create_new_orig_recursive_goals	merc-src/accumulator.m	/^:- func create_new_orig_recursive_goals(set(accu_g/
++create_new_recursive_goals	merc-src/accumulator.m	/^:- func create_new_recursive_goals(set(accu_goal_i/
++create_new_var	merc-src/accumulator.m	/^:- pred create_new_var(prog_var::in, string::in, p/
++create_orig_goal	merc-src/accumulator.m	/^:- pred create_orig_goal(hlds_goal::in, accu_subst/
++createPOEntries	php-src/lce_functions.php	/^      function createPOEntries()$/
++createWidgets	pyt-src/server.py	/^    def createWidgets(self):$/
++createWidgets	pyt-src/server.py	/^    def createWidgets(self, host):$/
++\cropmarks	tex-src/texinfo.tex	/^\\def\\cropmarks{\\let\\onepageout=\\croppageout }$/
++\croppageout	tex-src/texinfo.tex	/^\\def\\croppageout#1{\\hoffset=0pt % make sure this d/
++cscInitTime	cp-src/c.C	7
++cscSegmentationTime	cp-src/c.C	8
++CSRC	make-src/Makefile	/^CSRC=abbrev.c ..\/etags\/h.h .\/\/c.c torture.c getopt/
++C_stab_entry	c-src/etags.c	2271
++cstack	c-src/etags.c	2523
++C_STAR	c-src/etags.c	2196
++Cstar_entries	c-src/etags.c	/^Cstar_entries (FILE *inf)$/
++Cstar_suffixes	c-src/etags.c	562
++C_symtype	c-src/etags.c	/^C_symtype (char *str, int len, int c_ext)$/
++CTAGS13 CTAGS14 CTAGS15	make-src/Makefile	/^CTAGS13 CTAGS14 CTAGS15: ctags% ${infiles}$/
++CTAGS	c-src/etags.c	146
++CTAGS	c-src/etags.c	147
++CTAGS	c-src/etags.c	149
++CTAGS	make-src/Makefile	/^CTAGS: ctags ${infiles}$/
++CTAGS%	make-src/Makefile	/^CTAGS%: ctags% ${infiles}$/
++ctags	make-src/Makefile	/^ctags: etags.c ${OBJS}$/
++\ctl	tex-src/texinfo.tex	/^\\def\\ctl{{\\circle\\char'013\\hskip -6pt}}% 6pt from /
++\ctrl	tex-src/texinfo.tex	/^\\def\\ctrl #1{{\\tt \\rawbackslash \\hat}#1}$/
++\ctr	tex-src/texinfo.tex	/^\\def\\ctr{{\\hskip 6pt\\circle\\char'010}}$/
++Cube.data.getFoo	lua-src/test.lua	/^function Cube.data.getFoo ()$/
++curlb	c-src/etags.c	2929
++curlinepos	c-src/etags.c	2931
++current-idle-time	c-src/emacs/src/keyboard.c	/^DEFUN ("current-idle-time", Fcurrent_idle_time, Sc/
++current-input-mode	c-src/emacs/src/keyboard.c	/^DEFUN ("current-input-mode", Fcurrent_input_mode, /
++current_kboard	c-src/emacs/src/keyboard.c	85
++current_lb_is_new	c-src/etags.c	2926
++curry-test	scm-src/test.scm	/^(define (((((curry-test a) b) c) d) e)$/
++cursor_position	cp-src/screen.cpp	/^void cursor_position(void)$/
++cursor_x	cp-src/screen.cpp	15
++cursor_y	cp-src/screen.cpp	15
++CYAN	cp-src/screen.hpp	15
++DAEMON_RUNNING	c-src/emacs/src/lisp.h	4258
++DAEMON_RUNNING	c-src/emacs/src/lisp.h	4262
++DARKGRAY	cp-src/screen.hpp	20
++data	c-src/emacs/src/lisp.h	1395
++data	c-src/emacs/src/lisp.h	2129
++data	c-src/emacs/src/lisp.h	2395
++d	c.c	180
++D	cp-src/fail.C	41
++D	cp-src/fail.C	/^		D() : ::A::T2::T(97), x(1066) {}$/
++d	c-src/emacs/src/lisp.h	4673
++d	c-src/emacs/src/lisp.h	4679
++ddefineseen	c-src/etags.c	2462
++DEAFUN	c.c	/^DEAFUN ("expand-file-name", Fexpand_file_name, Sex/
++debian-bug	html-src/software.html	/^debian-bug.el$/
++Debug	cp-src/functions.cpp	/^void Debug ( int lineno, int level, char* func , c/
++DEBUG	c-src/etags.c	84
++DEBUG	c-src/etags.c	85
++DEBUG	c-src/etags.c	87
++DEBUG	objc-src/PackInsp.m	37
++debug_on_exit	c-src/emacs/src/lisp.h	2984
++decimalKey	objcpp-src/SimpleCalc.M	/^- decimalKey:sender$/
++declared_special	c-src/emacs/src/lisp.h	676
++DECLARE_GDB_SYM	c-src/emacs/src/lisp.h	/^#define DECLARE_GDB_SYM(type, id) type const id EX/
++decode_timer	c-src/emacs/src/keyboard.c	/^decode_timer (Lisp_Object timer, struct timespec */
++defalt	c-src/emacs/src/lisp.h	1585
++default_C_entries	c-src/etags.c	/^default_C_entries (FILE *inf)$/
++default_C_help	c-src/etags.c	515
++default_C_help	c-src/etags.c	523
++default_C_suffixes	c-src/etags.c	512
++DEFAULT_HASH_SIZE	c-src/emacs/src/lisp.h	1940
++__default_morecore	c-src/emacs/src/gmalloc.c	/^__default_morecore (ptrdiff_t increment)$/
++DEFAULT_REHASH_SIZE	c-src/emacs/src/lisp.h	1950
++DEFAULT_REHASH_THRESHOLD	c-src/emacs/src/lisp.h	1946
++default-tags-table-function	el-src/emacs/lisp/progmodes/etags.el	/^(defvar default-tags-table-function nil$/
++defcell	c-src/emacs/src/lisp.h	2351
++\defcodeindex	tex-src/texinfo.tex	/^\\def\\defcodeindex{\\parsearg\\newcodeindex}$/
++def	c-src/h.h	35
++def	c-src/h.h	38
++\defcvarheader	tex-src/texinfo.tex	/^\\def\\defcvarheader #1#2#3{%$/
++\defcv	tex-src/texinfo.tex	/^\\def\\defcv #1 {\\def\\defcvtype{#1}%$/
++\defcvx	tex-src/texinfo.tex	/^\\def\\defcvx #1 {\\errmessage{@defcvx in invalid con/
++\deffnheader	tex-src/texinfo.tex	/^\\def\\deffnheader #1#2#3{\\doind {fn}{\\code{#2}}%$/
++\deffn	tex-src/texinfo.tex	/^\\def\\deffn{\\defmethparsebody\\Edeffn\\deffnx\\deffnhe/
++\deffnx	tex-src/texinfo.tex	/^\\def\\deffnx #1 {\\errmessage{@deffnx in invalid con/
++\defindex	tex-src/texinfo.tex	/^\\def\\defindex{\\parsearg\\newindex}$/
++define-abbrev	c-src/abbrev.c	/^DEFUN ("define-abbrev", Fdefine_abbrev, Sdefine_ab/
++define-abbrev-table	c-src/abbrev.c	/^DEFUN ("define-abbrev-table", Fdefine_abbrev_table/
++definedef	c-src/etags.c	2464
++defined_GC_CHECK_STRING_BYTES	c-src/emacs/src/lisp.h	4663
++defined_GC_CHECK_STRING_BYTES	c-src/emacs/src/lisp.h	4665
++DEFINE_GDB_SYMBOL_BEGIN	c-src/emacs/src/lisp.h	/^# define DEFINE_GDB_SYMBOL_BEGIN(type, id) DECLARE/
++DEFINE_GDB_SYMBOL_BEGIN	c-src/emacs/src/lisp.h	/^# define DEFINE_GDB_SYMBOL_BEGIN(type, id) extern /
++DEFINE_GDB_SYMBOL_END	c-src/emacs/src/lisp.h	/^# define DEFINE_GDB_SYMBOL_END(id) = id;$/
++DEFINE_GDB_SYMBOL_END	c-src/emacs/src/lisp.h	/^# define DEFINE_GDB_SYMBOL_END(val) ;$/
++define-global-abbrev	c-src/abbrev.c	/^DEFUN ("define-global-abbrev", Fdefine_global_abbr/
++DEFINE_LISP_SYMBOL	c-src/emacs/src/lisp.h	/^#define DEFINE_LISP_SYMBOL(name) \\$/
++define-mode-abbrev	c-src/abbrev.c	/^DEFUN ("define-mode-abbrev", Fdefine_mode_abbrev, /
++DEFINE_NON_NIL_Q_SYMBOL_MACROS	c-src/emacs/src/lisp.h	755
++\defivarheader	tex-src/texinfo.tex	/^\\def\\defivarheader #1#2#3{%$/
++\defivar	tex-src/texinfo.tex	/^\\def\\defivar{\\defvrparsebody\\Edefivar\\defivarx\\def/
++\defivarx	tex-src/texinfo.tex	/^\\def\\defivarx #1 {\\errmessage{@defivarx in invalid/
++\defmacheader	tex-src/texinfo.tex	/^\\def\\defmacheader #1#2{\\doind {fn}{\\code{#1}}% Mak/
++\defmac	tex-src/texinfo.tex	/^\\def\\defmac{\\defparsebody\\Edefmac\\defmacx\\defmache/
++\defmacx	tex-src/texinfo.tex	/^\\def\\defmacx #1 {\\errmessage{@defmacx in invalid c/
++\defmethodheader	tex-src/texinfo.tex	/^\\def\\defmethodheader #1#2#3{%$/
++\defmethod	tex-src/texinfo.tex	/^\\def\\defmethod{\\defmethparsebody\\Edefmethod\\defmet/
++\defmethodx	tex-src/texinfo.tex	/^\\def\\defmethodx #1 {\\errmessage{@defmethodx in inv/
++\defmethparsebody	tex-src/texinfo.tex	/^\\def\\defmethparsebody #1#2#3#4 {\\begingroup\\inENV /
++\defname	tex-src/texinfo.tex	/^\\def\\defname #1#2{%$/
++\defopheader	tex-src/texinfo.tex	/^\\def\\defopheader #1#2#3{%$/
++\defopparsebody	tex-src/texinfo.tex	/^\\def\\defopparsebody #1#2#3#4#5 {\\begingroup\\inENV /
++\defop	tex-src/texinfo.tex	/^\\def\\defop #1 {\\def\\defoptype{#1}%$/
++\defoptheader	tex-src/texinfo.tex	/^\\def\\defoptheader #1#2{\\doind {vr}{\\code{#1}}% Mak/
++\defopt	tex-src/texinfo.tex	/^\\def\\defopt{\\defvarparsebody\\Edefopt\\defoptx\\defop/
++\defoptx	tex-src/texinfo.tex	/^\\def\\defoptx #1 {\\errmessage{@defoptx in invalid c/
++\defopvarparsebody	tex-src/texinfo.tex	/^\\def\\defopvarparsebody #1#2#3#4#5 {\\begingroup\\inE/
++\defopx	tex-src/texinfo.tex	/^\\def\\defopx #1 {\\errmessage{@defopx in invalid con/
++\defparsebody	tex-src/texinfo.tex	/^\\def\\defparsebody #1#2#3{\\begingroup\\inENV% Enviro/
++Def_	ruby-src/test1.ru	12
++\defspecheader	tex-src/texinfo.tex	/^\\def\\defspecheader #1#2{\\doind {fn}{\\code{#1}}% Ma/
++\defspec	tex-src/texinfo.tex	/^\\def\\defspec{\\defparsebody\\Edefspec\\defspecx\\defsp/
++\defspecx	tex-src/texinfo.tex	/^\\def\\defspecx #1 {\\errmessage{@defspecx in invalid/
++DEFSYM	c-src/emacs/src/lisp.h	/^#define DEFSYM(sym, name) \/* empty *\/$/
++DEFSYM	c-src/emacs/src/lisp.h	/^LISP_MACRO_DEFUN (SYMBOL_CONSTANT_P, int, (Lisp_Ob/
++\deftpargs	tex-src/texinfo.tex	/^\\def\\deftpargs #1{\\bf \\defvarargs{#1}}$/
++\deftpheader	tex-src/texinfo.tex	/^\\def\\deftpheader #1#2#3{\\doind {tp}{\\code{#2}}%$/
++\deftp	tex-src/texinfo.tex	/^\\def\\deftp{\\defvrparsebody\\Edeftp\\deftpx\\deftphead/
++\deftpx	tex-src/texinfo.tex	/^\\def\\deftpx #1 {\\errmessage{@deftpx in invalid con/
++\deftypefnheader	tex-src/texinfo.tex	/^\\def\\deftypefnheader #1#2#3{\\deftypefnheaderx{#1}{/
++\deftypefnheaderx	tex-src/texinfo.tex	/^\\def\\deftypefnheaderx #1#2#3 #4\\relax{%$/
++\deftypefn	tex-src/texinfo.tex	/^\\def\\deftypefn{\\defmethparsebody\\Edeftypefn\\deftyp/
++\deftypefnx	tex-src/texinfo.tex	/^\\def\\deftypefnx #1 {\\errmessage{@deftypefnx in inv/
++\deftypefunargs	tex-src/texinfo.tex	/^\\def\\deftypefunargs #1{%$/
++\deftypefunheader	tex-src/texinfo.tex	/^\\def\\deftypefunheader #1#2{\\deftypefunheaderx{#1}#/
++\deftypefunheaderx	tex-src/texinfo.tex	/^\\def\\deftypefunheaderx #1#2 #3\\relax{%$/
++\deftypefun	tex-src/texinfo.tex	/^\\def\\deftypefun{\\defparsebody\\Edeftypefun\\deftypef/
++\deftypeunx	tex-src/texinfo.tex	/^\\def\\deftypeunx #1 {\\errmessage{@deftypeunx in inv/
++\deftypevarheader	tex-src/texinfo.tex	/^\\def\\deftypevarheader #1#2{%$/
++\deftypevar	tex-src/texinfo.tex	/^\\def\\deftypevar{\\defvarparsebody\\Edeftypevar\\defty/
++\deftypevarx	tex-src/texinfo.tex	/^\\def\\deftypevarx #1 {\\errmessage{@deftypevarx in i/
++\deftypevrheader	tex-src/texinfo.tex	/^\\def\\deftypevrheader #1#2#3{\\doind {vr}{\\code{#3}}/
++\deftypevr	tex-src/texinfo.tex	/^\\def\\deftypevr{\\defvrparsebody\\Edeftypevr\\deftypev/
++\deftypevrx	tex-src/texinfo.tex	/^\\def\\deftypevrx #1 {\\errmessage{@deftypevrx in inv/
++DEFUN_ARGS_0	c-src/emacs/src/lisp.h	714
++DEFUN_ARGS_1	c-src/emacs/src/lisp.h	715
++DEFUN_ARGS_2	c-src/emacs/src/lisp.h	716
++DEFUN_ARGS_3	c-src/emacs/src/lisp.h	717
++DEFUN_ARGS_4	c-src/emacs/src/lisp.h	718
++DEFUN_ARGS_5	c-src/emacs/src/lisp.h	719
++DEFUN_ARGS_6	c-src/emacs/src/lisp.h	721
++DEFUN_ARGS_7	c-src/emacs/src/lisp.h	723
++DEFUN_ARGS_8	c-src/emacs/src/lisp.h	725
++DEFUN_ARGS_MANY	c-src/emacs/src/lisp.h	712
++\defunargs	tex-src/texinfo.tex	/^\\def\\defunargs #1{\\functionparens \\sl$/
++DEFUN_ARGS_UNEVALLED	c-src/emacs/src/lisp.h	713
++DEFUN	c-src/emacs/src/lisp.h	/^#define DEFUN(lname, fnname, sname, minargs, maxar/
++defun_func1	c.c	/^defun_func1()$/
++DEFUN_func2	c.c	/^DEFUN_func2()$/
++\defunheader	tex-src/texinfo.tex	/^\\def\\defunheader #1#2{\\doind {fn}{\\code{#1}}% Make/
++\defun	tex-src/texinfo.tex	/^\\def\\defun{\\defparsebody\\Edefun\\defunx\\defunheader/
++\defunx	tex-src/texinfo.tex	/^\\def\\defunx #1 {\\errmessage{@defunx in invalid con/
++\defvarargs	tex-src/texinfo.tex	/^\\def\\defvarargs #1{\\normalparens #1%$/
++DEFVAR_BOOL	c-src/emacs/src/lisp.h	/^#define DEFVAR_BOOL(lname, vname, doc)		\\$/
++DEFVAR_BUFFER_DEFAULTS	c-src/emacs/src/lisp.h	/^#define DEFVAR_BUFFER_DEFAULTS(lname, vname, doc)	/
++\defvarheader	tex-src/texinfo.tex	/^\\def\\defvarheader #1#2{\\doind {vr}{\\code{#1}}% Mak/
++DEFVAR_INT	c-src/emacs/src/lisp.h	/^#define DEFVAR_INT(lname, vname, doc)		\\$/
++DEFVAR_KBOARD	c-src/emacs/src/lisp.h	/^#define DEFVAR_KBOARD(lname, vname, doc)			\\$/
++DEFVAR_LISP	c-src/emacs/src/lisp.h	/^#define DEFVAR_LISP(lname, vname, doc)		\\$/
++DEFVAR_LISP_NOPRO	c-src/emacs/src/lisp.h	/^#define DEFVAR_LISP_NOPRO(lname, vname, doc)	\\$/
++\defvarparsebody	tex-src/texinfo.tex	/^\\def\\defvarparsebody #1#2#3{\\begingroup\\inENV% Env/
++\defvar	tex-src/texinfo.tex	/^\\def\\defvar{\\defvarparsebody\\Edefvar\\defvarx\\defva/
++\defvarx	tex-src/texinfo.tex	/^\\def\\defvarx #1 {\\errmessage{@defvarx in invalid c/
++\defvrheader	tex-src/texinfo.tex	/^\\def\\defvrheader #1#2#3{\\doind {vr}{\\code{#2}}%$/
++\defvrparsebody	tex-src/texinfo.tex	/^\\def\\defvrparsebody #1#2#3#4 {\\begingroup\\inENV %$/
++\defvr	tex-src/texinfo.tex	/^\\def\\defvr{\\defvrparsebody\\Edefvr\\defvrx\\defvrhead/
++\defvrx	tex-src/texinfo.tex	/^\\def\\defvrx #1 {\\errmessage{@defvrx in invalid con/
++delegate	objc-src/Subprocess.m	/^- delegate$/
++deleteItem	pyt-src/server.py	/^    def deleteItem(self):$/
++delete_kboard	c-src/emacs/src/keyboard.c	/^delete_kboard (KBOARD *kb)$/
++deliver_input_available_signal	c-src/emacs/src/keyboard.c	/^deliver_input_available_signal (int sig)$/
++deliver_interrupt_signal	c-src/emacs/src/keyboard.c	/^deliver_interrupt_signal (int sig)$/
++deliver_user_signal	c-src/emacs/src/keyboard.c	/^deliver_user_signal (int sig)$/
++depth	c-src/emacs/src/lisp.h	1618
++derived_analyses	prol-src/natded.prolog	/^derived_analyses([],[]).$/
++describe_abbrev	c-src/abbrev.c	/^describe_abbrev (sym, stream)$/
++\description	tex-src/texinfo.tex	/^\\def\\description{\\tablez{\\dontindex}{1}{}{}{}{}}$/
++/desperatepapersize	ps-src/rfc1245.ps	/^\/desperatepapersize {$/
++detect_input_pending	c-src/emacs/src/keyboard.c	/^detect_input_pending (void)$/
++detect_input_pending_ignore_squeezables	c-src/emacs/src/keyboard.c	/^detect_input_pending_ignore_squeezables (void)$/
++detect_input_pending_run_timers	c-src/emacs/src/keyboard.c	/^detect_input_pending_run_timers (bool do_display)$/
++DEVICE_LAST	c-src/h.h	24
++DEVICE_SWP	c-src/h.h	23
++\dfn	tex-src/texinfo.tex	/^\\def\\dfn##1{\\realbackslash dfn {##1}}$/
++\df	tex-src/texinfo.tex	/^\\def\\df{\\let\\tentt=\\deftt \\let\\tenbf = \\defbf \\bf}/
++/DiacriticEncoding	ps-src/rfc1245.ps	/^\/DiacriticEncoding [$/
++dialog_loop	erl-src/gs_dialog.erl	/^dialog_loop(Module, Window, Frame, Extra, Args) ->/
++/dieresis	ps-src/rfc1245.ps	/^\/dieresis \/.notdef \/AE \/Oslash \/.notdef \/.notdef \//
++dignorerest	c-src/etags.c	2463
++\direntry	tex-src/texinfo.tex	/^\\def\\direntry{\\begingroup\\direntryxxx}$/
++\direntryxxx	tex-src/texinfo.tex	/^\\long\\def\\direntryxxx #1\\end direntry{\\endgroup\\ig/
++discard-input	c-src/emacs/src/keyboard.c	/^DEFUN ("discard-input", Fdiscard_input, Sdiscard_i/
++discard_mouse_events	c-src/emacs/src/keyboard.c	/^discard_mouse_events (void)$/
++discrete_location	cp-src/clheir.hpp	56
++discrete_location	cp-src/clheir.hpp	/^    discrete_location(int xi, int yi, int zi):$/
++display	cp-src/conway.cpp	/^void display(void)$/
++\display	tex-src/texinfo.tex	/^\\def\\display{\\begingroup\\inENV %This group ends at/
++DisposeANameList	pas-src/common.pas	/^procedure DisposeANameList( $/
++DisposeNameList	pas-src/common.pas	/^procedure DisposeNameList;$/
++disposetextstring	pas-src/common.pas	/^procedure disposetextstring;(*($/
++/dmatrix	ps-src/rfc1245.ps	/^\/dmatrix matrix def$/
++\dmn	tex-src/texinfo.tex	/^\\def\\dmn#1{\\thinspace #1}$/
++dnone	c-src/etags.c	2460
++/dnormalize	ps-src/rfc1245.ps	/^\/dnormalize {$/
++\dobreak	tex-src/texinfo.tex	/^\\def\\dobreak#1#2{\\par\\ifdim\\lastskip<#1\\removelast/
++doc	c-src/emacs/src/lisp.h	1689
++\dochapentry	tex-src/texinfo.tex	/^\\def\\dochapentry#1#2{%$/
++\docodeindex	tex-src/texinfo.tex	/^\\def\\docodeindex#1{\\edef\\indexname{#1}\\parsearg\\si/
++dog	cp-src/c.C	126
++dog	cp-src/c.C	130
++dog	c-src/h.h	81
++\doindex	tex-src/texinfo.tex	/^\\def\\doindex#1{\\edef\\indexname{#1}\\parsearg\\single/
++\doind	tex-src/texinfo.tex	/^\\def\\doind #1#2{%$/
++\donoderef	tex-src/texinfo.tex	/^\\def\\donoderef{\\ifx\\lastnode\\relax\\else$/
++\dontindex	tex-src/texinfo.tex	/^\\def\\dontindex #1{}$/
++\dopageno	tex-src/texinfo.tex	/^\\def\\dopageno#1{{\\rm #1}}$/
++\doprintindex	tex-src/texinfo.tex	/^\\def\\doprintindex#1{%$/
++\dosecentry	tex-src/texinfo.tex	/^\\def\\dosecentry#1#2{%$/
++\dosetq	tex-src/texinfo.tex	/^\\def\\dosetq #1#2{{\\let\\folio=0 \\turnoffactive%$/
++\doshortpageno	tex-src/texinfo.tex	/^\\def\\doshortpageno#1{{\\rm #1}}$/
++DOS_NT	c-src/etags.c	117
++DOS_NT	c-src/etags.c	118
++\dosubind	tex-src/texinfo.tex	/^\\def\\dosubind #1#2#3{%$/
++\dosubsecentry	tex-src/texinfo.tex	/^\\def\\dosubsecentry#1#2{%$/
++\dosubsubsecentry	tex-src/texinfo.tex	/^\\def\\dosubsubsecentry#1#2{%$/
++dotfill	tex-src/texinfo.tex	/^\\noindent\\hskip\\secondaryindent\\hbox{#1}\\indexdotf/
++dotfill	tex-src/texinfo.tex	/^  \\null\\nobreak\\indexdotfill % Have leaders before/
++\dots	tex-src/texinfo.tex	/^\\def\\dots{$\\ldots$}$/
++\dots	tex-src/texinfo.tex	/^\\def\\dots{\\realbackslash dots }%$/
++\dots	tex-src/texinfo.tex	/^\\def\\dots{\\realbackslash dots}$/
++double_click_count	c-src/emacs/src/keyboard.c	5222
++\doublecolumnout	tex-src/texinfo.tex	/^\\def\\doublecolumnout{\\splittopskip=\\topskip \\split/
++/dpi	ps-src/rfc1245.ps	/^\/dpi    72 0 dmatrix defaultmatrix dtransform$/
++/D	ps-src/rfc1245.ps	/^\/D {curveto} bind def$/
++drag_n_drop_syms	c-src/emacs/src/keyboard.c	4629
++dribble	c-src/emacs/src/keyboard.c	236
++dsharpseen	c-src/etags.c	2461
++dummies	tex-src/texinfo.tex	/^{\\indexdummies % Must do this here, since \\bf, etc/
++dummy1	cp-src/burton.cpp	/^::dummy::dummy test::dummy1(void)$/
++dummy2	cp-src/burton.cpp	/^::dummy::dummy test::dummy2(::CORBA::Long dummy)$/
++dummy3	cp-src/burton.cpp	/^::dummy::dummy test::dummy3(char* name, ::CORBA::L/
++dummydots	tex-src/texinfo.tex	/^\\let\\dots=\\indexdummydots$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\b=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\code=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\emph=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\file=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\i=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\kbd=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\key=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\r=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\samp=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\sc=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\strong=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\tclose=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\t=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\var=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\w=\\indexdummyfont$/
++dummytex	tex-src/texinfo.tex	/^\\let\\TeX=\\indexdummytex$/
++DUMPED	c-src/emacs/src/gmalloc.c	80
++dump	pyt-src/server.py	/^    def dump(self, folded):$/
++eabs	c-src/emacs/src/lisp.h	/^#define eabs(x)         ((x) < 0 ? -(x) : (x))$/
++\Ealphaenumerate	tex-src/texinfo.tex	/^\\def\\Ealphaenumerate{\\Eenumerate}$/
++eassert	c-src/emacs/src/lisp.h	/^# define eassert(cond)						\\$/
++eassert	c-src/emacs/src/lisp.h	/^# define eassert(cond) ((void) (false && (cond))) /
++eassume	c-src/emacs/src/lisp.h	/^# define eassume(cond)						\\$/
++eassume	c-src/emacs/src/lisp.h	/^# define eassume(cond) assume (cond)$/
++eax	c-src/sysdep.h	31
++eax	c-src/sysdep.h	33
++\Ecapsenumerate	tex-src/texinfo.tex	/^\\def\\Ecapsenumerate{\\Eenumerate}$/
++\Ecartouche	tex-src/texinfo.tex	/^\\def\\Ecartouche{%$/
++echo_add_key	c-src/emacs/src/keyboard.c	/^echo_add_key (Lisp_Object c)$/
++echo_char	c-src/emacs/src/keyboard.c	/^echo_char (Lisp_Object c)$/
++echo_dash	c-src/emacs/src/keyboard.c	/^echo_dash (void)$/
++echoing	c-src/emacs/src/keyboard.c	154
++echo_kboard	c-src/emacs/src/keyboard.c	166
++echo_keystrokes_p	c-src/emacs/src/keyboard.c	/^echo_keystrokes_p (void)$/
++echo_length	c-src/emacs/src/keyboard.c	/^echo_length (void)$/
++echo_message_buffer	c-src/emacs/src/keyboard.c	171
++echo_now	c-src/emacs/src/keyboard.c	/^echo_now (void)$/
++echo_truncate	c-src/emacs/src/keyboard.c	/^echo_truncate (ptrdiff_t nchars)$/
++\Edescription	tex-src/texinfo.tex	/^\\def\\Edescription{\\Etable}% Necessary kludge.$/
++%ediff	make-src/Makefile	/^%ediff: ETAGS% ETAGS ${infiles}$/
++\Edisplay	tex-src/texinfo.tex	/^\\def\\Edisplay{\\endgroup\\afterenvbreak}%$/
++editItem	pyt-src/server.py	/^    def editItem(self):$/
++editsite	pyt-src/server.py	/^    def editsite(self, site):$/
++edituser	pyt-src/server.py	/^    def edituser(self, user):$/
++\Eexample	tex-src/texinfo.tex	/^\\def\\Eexample{\\Elisp}$/
++\Eflushleft	tex-src/texinfo.tex	/^\\def\\Eflushleft{\\endgroup\\afterenvbreak}%$/
++\Eflushright	tex-src/texinfo.tex	/^\\def\\Eflushright{\\endgroup\\afterenvbreak}%$/
++\Eformat	tex-src/texinfo.tex	/^\\def\\Eformat{\\endgroup\\afterenvbreak}$/
++\Eftable	tex-src/texinfo.tex	/^\\def\\Eftable{\\endgraf\\endgroup\\afterenvbreak}%$/
++egetenv	c-src/emacs/src/lisp.h	/^egetenv (const char *var)$/
++\Egroup	tex-src/texinfo.tex	/^  \\def\\Egroup{\\egroup\\endgroup}%$/
++\Eifclear	tex-src/texinfo.tex	/^\\def\\Eifclear{}$/
++\Eifset	tex-src/texinfo.tex	/^\\def\\Eifset{}$/
++\Eiftex	tex-src/texinfo.tex	/^\\def\\Eiftex{}$/
++ELEM_I	c-src/h.h	3
++\Elisp	tex-src/texinfo.tex	/^\\def\\Elisp{\\endgroup\\afterenvbreak}%$/
++ELSRC	make-src/Makefile	/^ELSRC=TAGTEST.EL emacs\/lisp\/progmodes\/etags.el$/
++emacs_abort	c-src/emacs/src/lisp.h	/^extern _Noreturn void emacs_abort (void) NO_INLINE/
++EMACS_INT	c-src/emacs/src/lisp.h	103
++EMACS_INT	c-src/emacs/src/lisp.h	91
++EMACS_INT	c-src/emacs/src/lisp.h	96
++EMACS_INT_MAX	c-src/emacs/src/lisp.h	105
++EMACS_INT_MAX	c-src/emacs/src/lisp.h	93
++EMACS_INT_MAX	c-src/emacs/src/lisp.h	98
++EMACS_LISP_H	c-src/emacs/src/lisp.h	22
++EMACS_NAME	c-src/etags.c	786
++EMACS_UINT	c-src/emacs/src/lisp.h	104
++EMACS_UINT	c-src/emacs/src/lisp.h	92
++EMACS_UINT	c-src/emacs/src/lisp.h	97
++\emph	tex-src/texinfo.tex	/^\\def\\emph##1{\\realbackslash emph {##1}}$/
++EmptyNmStr	pas-src/common.pas	/^function EmptyNmStr(* : NameString*);$/
++/ENDBITMAP	ps-src/rfc1245.ps	/^\/ENDBITMAP {$/
++end	c-src/emacs/src/keyboard.c	8753
++end	c-src/emacs/src/lisp.h	2039
++end	c-src/emacs/src/regex.h	432
++\enddoublecolumns	tex-src/texinfo.tex	/^\\def\\enddoublecolumns{\\output={\\balancecolumns}\\ej/
++/ENDPRINTCODE	ps-src/rfc1245.ps	/^\/ENDPRINTCODE {$/
++\end	tex-src/texinfo.tex	/^\\def\\end{\\parsearg\\endxxx}$/
++endtoken	c-src/etags.c	/^#define	endtoken(c)	(_etk[CHAR (c)]) \/* c ends tok/
++\endxxx	tex-src/texinfo.tex	/^\\def\\endxxx #1{%$/
++enter_critical_section	c-src/h.h	116
++ENTRY	c-src/sysdep.h	/^#define	ENTRY(name)							      \\$/
++entry	perl-src/htlmify-cystic	218
++entry	perl-src/htlmify-cystic	234
++entry	perl-src/htlmify-cystic	245
++entry	perl-src/htlmify-cystic	252
++entry	perl-src/htlmify-cystic	268
++entry	perl-src/htlmify-cystic	276
++entry	perl-src/htlmify-cystic	281
++entry	perl-src/htlmify-cystic	296
++\entry	tex-src/texinfo.tex	/^\\def\\entry #1#2{\\begingroup$/
++ENUM_BF	c-src/emacs/src/lisp.h	/^#define ENUM_BF(TYPE) enum TYPE$/
++ENUM_BF	c-src/emacs/src/lisp.h	/^#define ENUM_BF(TYPE) unsigned int$/
++\enumerate	tex-src/texinfo.tex	/^\\def\\enumerate{\\parsearg\\enumeratezzz}$/
++\enumeratey	tex-src/texinfo.tex	/^\\def\\enumeratey #1 #2\\endenumeratey{%$/
++\enumeratezzz	tex-src/texinfo.tex	/^\\def\\enumeratezzz #1{\\enumeratey #1  \\endenumerate/
++\ENVcheck	tex-src/texinfo.tex	/^\\def\\ENVcheck{%$/
++Environment	tex-src/gzip.texi	/^@node Environment, Tapes, Advanced usage, Top$/
++/E	ps-src/rfc1245.ps	/^\/E {lineto} bind def$/
++EQ	c-src/emacs/src/lisp.h	/^# define EQ(x, y) lisp_h_EQ (x, y)$/
++equalsKey	objcpp-src/SimpleCalc.M	/^- equalsKey:sender$/
++EQUAL	y-src/cccp.c	12
++\equiv	tex-src/texinfo.tex	/^\\def\\equiv{\\leavevmode\\lower.1ex\\hbox to 1em{\\hfil/
++\equiv	tex-src/texinfo.tex	/^\\def\\equiv{\\realbackslash equiv}$/
++\Equotation	tex-src/texinfo.tex	/^\\def\\Equotation{\\par\\endgroup\\afterenvbreak}%$/
++erlang_atom	c-src/etags.c	/^erlang_atom (char *s)$/
++erlang_attribute	c-src/etags.c	/^erlang_attribute (char *s)$/
++erlang_func	c-src/etags.c	/^erlang_func (char *s, char *last)$/
++Erlang_functions	c-src/etags.c	/^Erlang_functions (FILE *inf)$/
++Erlang_help	c-src/etags.c	567
++Erlang_suffixes	c-src/etags.c	565
++ERLSRC	make-src/Makefile	/^ERLSRC=gs_dialog.erl lines.erl lists.erl$/
++error	c-src/emacs/src/lisp.h	/^extern _Noreturn void error (const char *, ...) AT/
++error	c-src/etags.c	/^error (const char *format, ...)$/
++error	c-src/etags.c	/^static void error (const char *, ...) ATTRIBUTE_FO/
++\errorE	tex-src/texinfo.tex	/^\\def\\errorE#1{$/
++Error_Information/t	ada-src/2ataspri.ads	/^   type Error_Information is new Interfaces.C.POSI/
++error_signaled	c-src/etags.c	264
++\error	tex-src/texinfo.tex	/^\\def\\error{\\leavevmode\\lower.7ex\\copy\\errorbox}$/
++ERROR	y-src/cccp.c	9
++error	y-src/cccp.y	/^error (msg)$/
++ERROR	y-src/parse.y	304
++ErrStrToNmStr	pas-src/common.pas	/^function ErrStrToNmStr;(*($/
++\Esmallexample	tex-src/texinfo.tex	/^\\def\\Esmallexample{\\Elisp}$/
++\Esmallexample	tex-src/texinfo.tex	/^\\global\\def\\Esmallexample{\\Esmalllisp}$/
++\Esmalllisp	tex-src/texinfo.tex	/^\\def\\Esmalllisp{\\endgroup\\afterenvbreak}%$/
++\Etable	tex-src/texinfo.tex	/^\\def\\Etable{\\endgraf\\endgroup\\afterenvbreak}%$/
++ETAGS12	make-src/Makefile	/^ETAGS12: etags12 ${infiles}$/
++ETAGS13 ETAGS14 ETAGS15	make-src/Makefile	/^ETAGS13 ETAGS14 ETAGS15: etags% ${infiles}$/
++etags.1.man	make-src/Makefile	/^etags.1.man: etags.1$/
++etags	el-src/emacs/lisp/progmodes/etags.el	/^(defgroup etags nil "Tags tables."$/
++etags-file-of-tag	el-src/emacs/lisp/progmodes/etags.el	/^(defun etags-file-of-tag (&optional relative) ; Do/
++etags_getcwd	c-src/etags.c	/^etags_getcwd (void)$/
++etags-goto-tag-location	el-src/emacs/lisp/progmodes/etags.el	/^(defun etags-goto-tag-location (tag-info)$/
++etags	html-src/software.html	/^Etags$/
++etags-list-tags	el-src/emacs/lisp/progmodes/etags.el	/^(defun etags-list-tags (file) ; Doc string?$/
++etags	make-src/Makefile	/^etags: etags.c ${OBJS}$/
++ETAGS	make-src/Makefile	/^ETAGS: FRC etags ${infiles}$/
++ETAGS%	make-src/Makefile	/^ETAGS%: FRC etags% ${infiles}$/
++etags-recognize-tags-table	el-src/emacs/lisp/progmodes/etags.el	/^(defun etags-recognize-tags-table ()$/
++etags-snarf-tag	el-src/emacs/lisp/progmodes/etags.el	/^(defun etags-snarf-tag (&optional use-explicit) ; /
++etags-tags-apropos-additional	el-src/emacs/lisp/progmodes/etags.el	/^(defun etags-tags-apropos-additional (regexp)$/
++etags-tags-apropos	el-src/emacs/lisp/progmodes/etags.el	/^(defun etags-tags-apropos (string) ; Doc string?$/
++etags-tags-completion-table	el-src/emacs/lisp/progmodes/etags.el	/^(defun etags-tags-completion-table () ; Doc string/
++etags-tags-included-tables	el-src/emacs/lisp/progmodes/etags.el	/^(defun etags-tags-included-tables () ; Doc string?/
++etags-tags-table-files	el-src/emacs/lisp/progmodes/etags.el	/^(defun etags-tags-table-files () ; Doc string?$/
++etags-verify-tags-table	el-src/emacs/lisp/progmodes/etags.el	/^(defun etags-verify-tags-table ()$/
++etags--xref-find-definitions	el-src/emacs/lisp/progmodes/etags.el	/^(defun etags--xref-find-definitions (pattern &opti/
++etags-xref-find-definitions-tag-order	el-src/emacs/lisp/progmodes/etags.el	/^(defvar etags-xref-find-definitions-tag-order '(ta/
++etags-xref-find	el-src/emacs/lisp/progmodes/etags.el	/^(defun etags-xref-find (action id)$/
++etags--xref-limit	el-src/emacs/lisp/progmodes/etags.el	/^(defconst etags--xref-limit 1000)$/
++\Etitlepage	tex-src/texinfo.tex	/^\\def\\Etitlepage{%$/
++eval_dyn	c-src/emacs/src/keyboard.c	/^eval_dyn (Lisp_Object form)$/
++\evenfooting	tex-src/texinfo.tex	/^\\def\\evenfooting{\\parsearg\\evenfootingxxx}$/
++\evenheading	tex-src/texinfo.tex	/^\\def\\evenheading{\\parsearg\\evenheadingxxx}$/
++event-convert-list	c-src/emacs/src/keyboard.c	/^DEFUN ("event-convert-list", Fevent_convert_list, /
++event_head	c-src/emacs/src/keyboard.c	11021
++event-symbol-parse-modifiers	c-src/emacs/src/keyboard.c	/^DEFUN ("internal-event-symbol-parse-modifiers", Fe/
++event_to_kboard	c-src/emacs/src/keyboard.c	/^event_to_kboard (struct input_event *event)$/
++\everyfooting	tex-src/texinfo.tex	/^\\def\\everyfooting{\\parsearg\\everyfootingxxx}$/
++\everyheading	tex-src/texinfo.tex	/^\\def\\everyheading{\\parsearg\\everyheadingxxx}$/
++\Evtable	tex-src/texinfo.tex	/^\\def\\Evtable{\\endgraf\\endgroup\\afterenvbreak}%$/
++\ewbot	tex-src/texinfo.tex	/^\\def\\ewbot{\\vrule height0pt depth\\cornerthick widt/
++\ewtop	tex-src/texinfo.tex	/^\\def\\ewtop{\\vrule height\\cornerthick depth0pt widt/
++exact	c-src/emacs/src/gmalloc.c	200
++/exclamdown	ps-src/rfc1245.ps	/^\/exclamdown \/logicalnot \/.notdef \/florin \/.notdef /
++\exdent	tex-src/texinfo.tex	/^\\def\\exdent{\\parsearg\\exdentyyy}$/
++\exdentyyy	tex-src/texinfo.tex	/^\\def\\exdentyyy #1{{\\hfil\\break\\hbox{\\kern -\\exdent/
++execute	cp-src/c.C	/^        void execute(CPluginCSCState& p, int w, in/
++EXFUN	c-src/emacs/src/lisp.h	/^#define EXFUN(fnname, maxargs) \\$/
++exit_critical_to_previous	c-src/h.h	117
++exit	c-src/exit.c	/^DEFUN(exit, (status), int status)$/
++exit	c-src/exit.strange_suffix	/^DEFUN(exit, (status), int status)$/
++Exit_LL_Task/p	ada-src/2ataspri.adb	/^   procedure Exit_LL_Task is$/
++Exit_LL_Task/p	ada-src/2ataspri.ads	/^   procedure Exit_LL_Task;$/
++exit-recursive-edit	c-src/emacs/src/keyboard.c	/^DEFUN ("exit-recursive-edit", Fexit_recursive_edit/
++exp1	y-src/cccp.y	148
++expand-abbrev	c-src/abbrev.c	/^DEFUN ("expand-abbrev", Fexpand_abbrev, Sexpand_ab/
++expandmng	prol-src/natded.prolog	/^expandmng(var(V),var(V)).$/
++expandmng_tree	prol-src/natded.prolog	/^expandmng_tree(tree(Rule,Syn:Sem,Trees),$/
++expandmng_trees	prol-src/natded.prolog	/^expandmng_trees([],[]).$/
++expandsyn	prol-src/natded.prolog	/^expandsyn(Syn,Syn):-$/
++\expansion	tex-src/texinfo.tex	/^\\def\\expansion{\\leavevmode\\raise.1ex\\hbox to 1em{\\/
++\expansion	tex-src/texinfo.tex	/^\\def\\expansion{\\realbackslash expansion}$/
++explicitly-quoted-pending-delete-mode	el-src/TAGTEST.EL	/^(defalias (quote explicitly-quoted-pending-delete-/
++exp_list	y-src/parse.y	263
++expression_value	y-src/cccp.y	68
++exp	y-src/atest.y	2
++exp	y-src/cccp.y	156
++exp	y-src/cccp.y	185
++exp	y-src/parse.y	95
++EXTAGS	make-src/Makefile	/^EXTAGS: extags ${infiles} Makefile$/
++EXTERNALLY_VISIBLE	c-src/emacs/src/keyboard.c	3497
++EXTERNALLY_VISIBLE	c-src/emacs/src/keyboard.c	4372
++ExtractCommentInfo	pas-src/common.pas	/^procedure ExtractCommentInfo; (*($/
++extras	c-src/emacs/src/lisp.h	1603
++extvar	c-src/h.h	109
++f1	c.c	/^     f1 () { \/* Do something. *\/; }$/
++f1	perl-src/kai-test.pl	/^sub f1 {$/
++f2	c.c	/^void f2 () { \/* Do something. *\/; }$/
++f2	perl-src/kai-test.pl	/^sub main::f2 {$/
++f3	perl-src/kai-test.pl	/^sub f3 {$/
++f4	perl-src/kai-test.pl	/^sub Bar::f4 {$/
++f5	perl-src/kai-test.pl	/^sub f5 {$/
++f6	perl-src/kai-test.pl	/^sub f6 {$/
++f7	perl-src/kai-test.pl	/^sub f7 {$/
++Fabbrev_expansion	c-src/abbrev.c	/^DEFUN ("abbrev-expansion", Fabbrev_expansion, Sabb/
++Fabbrev_symbol	c-src/abbrev.c	/^DEFUN ("abbrev-symbol", Fabbrev_symbol, Sabbrev_sy/
++Fabort_recursive_edit	c-src/emacs/src/keyboard.c	/^DEFUN ("abort-recursive-edit", Fabort_recursive_ed/
++=/f	ada-src/etags-test-for.ada	/^   function "=" (L, R : System.Address) return Boo/
++Fails_t	c-src/h.h	5
++/fakecolorsetup	ps-src/rfc1245.ps	/^\/fakecolorsetup {$/
++FASTCFLAGS	make-src/Makefile	/^FASTCFLAGS=-O3 -finline-functions -ffast-math -fun/
++FASTCFLAGSWARN	make-src/Makefile	/^FASTCFLAGSWARN=${WARNINGS} -Werror ${FASTCFLAGS}$/
++fastctags	make-src/Makefile	/^fastctags:$/
++fastetags	make-src/Makefile	/^fastetags:$/
++fastmap_accurate	c-src/emacs/src/regex.h	383
++fastmap	c-src/emacs/src/regex.h	355
++fast_string_match_ignore_case	c-src/emacs/src/lisp.h	/^fast_string_match_ignore_case (Lisp_Object regexp,/
++fatala	c.c	/^void fatala () __attribute__ ((noreturn));$/
++fatal	c-src/etags.c	/^fatal (const char *s1, const char *s2)$/
++f	c.c	145
++f	c.c	156
++f	c.c	168
++f	c.c	/^int f$/
++Fclear_abbrev_table	c-src/abbrev.c	/^DEFUN ("clear-abbrev-table", Fclear_abbrev_table, /
++Fclear_this_command_keys	c-src/emacs/src/keyboard.c	/^DEFUN ("clear-this-command-keys", Fclear_this_comm/
++Fcommand_error_default_function	c-src/emacs/src/keyboard.c	/^DEFUN ("command-error-default-function", Fcommand_/
++fconst	forth-src/test-forth.fth	/^3.1415e fconstant fconst$/
++f	cp-src/c.C	/^A<float,B<int> > A<B<float>,int>::f(A<int>* x) {}$/
++f	cp-src/c.C	/^A<int>* f() {}$/
++f	cp-src/c.C	/^class B<int> { void f() {} };$/
++f	cp-src/c.C	/^int A<int>::f(A<int>* x) {}$/
++f	cp-src/c.C	/^int f(A<int> x) {}$/
++f	cp-src/c.C	/^  int f(){return 0;};		\/\/ first comment$/
++f	cp-src/c.C	/^     void f() {}$/
++f	cp-src/fail.C	/^int A::B::f() { return 2; }$/
++f	cp-src/fail.C	/^		int f() { return 5; }$/
++f	c-src/c.c	/^T f(){if(x){}$/
++f	c-src/h.h	89
++Fcurrent_idle_time	c-src/emacs/src/keyboard.c	/^DEFUN ("current-idle-time", Fcurrent_idle_time, Sc/
++Fcurrent_input_mode	c-src/emacs/src/keyboard.c	/^DEFUN ("current-input-mode", Fcurrent_input_mode, /
++Fdefine_abbrev	c-src/abbrev.c	/^DEFUN ("define-abbrev", Fdefine_abbrev, Sdefine_ab/
++Fdefine_abbrev_table	c-src/abbrev.c	/^DEFUN ("define-abbrev-table", Fdefine_abbrev_table/
++Fdefine_global_abbrev	c-src/abbrev.c	/^DEFUN ("define-global-abbrev", Fdefine_global_abbr/
++Fdefine_mode_abbrev	c-src/abbrev.c	/^DEFUN ("define-mode-abbrev", Fdefine_mode_abbrev, /
++fdefunkey	c-src/etags.c	2409
++fdefunname	c-src/etags.c	2410
++fdesc	c-src/etags.c	201
++fdesc	c-src/etags.c	212
++fdHandler	objc-src/Subprocess.m	/^- fdHandler:(int)theFd$/
++fdHandler	objc-src/Subprocess.m	/^fdHandler (int theFd, id self)$/
++Fdiscard_input	c-src/emacs/src/keyboard.c	/^DEFUN ("discard-input", Fdiscard_input, Sdiscard_i/
++fdp	c-src/etags.c	217
++Fevent_convert_list	c-src/emacs/src/keyboard.c	/^DEFUN ("event-convert-list", Fevent_convert_list, /
++Fevent_symbol_parse_modifiers	c-src/emacs/src/keyboard.c	/^DEFUN ("internal-event-symbol-parse-modifiers", Fe/
++Fexit_recursive_edit	c-src/emacs/src/keyboard.c	/^DEFUN ("exit-recursive-edit", Fexit_recursive_edit/
++Fexpand_abbrev	c-src/abbrev.c	/^DEFUN ("expand-abbrev", Fexpand_abbrev, Sexpand_ab/
++ff	cp-src/c.C	/^  int ff(){return 1;};$/
++F_getit	c-src/etags.c	/^F_getit (FILE *inf)$/
++>field1	forth-src/test-forth.fth	/^   9   field   >field1$/
++>field2	forth-src/test-forth.fth	/^   5   field   >field2$/
++field_of_play	cp-src/conway.cpp	18
++fignore	c-src/etags.c	2416
++file_end	perl-src/htlmify-cystic	/^sub file_end ()$/
++file_index	perl-src/htlmify-cystic	33
++fileJoin	php-src/lce_functions.php	/^  function fileJoin()$/
++filename_is_absolute	c-src/etags.c	/^filename_is_absolute (char *fn)$/
++filenames	c-src/etags.c	196
++file-of-tag	el-src/emacs/lisp/progmodes/etags.el	/^(defun file-of-tag (&optional relative)$/
++file-of-tag-function	el-src/emacs/lisp/progmodes/etags.el	/^(defvar file-of-tag-function nil$/
++\file	tex-src/texinfo.tex	/^\\def\\file##1{\\realbackslash file {##1}}%$/
++\file	tex-src/texinfo.tex	/^\\def\\file##1{\\realbackslash file {##1}}$/
++file_tocs	perl-src/htlmify-cystic	30
++/fillprocs	ps-src/rfc1245.ps	/^\/fillprocs 32 array def$/
++FILTER	make-src/Makefile	/^FILTER=grep -v '\\.[Cchefy][lor]*,[1-9][0-9]*' || t/
++FINAL_FREE_BLOCKS	c-src/emacs/src/gmalloc.c	135
++Finalize_Cond/p	ada-src/2ataspri.adb	/^   procedure Finalize_Cond (Cond : in out Conditio/
++Finalize_Cond/p	ada-src/2ataspri.ads	/^   procedure Finalize_Cond (Cond : in out Conditio/
++Finalize_Lock/p	ada-src/2ataspri.adb	/^   procedure Finalize_Lock (L : in out Lock) is$/
++Finalize_Lock/p	ada-src/2ataspri.ads	/^   procedure Finalize_Lock (L : in out Lock);$/
++FINALIZERP	c-src/emacs/src/lisp.h	/^FINALIZERP (Lisp_Object x)$/
++Finalize_TAS_Cell/p	ada-src/2ataspri.adb	/^   procedure Finalize_TAS_Cell (Cell : in out TAS_/
++Finalize_TAS_Cell/p	ada-src/2ataspri.ads	/^   procedure Finalize_TAS_Cell   (Cell : in out TA/
++\finalout	tex-src/texinfo.tex	/^\\def\\finalout{\\overfullrule=0pt}$/
++findcats	prol-src/natded.prolog	/^findcats([],Left,Left).$/
++find_entries	c-src/etags.c	/^find_entries (FILE *inf)$/
++\findex	tex-src/texinfo.tex	/^\\def\\findex {\\fnindex}$/
++find-tag-default-function	el-src/emacs/lisp/progmodes/etags.el	/^(defcustom find-tag-default-function nil$/
++find-tag	el-src/emacs/lisp/progmodes/etags.el	/^(defun find-tag (tagname &optional next-p regexp-p/
++find-tag-history	el-src/emacs/lisp/progmodes/etags.el	/^(defvar find-tag-history nil) ; Doc string?$/
++find-tag-hook	el-src/emacs/lisp/progmodes/etags.el	/^(defcustom find-tag-hook nil$/
++find-tag-in-order	el-src/emacs/lisp/progmodes/etags.el	/^(defun find-tag-in-order (pattern$/
++find-tag-interactive	el-src/emacs/lisp/progmodes/etags.el	/^(defun find-tag-interactive (prompt &optional no-d/
++find-tag-marker-ring	el-src/emacs/lisp/progmodes/etags.el	/^(defvaralias 'find-tag-marker-ring 'xref--marker-r/
++find-tag-marker-ring-length	el-src/emacs/lisp/progmodes/etags.el	/^(define-obsolete-variable-alias 'find-tag-marker-r/
++find-tag-next-line-after-failure-p	el-src/emacs/lisp/progmodes/etags.el	/^(defvar find-tag-next-line-after-failure-p nil$/
++find-tag-noselect	el-src/emacs/lisp/progmodes/etags.el	/^(defun find-tag-noselect (tagname &optional next-p/
++find-tag-other-frame	el-src/emacs/lisp/progmodes/etags.el	/^(defun find-tag-other-frame (tagname &optional nex/
++find-tag-other-window	el-src/emacs/lisp/progmodes/etags.el	/^(defun find-tag-other-window (tagname &optional ne/
++find-tag-regexp	el-src/emacs/lisp/progmodes/etags.el	/^(defun find-tag-regexp (regexp &optional next-p ot/
++find-tag-regexp-next-line-after-failure-p	el-src/emacs/lisp/progmodes/etags.el	/^(defvar find-tag-regexp-next-line-after-failure-p /
++find-tag-regexp-search-function	el-src/emacs/lisp/progmodes/etags.el	/^(defvar find-tag-regexp-search-function nil$/
++find-tag-regexp-tag-order	el-src/emacs/lisp/progmodes/etags.el	/^(defvar find-tag-regexp-tag-order nil$/
++find-tag-search-function	el-src/emacs/lisp/progmodes/etags.el	/^(defvar find-tag-search-function nil$/
++find-tag-tag	el-src/emacs/lisp/progmodes/etags.el	/^(defun find-tag-tag (string)$/
++find-tag-tag-order	el-src/emacs/lisp/progmodes/etags.el	/^(defvar find-tag-tag-order nil$/
++find_user_signal_name	c-src/emacs/src/keyboard.c	/^find_user_signal_name (int sig)$/
++finish_appendices	perl-src/htlmify-cystic	/^sub finish_appendices ()$/
++finish_sections	perl-src/htlmify-cystic	/^sub finish_sections ()$/
++finish_subsections	perl-src/htlmify-cystic	/^sub finish_subsections ()$/
++finish_subsubsections	perl-src/htlmify-cystic	/^sub finish_subsubsections ()$/
++\finishtitlepage	tex-src/texinfo.tex	/^\\def\\finishtitlepage{%$/
++finlist	c-src/etags.c	2414
++Finput_pending_p	c-src/emacs/src/keyboard.c	/^DEFUN ("input-pending-p", Finput_pending_p, Sinput/
++Finsert_abbrev_table_description	c-src/abbrev.c	/^DEFUN ("insert-abbrev-table-description", Finsert_/
++First100Chars	pas-src/common.pas	/^procedure First100Chars; (*($/
++first	c-src/emacs/src/gmalloc.c	151
++fitchtreelist	prol-src/natded.prolog	/^fitchtreelist([]).$/
++FIXNUM_BITS	c-src/emacs/src/lisp.h	252
++FIXNUM_OVERFLOW_P	c-src/emacs/src/lisp.h	/^#define FIXNUM_OVERFLOW_P(i) \\$/
++FIXNUM_OVERFLOW_P	c-src/emacs/src/lisp.h	/^LISP_MACRO_DEFUN (EQ, bool, (Lisp_Object x, Lisp_O/
++fixup_locale	c-src/emacs/src/lisp.h	/^INLINE void fixup_locale (void) {}$/
++flag2str	pyt-src/server.py	/^def flag2str(value, string):$/
++flag	c-src/getopt.h	83
++flistseen	c-src/etags.c	2415
++FLOATP	c-src/emacs/src/lisp.h	/^# define FLOATP(x) lisp_h_FLOATP (x)$/
++FLOAT_TO_STRING_BUFSIZE	c-src/emacs/src/lisp.h	3927
++/fl	ps-src/rfc1245.ps	/^\/fl { $/
++\flushcr	tex-src/texinfo.tex	/^\\def\\flushcr{\\ifx\\par\\lisppar \\def\\next##1{}\\else /
++\flushleft	tex-src/texinfo.tex	/^\\def\\flushleft{%$/
++\flushright	tex-src/texinfo.tex	/^\\def\\flushright{%$/
++Fmake_abbrev_table	c-src/abbrev.c	/^DEFUN ("make-abbrev-table", Fmake_abbrev_table, Sm/
++/FMBEGINEPSF	ps-src/rfc1245.ps	/^\/FMBEGINEPSF { $/
++/FMBEGINPAGE	ps-src/rfc1245.ps	/^\/FMBEGINPAGE { $/
++/Fmcc	ps-src/rfc1245.ps	/^\/Fmcc {$/
++/FMDEFINEFONT	ps-src/rfc1245.ps	/^\/FMDEFINEFONT { $/
++/FMDOCUMENT	ps-src/rfc1245.ps	/^\/FMDOCUMENT { $/
++/FMENDEPSF	ps-src/rfc1245.ps	/^\/FMENDEPSF {$/
++/FMENDPAGE	ps-src/rfc1245.ps	/^\/FMENDPAGE {$/
++/FMLOCAL	ps-src/rfc1245.ps	/^\/FMLOCAL {$/
++/FMNORMALIZEGRAPHICS	ps-src/rfc1245.ps	/^\/FMNORMALIZEGRAPHICS { $/
++/FMVERSION	ps-src/rfc1245.ps	/^\/FMVERSION {$/
++/FMversion	ps-src/rfc1245.ps	/^\/FMversion (2.0) def $/
++fn	c-src/exit.c	/^    void EXFUN((*fn[1]), (NOARGS));$/
++fn	c-src/exit.strange_suffix	/^    void EXFUN((*fn[1]), (NOARGS));$/
++fnin	y-src/parse.y	68
++\fnitemindex	tex-src/texinfo.tex	/^\\def\\fnitemindex #1{\\doind {fn}{\\code{#1}}}%$/
++focus_set	pyt-src/server.py	/^    def focus_set(self):$/
++follow_key	c-src/emacs/src/keyboard.c	/^follow_key (Lisp_Object keymap, Lisp_Object key)$/
++fonts\rm	tex-src/texinfo.tex	/^  \\indexfonts\\rm \\tolerance=9500 \\advance\\baseline/
++fonts	tex-src/texinfo.tex	/^\\obeyspaces \\obeylines \\ninett \\indexfonts \\rawbac/
++foo1	ruby-src/test1.ru	/^    attr_reader(:foo1, :bar1, # comment$/
++foo2	ruby-src/test1.ru	/^    alias_method ( :foo2, #cmmt$/
++foobar2_	c-src/h.h	16
++foobar2	c-src/h.h	20
++foobar	c.c	/^extern void foobar (void) __attribute__ ((section /
++foobar	c-src/c.c	/^int foobar() {;}$/
++foo==bar	el-src/TAGTEST.EL	/^(defun foo==bar () (message "hi"))  ; Bug#5624$/
++Foo::Bar	perl-src/kai-test.pl	/^package Foo::Bar;$/
++foo	c.c	150
++foo	c.c	166
++foo	c.c	167
++foo	c.c	178
++foo	c.c	189
++foo	cp-src/c.C	68
++foo	cp-src/c.C	79
++foo	cp-src/c.C	/^    foo() {$/
++foo	cp-src/x.cc	/^XX::foo()$/
++foo	c-src/h.h	18
++(foo)	forth-src/test-forth.fth	/^: (foo) 1 ;$/
++foo	forth-src/test-forth.fth	/^: foo (foo) ;$/
++foo	f-src/entry.for	/^       character*(*) function foo()$/
++foo	f-src/entry.strange	/^       character*(*) function foo()$/
++foo	f-src/entry.strange_suffix	/^       character*(*) function foo()$/
++Foo	perl-src/kai-test.pl	/^package Foo;$/
++foo	php-src/ptest.php	/^foo()$/
++foo	ruby-src/test1.ru	/^    attr_reader :foo$/
++foo!	ruby-src/test1.ru	/^    def foo!$/
++Fopen_dribble_file	c-src/emacs/src/keyboard.c	/^DEFUN ("open-dribble-file", Fopen_dribble_file, So/
++foperator	c-src/etags.c	2411
++force_auto_save_soon	c-src/emacs/src/keyboard.c	/^force_auto_save_soon (void)$/
++force_explicit_name	c-src/etags.c	265
++force_quit_count	c-src/emacs/src/keyboard.c	10387
++FOR_EACH_ALIST_VALUE	c-src/emacs/src/lisp.h	/^#define FOR_EACH_ALIST_VALUE(head_var, list_var, v/
++FOR_EACH_TAIL	c-src/emacs/src/lisp.h	/^#define FOR_EACH_TAIL(hare, list, tortoise, n)	\\$/
++foreign_export	merc-src/accumulator.m	/^:- pragma foreign_export("C", unravel_univ(in, out/
++formatSize	objc-src/PackInsp.m	/^-(const char *)formatSize:(const char *)size inBuf/
++\format	tex-src/texinfo.tex	/^\\def\\format{\\begingroup\\inENV %This group ends at /
++Forth_help	c-src/etags.c	573
++FORTHSRC	make-src/Makefile	/^FORTHSRC=test-forth.fth$/
++Forth_suffixes	c-src/etags.c	571
++Forth_words	c-src/etags.c	/^Forth_words (FILE *inf)$/
++Fortran_functions	c-src/etags.c	/^Fortran_functions (FILE *inf)$/
++Fortran_help	c-src/etags.c	579
++Fortran_suffixes	c-src/etags.c	577
++found	c-src/emacs/src/lisp.h	2344
++Fposn_at_point	c-src/emacs/src/keyboard.c	/^DEFUN ("posn-at-point", Fposn_at_point, Sposn_at_p/
++Fposn_at_x_y	c-src/emacs/src/keyboard.c	/^DEFUN ("posn-at-x-y", Fposn_at_x_y, Sposn_at_x_y, /
++/F	ps-src/rfc1245.ps	/^\/F { $/
++fracas	html-src/software.html	/^Fracas$/
++/fraction	ps-src/rfc1245.ps	/^\/fraction \/currency \/guilsinglleft \/guilsinglright/
++frag	c-src/emacs/src/gmalloc.c	152
++_fraghead	c-src/emacs/src/gmalloc.c	370
++/FrameDict	ps-src/rfc1245.ps	/^\/FrameDict 190 dict def $/
++frame_local	c-src/emacs/src/lisp.h	2341
++FRAMEP	c-src/emacs/src/lisp.h	/^FRAMEP (Lisp_Object a)$/
++FRC	make-src/Makefile	/^FRC:;$/
++Fread_key_sequence	c-src/emacs/src/keyboard.c	/^DEFUN ("read-key-sequence", Fread_key_sequence, Sr/
++Fread_key_sequence_vector	c-src/emacs/src/keyboard.c	/^DEFUN ("read-key-sequence-vector", Fread_key_seque/
++Frecent_keys	c-src/emacs/src/keyboard.c	/^DEFUN ("recent-keys", Frecent_keys, Srecent_keys, /
++Frecursion_depth	c-src/emacs/src/keyboard.c	/^DEFUN ("recursion-depth", Frecursion_depth, Srecur/
++Frecursive_edit	c-src/emacs/src/keyboard.c	/^DEFUN ("recursive-edit", Frecursive_edit, Srecursi/
++free	c-src/emacs/src/gmalloc.c	166
++free	c-src/emacs/src/gmalloc.c	1719
++free	c-src/emacs/src/gmalloc.c	67
++free	c-src/emacs/src/gmalloc.c	72
++_free	c-src/emacs/src/gmalloc.c	/^_free (void *ptr)$/
++free	c-src/emacs/src/gmalloc.c	/^free (void *ptr)$/
++free_fdesc	c-src/etags.c	/^free_fdesc (register fdesc *fdp)$/
++FREEFLOOD	c-src/emacs/src/gmalloc.c	1858
++free_for	prol-src/natded.prolog	/^free_for(var(_),_,_).$/
++freehook	c-src/emacs/src/gmalloc.c	/^freehook (void *ptr)$/
++_free_internal	c-src/emacs/src/gmalloc.c	/^_free_internal (void *ptr)$/
++_free_internal_nolock	c-src/emacs/src/gmalloc.c	/^_free_internal_nolock (void *ptr)$/
++free_regexps	c-src/etags.c	/^free_regexps (void)$/
++free_tree	c-src/etags.c	/^free_tree (register node *np)$/
++free_var	prol-src/natded.prolog	/^free_var(var(V),var(V)).$/
++\frenchspacing	tex-src/texinfo.tex	/^\\def\\frenchspacing{\\sfcode46=1000 \\sfcode63=1000 \\/
++/freq	ps-src/rfc1245.ps	/^\/freq dpi 18.75 div 8 div round dup 0 eq {pop 1} i/
++Freset_this_command_lengths	c-src/emacs/src/keyboard.c	/^DEFUN ("reset-this-command-lengths", Freset_this_c/
++fresh_vars	prol-src/natded.prolog	/^fresh_vars(var(V),var(V)).$/
++Fset_input_interrupt_mode	c-src/emacs/src/keyboard.c	/^DEFUN ("set-input-interrupt-mode", Fset_input_inte/
++Fset_input_meta_mode	c-src/emacs/src/keyboard.c	/^DEFUN ("set-input-meta-mode", Fset_input_meta_mode/
++Fset_input_mode	c-src/emacs/src/keyboard.c	/^DEFUN ("set-input-mode", Fset_input_mode, Sset_inp/
++Fset_output_flow_control	c-src/emacs/src/keyboard.c	/^DEFUN ("set-output-flow-control", Fset_output_flow/
++Fset_quit_char	c-src/emacs/src/keyboard.c	/^DEFUN ("set-quit-char", Fset_quit_char, Sset_quit_/
++FSRC	make-src/Makefile	/^FSRC=entry.for entry.strange_suffix entry.strange$/
++fstartlist	c-src/etags.c	2413
++Fsuspend_emacs	c-src/emacs/src/keyboard.c	/^DEFUN ("suspend-emacs", Fsuspend_emacs, Ssuspend_e/
++\ftable	tex-src/texinfo.tex	/^\\def\\ftable{\\begingroup\\inENV\\obeylines\\obeyspaces/
++F_takeprec	c-src/etags.c	/^F_takeprec (void)$/
++Fthis_command_keys	c-src/emacs/src/keyboard.c	/^DEFUN ("this-command-keys", Fthis_command_keys, St/
++Fthis_command_keys_vector	c-src/emacs/src/keyboard.c	/^DEFUN ("this-command-keys-vector", Fthis_command_k/
++Fthis_single_command_keys	c-src/emacs/src/keyboard.c	/^DEFUN ("this-single-command-keys", Fthis_single_co/
++Fthis_single_command_raw_keys	c-src/emacs/src/keyboard.c	/^DEFUN ("this-single-command-raw-keys", Fthis_singl/
++Ftop_level	c-src/emacs/src/keyboard.c	/^DEFUN ("top-level", Ftop_level, Stop_level, 0, 0, /
++Ftrack_mouse	c-src/emacs/src/keyboard.c	/^DEFUN ("internal--track-mouse", Ftrack_mouse, Stra/
++FUN0	y-src/parse.y	/^yylex FUN0()$/
++FUN1	y-src/parse.y	/^str_to_col FUN1(char **,str)$/
++FUN1	y-src/parse.y	/^yyerror FUN1(char *, s)$/
++FUN2	y-src/parse.y	/^make_list FUN2(YYSTYPE, car, YYSTYPE, cdr)$/
++FUN2	y-src/parse.y	/^parse_cell_or_range FUN2(char **,ptr, struct rng */
++func1	c.c	/^int func1$/
++func2	c.c	/^int func2 (a,b$/
++funcboo	c.c	/^bool funcboo ()$/
++func	c-src/emacs/src/lisp.h	/^      void (*func) (int);$/
++func	c-src/emacs/src/lisp.h	/^      void (*func) (Lisp_Object);$/
++func	c-src/emacs/src/lisp.h	/^      void (*func) (void *);$/
++func	c-src/emacs/src/lisp.h	/^      void (*func) (void);$/
++func_key_syms	c-src/emacs/src/keyboard.c	4626
++funcpointer	c-src/emacs/src/lisp.h	2126
++funcptr	c-src/h.h	/^    fu   int (*funcptr) (void *ptr);$/
++function	c-src/emacs/src/lisp.h	1685
++function	c-src/emacs/src/lisp.h	2197
++function	c-src/emacs/src/lisp.h	2985
++function	c-src/emacs/src/lisp.h	694
++function	c-src/etags.c	194
++FUNCTION_KEY_OFFSET	c-src/emacs/src/keyboard.c	4766
++FUNCTION_KEY_OFFSET	c-src/emacs/src/keyboard.c	5061
++FUNCTIONP	c-src/emacs/src/lisp.h	/^FUNCTIONP (Lisp_Object obj)$/
++functionp	c-src/emacs/src/lisp.h	/^functionp (Lisp_Object object)$/
++Funexpand_abbrev	c-src/abbrev.c	/^DEFUN ("unexpand-abbrev", Funexpand_abbrev, Sunexp/
++fval	forth-src/test-forth.fth	/^fconst fvalue fval$/
++fvar	forth-src/test-forth.fth	/^fvariable fvar$/
++fvdef	c-src/etags.c	2418
++fvextern	c-src/etags.c	2420
++fvnameseen	c-src/etags.c	2412
++fvnone	c-src/etags.c	2408
++fwd	c-src/emacs/src/lisp.h	2346
++fwd	c-src/emacs/src/lisp.h	690
++Fx_get_selection_internal	c.c	/^DEFUN ("x-get-selection-internal", Fx_get_selectio/
++Fx_get_selection_internal	c.c	/^       Fx_get_selection_internal, Sx_get_selection/
++Fy_get_selection_internal	c.c	/^      Fy_get_selection_internal, Sy_get_selection_/
++galileo	html-src/software.html	/^GaliLEO$/
++GatherControls	pyt-src/server.py	/^    def GatherControls(self):$/
++gather	pyt-src/server.py	/^    def gather(self):$/
++GCALIGNED	c-src/emacs/src/lisp.h	288
++GCALIGNED	c-src/emacs/src/lisp.h	290
++GCALIGNMENT	c-src/emacs/src/lisp.h	243
++gc_aset	c-src/emacs/src/lisp.h	/^gc_aset (Lisp_Object array, ptrdiff_t idx, Lisp_Ob/
++GC_MAKE_GCPROS_NOOPS	c-src/emacs/src/lisp.h	3172
++gcmarkbit	c-src/emacs/src/lisp.h	1974
++gcmarkbit	c-src/emacs/src/lisp.h	1981
++gcmarkbit	c-src/emacs/src/lisp.h	2035
++gcmarkbit	c-src/emacs/src/lisp.h	2113
++gcmarkbit	c-src/emacs/src/lisp.h	2204
++gcmarkbit	c-src/emacs/src/lisp.h	656
++GC_MARK_STACK_CHECK_GCPROS	c-src/emacs/src/lisp.h	3173
++GC_MARK_STACK	c-src/emacs/src/lisp.h	3177
++GCPRO1	c-src/emacs/src/lisp.h	/^#define GCPRO1(a)							\\$/
++GCPRO1	c-src/emacs/src/lisp.h	/^#define GCPRO1(varname) ((void) gcpro1)$/
++GCPRO2	c-src/emacs/src/lisp.h	/^#define GCPRO2(a, b)							\\$/
++GCPRO2	c-src/emacs/src/lisp.h	/^#define GCPRO2(varname1, varname2) ((void) gcpro2,/
++GCPRO3	c-src/emacs/src/lisp.h	/^#define GCPRO3(a, b, c)							\\$/
++GCPRO3	c-src/emacs/src/lisp.h	/^#define GCPRO3(varname1, varname2, varname3) \\$/
++GCPRO4	c-src/emacs/src/lisp.h	/^#define GCPRO4(a, b, c, d)						\\$/
++GCPRO4	c-src/emacs/src/lisp.h	/^#define GCPRO4(varname1, varname2, varname3, varna/
++GCPRO5	c-src/emacs/src/lisp.h	/^#define GCPRO5(a, b, c, d, e)						\\$/
++GCPRO5	c-src/emacs/src/lisp.h	/^#define GCPRO5(varname1, varname2, varname3, varna/
++GCPRO6	c-src/emacs/src/lisp.h	/^#define GCPRO6(a, b, c, d, e, f)					\\$/
++GCPRO6	c-src/emacs/src/lisp.h	/^#define GCPRO6(varname1, varname2, varname3, varna/
++GCPRO7	c-src/emacs/src/lisp.h	/^#define GCPRO7(a, b, c, d, e, f, g)					\\$/
++GCPRO7	c-src/emacs/src/lisp.h	/^#define GCPRO7(a, b, c, d, e, f, g) (GCPRO6 (a, b,/
++gcpro	c-src/emacs/src/lisp.h	3042
++gcpro	c-src/emacs/src/lisp.h	3132
++g	cp-src/c.C	/^  int g(){return 2;};$/
++GCTYPEBITS	c-src/emacs/src/lisp.h	67
++GCTYPEBITS	c-src/emacs/src/lisp.h	/^DEFINE_GDB_SYMBOL_BEGIN (int, GCTYPEBITS)$/
++GC_USE_GCPROS_AS_BEFORE	c-src/emacs/src/lisp.h	3171
++GC_USE_GCPROS_CHECK_ZOMBIES	c-src/emacs/src/lisp.h	3174
++genalgorithm	html-src/algrthms.html	/^Generating the Data<\/font><\/i><\/b>$/
++generate_warning	merc-src/accumulator.m	/^:- pred generate_warning(module_info::in, prog_var/
++generate_warnings	merc-src/accumulator.m	/^:- pred generate_warnings(module_info::in, prog_va/
++~generic_object	cp-src/clheir.cpp	/^generic_object::~generic_object(void)$/
++generic_object	cp-src/clheir.cpp	/^generic_object::generic_object(void)$/
++generic_object	cp-src/clheir.hpp	13
++GENERIC_PTR	y-src/cccp.y	56
++GENERIC_PTR	y-src/cccp.y	58
++gen_help_event	c-src/emacs/src/keyboard.c	/^gen_help_event (Lisp_Object help, Lisp_Object fram/
++GEQ	y-src/cccp.c	15
++getArchs	objc-src/PackInsp.m	/^-(void)getArchs$/
++getcjmp	c-src/emacs/src/keyboard.c	147
++get_compressor_from_suffix	c-src/etags.c	/^get_compressor_from_suffix (char *file, char **ext/
++get_contiguous_space	c-src/emacs/src/gmalloc.c	/^get_contiguous_space (ptrdiff_t size, void *positi/
++get_current_dir_name	c-src/emacs/src/gmalloc.c	33
++getDomainNames	php-src/lce_functions.php	/^      function getDomainNames()$/
++getFoo	lua-src/test.lua	/^function Cube.data.getFoo ()$/
++get_input_pending	c-src/emacs/src/keyboard.c	/^get_input_pending (int flags)$/
++get_language_from_filename	c-src/etags.c	/^get_language_from_filename (char *file, int case_s/
++get_language_from_interpreter	c-src/etags.c	/^get_language_from_interpreter (char *interpreter)$/
++get_language_from_langname	c-src/etags.c	/^get_language_from_langname (const char *name)$/
++GetLayerByName	lua-src/allegro.lua	/^function GetLayerByName (name)$/
++get_layer_by_name	lua-src/allegro.lua	/^local function get_layer_by_name (sprite, layer, n/
++GetNameList	pas-src/common.pas	/^function GetNameList; (* : BinNodePointer;*)$/
++GetNewNameListNode	pas-src/common.pas	/^function GetNewNameListNode;(*($/
++getopt1.o	make-src/Makefile	/^getopt1.o: emacs\/lib-src\/getopt1.c$/
++_GETOPT_H	c-src/getopt.h	19
++GETOPTOBJS	make-src/Makefile	/^GETOPTOBJS= #getopt.o getopt1.o$/
++getopt.o	make-src/Makefile	/^getopt.o: emacs\/lib-src\/getopt.c$/
++getopt	perl-src/yagrip.pl	/^sub getopt {$/
++Get_Own_Priority/f	ada-src/2ataspri.adb	/^   function Get_Own_Priority return System.Any_Pri/
++Get_Own_Priority/f	ada-src/2ataspri.ads	/^   function Get_Own_Priority return System.Any_Pri/
++getPath	objc-src/PackInsp.m	/^-(const char *)getPath:(char *)buf forType:(const /
++getPOReader	php-src/lce_functions.php	/^      function &getPOReader($domain)$/
++getPos	lua-src/test.lua	/^function Circle.getPos ()$/
++getPos	lua-src/test.lua	/^function Rectangle.getPos ()$/
++Get_Priority/f	ada-src/2ataspri.adb	/^   function Get_Priority (T : TCB_Ptr) return Syst/
++Get_Priority/f	ada-src/2ataspri.ads	/^   function Get_Priority (T : TCB_Ptr) return Syst/
++getptys	objc-src/Subprocess.m	/^getptys (int *master, int *slave)$/
++get_tag	c-src/etags.c	/^get_tag (register char *bp, char **namepp)$/
++getTextDomains	php-src/lce_functions.php	/^  function getTextDomains($lines)$/
++gettext	php-src/lce_functions.php	/^      function gettext($msgid)$/
++GetTextRef	pas-src/common.pas	/^function GetTextRef;(*($/
++GetUniqueLayerName	lua-src/allegro.lua	/^function GetUniqueLayerName ()$/
++get_word	c-src/tab.c	/^static char		*get_word(char **str, char delim)$/
++GE	y-src/parse.c	8
++ggg	c-src/h.h	10
++ghi1	c-src/h.h	36
++ghi2	c-src/h.h	39
++giallo	cp-src/c.C	40
++glider	cp-src/conway.cpp	/^void glider(int x, int y)$/
++\gloggingall	tex-src/texinfo.tex	/^\\def\\gloggingall{\\begingroup \\globaldefs = 1 \\logg/
++/gn	ps-src/rfc1245.ps	/^\/gn { $/
++gnu	html-src/software.html	/^Free software that I wrote for the GNU project or /
++_GNU_SOURCE	c-src/etags.c	94
++gobble_input	c-src/emacs/src/keyboard.c	/^gobble_input (void)$/
++goto-tag-location-function	el-src/emacs/lisp/progmodes/etags.el	/^(defvar goto-tag-location-function nil$/
++goto_xy	cp-src/screen.cpp	/^void goto_xy(unsigned char x, unsigned char y)$/
++/G	ps-src/rfc1245.ps	/^\/G { $/
++/graymode	ps-src/rfc1245.ps	/^\/graymode true def$/
++/grayness	ps-src/rfc1245.ps	/^\/grayness {$/
++GREEN	cp-src/screen.hpp	14
++\group	tex-src/texinfo.tex	/^\\def\\group{\\begingroup$/
++GROW_RAW_KEYBUF	c-src/emacs/src/keyboard.c	119
++\gtr	tex-src/texinfo.tex	/^\\def\\gtr{\\realbackslash gtr}%$/
++\gtr	tex-src/texinfo.tex	/^\\def\\gtr{\\realbackslash gtr}$/
++/guillemotleft	ps-src/rfc1245.ps	/^\/guillemotleft \/guillemotright \/ellipsis \/.notdef /
++handle_async_input	c-src/emacs/src/keyboard.c	/^handle_async_input (void)$/
++handle_input_available_signal	c-src/emacs/src/keyboard.c	/^handle_input_available_signal (int sig)$/
++handle_interrupt	c-src/emacs/src/keyboard.c	/^handle_interrupt (bool in_signal_handler)$/
++handle_interrupt_signal	c-src/emacs/src/keyboard.c	/^handle_interrupt_signal (int sig)$/
++handleList	pyt-src/server.py	/^    def handleList(self, event):$/
++handleNew	pyt-src/server.py	/^    def handleNew(self, event):$/
++handler	c-src/emacs/src/lisp.h	3023
++handlertype	c-src/emacs/src/lisp.h	3021
++handle_user_signal	c-src/emacs/src/keyboard.c	/^handle_user_signal (int sig)$/
++has_arg	c-src/getopt.h	82
++hash	c-src/emacs/src/lisp.h	1843
++hash	c-src/etags.c	/^hash (const char *str, int len)$/
++hashfn	c-src/emacs/src/lisp.h	/^  EMACS_UINT (*hashfn) (struct hash_table_test *t,/
++HASH_HASH	c-src/emacs/src/lisp.h	/^HASH_HASH (struct Lisp_Hash_Table *h, ptrdiff_t id/
++HASH_INDEX	c-src/emacs/src/lisp.h	/^HASH_INDEX (struct Lisp_Hash_Table *h, ptrdiff_t i/
++HASH_KEY	c-src/emacs/src/lisp.h	/^HASH_KEY (struct Lisp_Hash_Table *h, ptrdiff_t idx/
++HASH_NEXT	c-src/emacs/src/lisp.h	/^HASH_NEXT (struct Lisp_Hash_Table *h, ptrdiff_t id/
++HASH_TABLE_P	c-src/emacs/src/lisp.h	/^HASH_TABLE_P (Lisp_Object a)$/
++HASH_TABLE_SIZE	c-src/emacs/src/lisp.h	/^HASH_TABLE_SIZE (struct Lisp_Hash_Table *h)$/
++hash_table_test	c-src/emacs/src/lisp.h	1805
++HASH_VALUE	c-src/emacs/src/lisp.h	/^HASH_VALUE (struct Lisp_Hash_Table *h, ptrdiff_t i/
++\hat	tex-src/texinfo.tex	/^\\def\\hat{\\realbackslash hat}%$/
++\hat	tex-src/texinfo.tex	/^\\def\\hat{\\realbackslash hat}$/
++HAVE_NTGUI	c-src/etags.c	116
++hdr	c-src/emacs/src/gmalloc.c	1860
++header	c-src/emacs/src/lisp.h	1371
++header	c-src/emacs/src/lisp.h	1388
++header	c-src/emacs/src/lisp.h	1581
++header	c-src/emacs/src/lisp.h	1610
++header	c-src/emacs/src/lisp.h	1672
++header	c-src/emacs/src/lisp.h	1826
++header_size	c-src/emacs/src/lisp.h	1471
++\HEADINGSafter	tex-src/texinfo.tex	/^\\def\\HEADINGSafter{\\let\\HEADINGShook=\\HEADINGSdoub/
++\HEADINGSdouble	tex-src/texinfo.tex	/^\\def\\HEADINGSdouble{$/
++\HEADINGSdoublex	tex-src/texinfo.tex	/^\\def\\HEADINGSdoublex{%$/
++\HEADINGSoff	tex-src/texinfo.tex	/^\\def\\HEADINGSoff{$/
++\HEADINGSon	tex-src/texinfo.tex	/^\\def\\HEADINGSon{\\HEADINGSdouble}$/
++\HEADINGSon	tex-src/texinfo.tex	/^\\global\\def\\HEADINGSon{\\HEADINGSdouble}}$/
++\HEADINGSon	tex-src/texinfo.tex	/^\\global\\def\\HEADINGSon{\\HEADINGSsingle}}$/
++\HEADINGSsingleafter	tex-src/texinfo.tex	/^\\def\\HEADINGSsingleafter{\\let\\HEADINGShook=\\HEADIN/
++\HEADINGSsingle	tex-src/texinfo.tex	/^\\def\\HEADINGSsingle{$/
++\HEADINGSsinglex	tex-src/texinfo.tex	/^\\def\\HEADINGSsinglex{%$/
++\headings	tex-src/texinfo.tex	/^\\def\\headings #1 {\\csname HEADINGS#1\\endcsname}$/
++\heading	tex-src/texinfo.tex	/^\\def\\heading{\\parsearg\\secheadingi}$/
++head_table	c-src/emacs/src/keyboard.c	11027
++_heapbase	c-src/emacs/src/gmalloc.c	355
++HEAP	c-src/emacs/src/gmalloc.c	131
++_heapindex	c-src/emacs/src/gmalloc.c	364
++_heapinfo	c-src/emacs/src/gmalloc.c	358
++_heaplimit	c-src/emacs/src/gmalloc.c	367
++heapsize	c-src/emacs/src/gmalloc.c	361
++hello	scm-src/test.scm	/^(define hello "Hello, Emacs!")$/
++hello	scm-src/test.scm	/^(set! hello "Hello, world!")$/
++hello-world	scm-src/test.scm	/^(define (hello-world)$/
++help_char_p	c-src/emacs/src/keyboard.c	/^help_char_p (Lisp_Object c)$/
++help	c-src/etags.c	193
++help_form_saved_window_configs	c-src/emacs/src/keyboard.c	2156
++helpPanel	objcpp-src/SimpleCalc.M	/^- helpPanel:sender$/
++helpwin	pyt-src/server.py	/^def helpwin(helpdict):$/
++hide_cursor	cp-src/screen.cpp	/^void hide_cursor(void)$/
++hlds	merc-src/accumulator.m	/^:- import_module hlds.$/
++/home/www/pub/etags.c.gz	make-src/Makefile	/^\/home\/www\/pub\/etags.c.gz: etags.c$/
++/home/www/pub/software/unix/etags.tar.gz	make-src/Makefile	/^\/home\/www\/pub\/software\/unix\/etags.tar.gz: Makefile/
++/H	ps-src/rfc1245.ps	/^\/H { $/
++HTML_help	c-src/etags.c	584
++HTML_labels	c-src/etags.c	/^HTML_labels (FILE *inf)$/
++HTMLSRC	make-src/Makefile	/^HTMLSRC=softwarelibero.html index.shtml algrthms.h/
++HTML_suffixes	c-src/etags.c	582
++htmltreelist	prol-src/natded.prolog	/^htmltreelist([]).$/
++/hx	ps-src/rfc1245.ps	/^\/hx { $/
++hybrid_aligned_alloc	c-src/emacs/src/gmalloc.c	/^hybrid_aligned_alloc (size_t alignment, size_t siz/
++hybrid_calloc	c-src/emacs/src/gmalloc.c	/^hybrid_calloc (size_t nmemb, size_t size)$/
++hybrid_free	c-src/emacs/src/gmalloc.c	/^hybrid_free (void *ptr)$/
++hybrid_get_current_dir_name	c-src/emacs/src/gmalloc.c	/^hybrid_get_current_dir_name (void)$/
++hybrid_malloc	c-src/emacs/src/gmalloc.c	/^hybrid_malloc (size_t size)$/
++hybrid_realloc	c-src/emacs/src/gmalloc.c	/^hybrid_realloc (void *ptr, size_t size)$/
++hypothetical_mem	prol-src/natded.prolog	/^hypothetical_mem(fi(N),Ass,_):-$/
++/iacute	ps-src/rfc1245.ps	/^\/iacute \/igrave \/icircumflex \/idieresis \/ntilde \/o/
++ialpage	tex-src/texinfo.tex	/^  \\availdimen@=\\pageheight \\advance\\availdimen@ by/
++ialpage	tex-src/texinfo.tex	/^     \\dimen@=\\pageheight \\advance\\dimen@ by-\\ht\\pa/
++ialpage	tex-src/texinfo.tex	/^  \\dimen@=\\pageheight \\advance\\dimen@ by-\\ht\\parti/
++ialpage	tex-src/texinfo.tex	/^\\newbox\\partialpage$/
++ialpage=	tex-src/texinfo.tex	/^  \\output={\\global\\setbox\\partialpage=$/
++i	c.c	169
++/Icircumflex	ps-src/rfc1245.ps	/^\/Icircumflex \/Idieresis \/Igrave \/Oacute \/Ocircumfl/
++i	cp-src/c.C	132
++/ic	ps-src/rfc1245.ps	/^\/ic [ $/
++i	c-src/c.c	2
++i	c-src/emacs/src/lisp.h	4673
++i	c-src/emacs/src/lisp.h	4679
++i	c-src/emacs/src/lisp.h	567
++identify_goal_type	merc-src/accumulator.m	/^:- pred identify_goal_type(pred_id::in, proc_id::i/
++identify_out_and_out_prime	merc-src/accumulator.m	/^:- pred identify_out_and_out_prime(module_info::in/
++identify_recursive_calls	merc-src/accumulator.m	/^:- pred identify_recursive_calls(pred_id::in, proc/
++idx	c-src/emacs/src/lisp.h	3150
++IEEE_FLOATING_POINT	c-src/emacs/src/lisp.h	2415
++\ifclearfail	tex-src/texinfo.tex	/^\\def\\ifclearfail{\\begingroup\\ignoresections\\ifclea/
++\ifclearfailxxx	tex-src/texinfo.tex	/^\\long\\def\\ifclearfailxxx #1\\end ifclear{\\endgroup\\/
++\ifclear	tex-src/texinfo.tex	/^\\def\\ifclear{\\begingroup\\ignoresections\\parsearg\\i/
++\ifclearxxx	tex-src/texinfo.tex	/^\\def\\ifclearxxx #1{\\endgroup$/
++\ifinfo	tex-src/texinfo.tex	/^\\def\\ifinfo{\\begingroup\\ignoresections\\ifinfoxxx}$/
++\ifinfoxxx	tex-src/texinfo.tex	/^\\long\\def\\ifinfoxxx #1\\end ifinfo{\\endgroup\\ignore/
++\ifsetfail	tex-src/texinfo.tex	/^\\def\\ifsetfail{\\begingroup\\ignoresections\\ifsetfai/
++\ifsetfailxxx	tex-src/texinfo.tex	/^\\long\\def\\ifsetfailxxx #1\\end ifset{\\endgroup\\igno/
++\ifset	tex-src/texinfo.tex	/^\\def\\ifset{\\begingroup\\ignoresections\\parsearg\\ifs/
++\ifsetxxx	tex-src/texinfo.tex	/^\\def\\ifsetxxx #1{\\endgroup$/
++\iftex	tex-src/texinfo.tex	/^\\def\\iftex{}$/
++\ifusingtt	tex-src/texinfo.tex	/^\\def\\ifusingtt#1#2{\\ifdim \\fontdimen3\\the\\font=0pt/
++ignore_case	c-src/etags.c	266
++ignore_mouse_drag_p	c-src/emacs/src/keyboard.c	1256
++\ignoresections	tex-src/texinfo.tex	/^\\def\\ignoresections{%$/
++\ignore	tex-src/texinfo.tex	/^\\def\\ignore{\\begingroup\\ignoresections$/
++\ignorexxx	tex-src/texinfo.tex	/^\\long\\def\\ignorexxx #1\\end ignore{\\endgroup\\ignore/
++\ii	tex-src/texinfo.tex	/^\\def\\ii#1{{\\it #1}}		% italic font$/
++ill=\relax	tex-src/texinfo.tex	/^\\let\\refill=\\relax$/
++IMAGEP	c-src/emacs/src/lisp.h	/^IMAGEP (Lisp_Object x)$/
++immediate_quit	c-src/emacs/src/keyboard.c	174
++impatto	html-src/softwarelibero.html	/^Impatto pratico del software libero$/
++implementation	merc-src/accumulator.m	/^:- implementation.$/
++inattribute	c-src/etags.c	2400
++inc	cp-src/Range.h	/^  double inc (void) const { return rng_inc;   }$/
++/inch	ps-src/rfc1245.ps	/^\/inch {72 mul} def$/
++\include	tex-src/texinfo.tex	/^\\def\\include{\\parsearg\\includezzz}$/
++\includezzz	tex-src/texinfo.tex	/^\\def\\includezzz #1{{\\def\\thisfile{#1}\\input #1$/
++\indexbackslash	tex-src/texinfo.tex	/^  \\def\\indexbackslash{\\rawbackslashxx}$/
++index	c-src/emacs/src/lisp.h	1856
++\indexdotfill	tex-src/texinfo.tex	/^\\def\\indexdotfill{\\cleaders$/
++\indexdummies	tex-src/texinfo.tex	/^\\def\\indexdummies{%$/
++\indexdummydots	tex-src/texinfo.tex	/^\\def\\indexdummydots{...}$/
++\indexdummyfont	tex-src/texinfo.tex	/^\\def\\indexdummyfont#1{#1}$/
++=\indexdummyfont	tex-src/texinfo.tex	/^\\let\\cite=\\indexdummyfont$/
++\indexdummytex	tex-src/texinfo.tex	/^\\def\\indexdummytex{TeX}$/
++\indexfonts	tex-src/texinfo.tex	/^\\def\\indexfonts{%$/
++\indexnofonts	tex-src/texinfo.tex	/^\\def\\indexnofonts{%$/
++\inENV	tex-src/texinfo.tex	/^\\newif\\ifENV \\ENVfalse \\def\\inENV{\\ifENV\\relax\\els/
++infabsdir	c-src/etags.c	206
++infabsname	c-src/etags.c	205
++infiles	make-src/Makefile	/^infiles = $(filter-out ${NONSRCS},${SRCS}) srclist/
++infname	c-src/etags.c	204
++\infoappendixsec	tex-src/texinfo.tex	/^\\def\\infoappendixsec{\\parsearg\\appendixseczzz}$/
++\infoappendixsubsec	tex-src/texinfo.tex	/^\\def\\infoappendixsubsec{\\parsearg\\appendixsubseczz/
++\infoappendixsubsubsec	tex-src/texinfo.tex	/^\\def\\infoappendixsubsubsec{\\parsearg\\appendixsubsu/
++\infoappendix	tex-src/texinfo.tex	/^\\def\\infoappendix{\\parsearg\\appendixzzz}$/
++\infochapter	tex-src/texinfo.tex	/^\\def\\infochapter{\\parsearg\\chapterzzz}$/
++info	c-src/emacs/src/gmalloc.c	157
++infoPanel	objcpp-src/SimpleCalc.M	/^- infoPanel:sender$/
++\inforef	tex-src/texinfo.tex	/^\\def\\inforef #1{\\inforefzzz #1,,,,**}$/
++\inforefzzz	tex-src/texinfo.tex	/^\\def\\inforefzzz #1,#2,#3,#4**{See Info file \\file{/
++\infosection	tex-src/texinfo.tex	/^\\def\\infosection{\\parsearg\\sectionzzz}$/
++\infosubsection	tex-src/texinfo.tex	/^\\def\\infosubsection{\\parsearg\\subsectionzzz}$/
++\infosubsubsection	tex-src/texinfo.tex	/^\\def\\infosubsubsection{\\parsearg\\subsubsectionzzz}/
++\infotop	tex-src/texinfo.tex	/^\\def\\infotop{\\parsearg\\unnumberedzzz}$/
++\infounnumberedsec	tex-src/texinfo.tex	/^\\def\\infounnumberedsec{\\parsearg\\unnumberedseczzz}/
++\infounnumberedsubsec	tex-src/texinfo.tex	/^\\def\\infounnumberedsubsec{\\parsearg\\unnumberedsubs/
++\infounnumberedsubsubsec	tex-src/texinfo.tex	/^\\def\\infounnumberedsubsubsec{\\parsearg\\unnumbereds/
++\infounnumbered	tex-src/texinfo.tex	/^\\def\\infounnumbered{\\parsearg\\unnumberedzzz}$/
++inita	c.c	/^static void inita () {}$/
++initb	c.c	/^static void initb () {}$/
++init_control	c.c	239
++init	c-src/etags.c	/^init (void)$/
++Initialize_Cond/p	ada-src/2ataspri.adb	/^   procedure Initialize_Cond (Cond : in out Condit/
++Initialize_Cond/p	ada-src/2ataspri.ads	/^   procedure Initialize_Cond (Cond : in out Condit/
++initialize_goal_store	merc-src/accumulator.m	/^:- func initialize_goal_store(list(hlds_goal), ins/
++Initialize_LL_Tasks/p	ada-src/2ataspri.adb	/^   procedure Initialize_LL_Tasks (T : TCB_Ptr) is$/
++Initialize_LL_Tasks/p	ada-src/2ataspri.ads	/^   procedure Initialize_LL_Tasks (T : TCB_Ptr);$/
++Initialize_Lock/p	ada-src/2ataspri.adb	/^   procedure Initialize_Lock$/
++Initialize_Lock/p	ada-src/2ataspri.ads	/^   procedure Initialize_Lock (Prio : System.Any_Pr/
++initialize-new-tags-table	el-src/emacs/lisp/progmodes/etags.el	/^(defun initialize-new-tags-table ()$/
++initialize_random_junk	y-src/cccp.y	/^initialize_random_junk ()$/
++InitializeStringPackage	pas-src/common.pas	/^procedure InitializeStringPackage;$/
++Initialize_TAS_Cell/p	ada-src/2ataspri.adb	/^   procedure Initialize_TAS_Cell (Cell : out TAS_C/
++Initialize_TAS_Cell/p	ada-src/2ataspri.ads	/^   procedure Initialize_TAS_Cell (Cell :    out TA/
++initial_kboard	c-src/emacs/src/keyboard.c	84
++\initial	tex-src/texinfo.tex	/^\\def\\initial #1{%$/
++init_kboard	c-src/emacs/src/keyboard.c	/^init_kboard (KBOARD *kb, Lisp_Object type)$/
++init_keyboard	c-src/emacs/src/keyboard.c	/^init_keyboard (void)$/
++InitNameList	pas-src/common.pas	/^procedure InitNameList;$/
++InitNameStringPool	pas-src/common.pas	/^procedure InitNameStringPool;$/
++init	objcpp-src/SimpleCalc.M	/^- init$/
++init	objc-src/Subprocess.m	/^    andStdErr:(BOOL)wantsStdErr$/
++init	objc-src/Subprocess.m	/^- init:(const char *)subprocessString$/
++__init__	pyt-src/server.py	/^    def __init__(self):$/
++__init__	pyt-src/server.py	/^    def __init__(self, host, sitelist, master=None/
++__init__	pyt-src/server.py	/^    def __init__(self, master=None):$/
++__init__	pyt-src/server.py	/^    def __init__(self, Master, text, textvar, widt/
++__init__	pyt-src/server.py	/^    def __init__(self, newlegend, list, editor, ma/
++__init__	pyt-src/server.py	/^    def __init__(self, user, userlist, master=None/
++init_registry	cp-src/clheir.cpp	/^void init_registry(void)$/
++init_tool_bar_items	c-src/emacs/src/keyboard.c	/^init_tool_bar_items (Lisp_Object reuse)$/
++Inner1/b	ada-src/etags-test-for.ada	/^  package body Inner1 is$/
++Inner1/b	ada-src/waroquiers.ada	/^  package body Inner1 is$/
++Inner1/s	ada-src/etags-test-for.ada	/^  package Inner1 is$/
++Inner1/s	ada-src/waroquiers.ada	/^  package Inner1 is$/
++Inner2/b	ada-src/etags-test-for.ada	/^  package body Inner2 is$/
++Inner2/b	ada-src/waroquiers.ada	/^  package body Inner2 is$/
++Inner2/s	ada-src/etags-test-for.ada	/^  package Inner2 is$/
++Inner2/s	ada-src/waroquiers.ada	/^  package Inner2 is$/
++input_available_clear_time	c-src/emacs/src/keyboard.c	324
++INPUT_EVENT_POS_MAX	c-src/emacs/src/keyboard.c	3698
++INPUT_EVENT_POS_MIN	c-src/emacs/src/keyboard.c	3701
++input_pending	c-src/emacs/src/keyboard.c	239
++input-pending-p	c-src/emacs/src/keyboard.c	/^DEFUN ("input-pending-p", Finput_pending_p, Sinput/
++input_polling_used	c-src/emacs/src/keyboard.c	/^input_polling_used (void)$/
++input_was_pending	c-src/emacs/src/keyboard.c	287
++insert-abbrev-table-description	c-src/abbrev.c	/^DEFUN ("insert-abbrev-table-description", Finsert_/
++insertion_type	c-src/emacs/src/lisp.h	1989
++insertname	pas-src/common.pas	/^function insertname;(*($/
++INSERT_TREE_NODE	pas-src/common.pas	/^procedure INSERT_TREE_NODE;(*( $/
++Install_Abort_Handler/p	ada-src/2ataspri.adb	/^   procedure Install_Abort_Handler (Handler : Abor/
++Install_Abort_Handler/p	ada-src/2ataspri.ads	/^   procedure Install_Abort_Handler (Handler : Abor/
++Install_Error_Handler/p	ada-src/2ataspri.adb	/^   procedure Install_Error_Handler (Handler : Syst/
++Install_Error_Handler/p	ada-src/2ataspri.ads	/^   procedure Install_Error_Handler (Handler : Syst/
++instance_method_equals=	ruby-src/test.rb	/^        def instance_method_equals=$/
++instance_method_exclamation!	ruby-src/test.rb	/^        def instance_method_exclamation!$/
++instance_method_question?	ruby-src/test.rb	/^        def instance_method_question?$/
++instance_method	ruby-src/test.rb	/^        def instance_method$/
++INSTANTIATE_MDIAGARRAY_FRIENDS	cp-src/MDiagArray2.h	/^#define INSTANTIATE_MDIAGARRAY_FRIENDS(T) \\$/
++instruct	c-src/etags.c	2527
++instr	y-src/parse.y	81
++INT_BIT	c-src/emacs/src/gmalloc.c	124
++INT	c-src/h.h	32
++integer	c-src/emacs/src/lisp.h	2127
++integer_overflow	y-src/cccp.y	/^integer_overflow ()$/
++INTEGERP	c-src/emacs/src/lisp.h	/^# define INTEGERP(x) lisp_h_INTEGERP (x)$/
++INTEGER_TO_CONS	c-src/emacs/src/lisp.h	/^#define INTEGER_TO_CONS(i)					    \\$/
++integertonmstr	pas-src/common.pas	/^function integertonmstr; (* (TheInteger : integer)/
++integer	y-src/cccp.y	112
++intensity1	f-src/entry.for	/^     & intensity1(efv,fv,svin,svquad,sfpv,maxp,val/
++intensity1	f-src/entry.strange	/^     & intensity1(efv,fv,svin,svquad,sfpv,maxp,val/
++intensity1	f-src/entry.strange_suffix	/^     & intensity1(efv,fv,svin,svquad,sfpv,maxp,val/
++interface_locate	c-src/c.c	/^interface_locate(void)$/
++interface	merc-src/accumulator.m	/^:- interface.$/
++\internalBitem	tex-src/texinfo.tex	/^\\def\\internalBitem{\\smallbreak \\parsearg\\itemzzz}$/
++\internalBitemx	tex-src/texinfo.tex	/^\\def\\internalBitemx{\\par \\parsearg\\itemzzz}$/
++\internalBkitem	tex-src/texinfo.tex	/^\\def\\internalBkitem{\\smallbreak \\parsearg\\kitemzzz/
++\internalBkitemx	tex-src/texinfo.tex	/^\\def\\internalBkitemx{\\par \\parsearg\\kitemzzz}$/
++\internalBxitem	tex-src/texinfo.tex	/^\\def\\internalBxitem "#1"{\\def\\xitemsubtopix{#1} \\s/
++\internalBxitemx	tex-src/texinfo.tex	/^\\def\\internalBxitemx "#1"{\\def\\xitemsubtopix{#1} \\/
++internal_last_event_frame	c-src/emacs/src/keyboard.c	228
++\internalsetq	tex-src/texinfo.tex	/^\\def\\internalsetq #1#2{'xrdef {#1}{\\csname #2\\endc/
++intern	c-src/emacs/src/lisp.h	/^intern (const char *str)$/
++intern_c_string	c-src/emacs/src/lisp.h	/^intern_c_string (const char *str)$/
++interned	c-src/emacs/src/lisp.h	672
++interpreters	c-src/etags.c	197
++interrupt_input_blocked	c-src/emacs/src/keyboard.c	76
++interrupt_input_blocked	c-src/emacs/src/lisp.h	3048
++interrupt_input	c-src/emacs/src/keyboard.c	328
++interrupts_deferred	c-src/emacs/src/keyboard.c	331
++INTERVAL	c-src/emacs/src/lisp.h	1149
++INTMASK	c-src/emacs/src/lisp.h	437
++int	merc-src/accumulator.m	/^:- import_module int.$/
++intNumber	go-src/test1.go	13
++intoken	c-src/etags.c	/^#define	intoken(c)	(_itk[CHAR (c)]) \/* c can be in/
++intspec	c-src/emacs/src/lisp.h	1688
++INTTYPEBITS	c-src/emacs/src/lisp.h	249
++INT_TYPE_SIZE	y-src/cccp.y	91
++intvar	c-src/emacs/src/lisp.h	2277
++INT	y-src/cccp.c	6
++invalidate_nodes	c-src/etags.c	/^invalidate_nodes (fdesc *badfdp, node **npp)$/
++Invoking gzip	tex-src/gzip.texi	/^@node Invoking gzip, Advanced usage, Sample, Top$/
++in_word_set	c-src/etags.c	/^in_word_set (register const char *str, register un/
++io	merc-src/accumulator.m	/^:- import_module io.$/
++IpAddrKind	rs-src/test.rs	3
++ipc3dChannelType	cp-src/c.C	1
++ipc3dCSC19	cp-src/c.C	6
++ipc3dIslandHierarchy	cp-src/c.C	1
++ipc3dLinkControl	cp-src/c.C	1
++__ip	c.c	159
++/ip	ps-src/rfc1245.ps	/^\/ip { $/
++/i	ps-src/rfc1245.ps	/^\/i \/j \/k \/l \/m \/n \/o \/p \/q \/r \/s \/t \/u \/v \/w \/x \/y/
++irregular_location	cp-src/clheir.hpp	47
++irregular_location	cp-src/clheir.hpp	/^    irregular_location(double xi, double yi, doubl/
++ISALNUM	c-src/etags.c	/^#define ISALNUM(c)	isalnum (CHAR (c))$/
++ISALPHA	c-src/etags.c	/^#define ISALPHA(c)	isalpha (CHAR (c))$/
++is_associative_construction	merc-src/accumulator.m	/^:- pred is_associative_construction(module_info::i/
++isComment	php-src/lce_functions.php	/^      function isComment($class)$/
++IsControlCharName	pas-src/common.pas	/^function IsControlCharName($/
++IsControlChar	pas-src/common.pas	/^function IsControlChar; (*($/
++is_curly_brace_form	c-src/h.h	54
++IS_DAEMON	c-src/emacs/src/lisp.h	4257
++IS_DAEMON	c-src/emacs/src/lisp.h	4261
++ISDIGIT	c-src/etags.c	/^#define ISDIGIT(c)	isdigit (CHAR (c))$/
++is_explicit	c-src/h.h	49
++is_func	c-src/etags.c	221
++isHoliday	cp-src/functions.cpp	/^bool isHoliday ( Date d ){$/
++is_hor_space	y-src/cccp.y	953
++is_idchar	y-src/cccp.y	948
++is_idstart	y-src/cccp.y	950
++isLeap	cp-src/functions.cpp	/^bool isLeap ( int year ){$/
++ISLOWER	c-src/etags.c	/^#define ISLOWER(c)	islower (CHAR (c))$/
++is_muldiv_operation	cp-src/c.C	/^is_muldiv_operation(pc)$/
++ISO_FUNCTION_KEY_OFFSET	c-src/emacs/src/keyboard.c	5149
++iso_lispy_function_keys	c-src/emacs/src/keyboard.c	5151
++isoperator	prol-src/natded.prolog	/^isoperator(Char):-$/
++isoptab	prol-src/natded.prolog	/^isoptab('%').$/
++is_ordset	prol-src/ordsets.prolog	/^is_ordset(X) :- var(X), !, fail.$/
++is_recursive_case	merc-src/accumulator.m	/^:- pred is_recursive_case(list(hlds_goal)::in, pre/
++Is_Set/f	ada-src/2ataspri.adb	/^   function  Is_Set (Cell : in TAS_Cell) return Bo/
++Is_Set/f	ada-src/2ataspri.ads	/^   function  Is_Set       (Cell : in     TAS_Cell)/
++ISUPPER	c-src/etags.c	/^# define ISUPPER(c)	isupper (CHAR (c))$/
++iswhite	c-src/etags.c	/^#define	iswhite(c)	(_wht[CHAR (c)]) \/* c is white /
++\itemcontents	tex-src/texinfo.tex	/^\\def\\itemcontents{#1}%$/
++\itemfont	tex-src/texinfo.tex	/^\\def\\itemfont{#2}%$/
++\itemizeitem	tex-src/texinfo.tex	/^\\def\\itemizeitem{%$/
++\itemize	tex-src/texinfo.tex	/^\\def\\itemize{\\parsearg\\itemizezzz}$/
++\itemizey	tex-src/texinfo.tex	/^\\def\\itemizey #1#2{%$/
++\itemizezzz	tex-src/texinfo.tex	/^\\def\\itemizezzz #1{%$/
++item_properties	c-src/emacs/src/keyboard.c	7568
++\item	tex-src/texinfo.tex	/^\\def\\item{\\errmessage{@item while not in a table}}/
++\itemx	tex-src/texinfo.tex	/^\\def\\itemx{\\errmessage{@itemx while not in a table/
++\itemzzz	tex-src/texinfo.tex	/^\\def\\itemzzz #1{\\begingroup %$/
++\i	tex-src/texinfo.tex	/^\\def\\i##1{\\realbackslash i {##1}}%$/
++\i	tex-src/texinfo.tex	/^\\def\\i##1{\\realbackslash i {##1}}$/
++JAVASRC	make-src/Makefile	/^JAVASRC=AWTEMul.java KeyEve.java SMan.java SysCol./
++jmp	c-src/emacs/src/lisp.h	3044
++just_read_file	c-src/etags.c	/^just_read_file (FILE *inf)$/
++kbd_buffer	c-src/emacs/src/keyboard.c	291
++kbd_buffer_events_waiting	c-src/emacs/src/keyboard.c	/^kbd_buffer_events_waiting (void)$/
++kbd_buffer_get_event	c-src/emacs/src/keyboard.c	/^kbd_buffer_get_event (KBOARD **kbp,$/
++kbd_buffer_nr_stored	c-src/emacs/src/keyboard.c	/^kbd_buffer_nr_stored (void)$/
++KBD_BUFFER_SIZE	c-src/emacs/src/keyboard.c	82
++kbd_buffer_store_event	c-src/emacs/src/keyboard.c	/^kbd_buffer_store_event (register struct input_even/
++kbd_buffer_store_event_hold	c-src/emacs/src/keyboard.c	/^kbd_buffer_store_event_hold (register struct input/
++kbd_buffer_store_help_event	c-src/emacs/src/keyboard.c	/^kbd_buffer_store_help_event (Lisp_Object frame, Li/
++kbd_buffer_unget_event	c-src/emacs/src/keyboard.c	/^kbd_buffer_unget_event (register struct input_even/
++kbd_fetch_ptr	c-src/emacs/src/keyboard.c	297
++\kbdfoo	tex-src/texinfo.tex	/^\\def\\kbdfoo#1#2#3\\par{\\def\\one{#1}\\def\\three{#3}\\d/
++kbd_store_ptr	c-src/emacs/src/keyboard.c	302
++\kbd	tex-src/texinfo.tex	/^\\def\\kbd#1{\\def\\look{#1}\\expandafter\\kbdfoo\\look??/
++\kbd	tex-src/texinfo.tex	/^\\def\\kbd##1{\\realbackslash kbd {##1}}%$/
++\kbd	tex-src/texinfo.tex	/^\\def\\kbd##1{\\realbackslash kbd {##1}}$/
++kboard	c-src/emacs/src/keyboard.c	860
++kboard_stack	c-src/emacs/src/keyboard.c	858
++kboard_stack	c-src/emacs/src/keyboard.c	864
++KBYTES	objc-src/PackInsp.m	58
++key_and_value	c-src/emacs/src/lisp.h	1868
++keyremap	c-src/emacs/src/keyboard.c	8742
++keyremap	c-src/emacs/src/keyboard.c	8754
++keyremap_step	c-src/emacs/src/keyboard.c	/^keyremap_step (Lisp_Object *keybuf, int bufsize, v/
++keys_of_keyboard	c-src/emacs/src/keyboard.c	/^keys_of_keyboard (void)$/
++\key	tex-src/texinfo.tex	/^\\def\\key##1{\\realbackslash key {##1}}%$/
++\key	tex-src/texinfo.tex	/^\\def\\key##1{\\realbackslash key {##1}}$/
++\key	tex-src/texinfo.tex	/^\\def\\key #1{{\\tt \\exhyphenpenalty=10000\\uppercase{/
++KEY_TO_CHAR	c-src/emacs/src/keyboard.c	/^#define KEY_TO_CHAR(k) (XINT (k) & ((1 << CHARACTE/
++keyvalcgi	prol-src/natded.prolog	/^keyvalcgi(Key,Val):-$/
++keyval	prol-src/natded.prolog	/^keyval(key(Key,Val)) --> [Key,'='], valseq(Val).$/
++keyvalscgi	prol-src/natded.prolog	/^keyvalscgi(KeyVals),$/
++keyvalseq	prol-src/natded.prolog	/^keyvalseq([KeyVal|KeyVals]) --> $/
++keyword_parsing	y-src/cccp.y	73
++keywords	y-src/cccp.y	114
++keywords	y-src/cccp.y	306
++kind	c-src/emacs/src/keyboard.c	11024
++kind	c-src/h.h	46
++\kindex	tex-src/texinfo.tex	/^\\def\\kindex {\\kyindex}$/
++\kitem	tex-src/texinfo.tex	/^\\def\\kitem{\\errmessage{@kitem while not in a table/
++\kitemx	tex-src/texinfo.tex	/^\\def\\kitemx{\\errmessage{@kitemx while not in a tab/
++\kitemzzz	tex-src/texinfo.tex	/^\\def\\kitemzzz #1{\\dosubind {kw}{\\code{#1}}{for {\\b/
++kset_echo_string	c-src/emacs/src/keyboard.c	/^kset_echo_string (struct kboard *kb, Lisp_Object v/
++kset_kbd_queue	c-src/emacs/src/keyboard.c	/^kset_kbd_queue (struct kboard *kb, Lisp_Object val/
++kset_keyboard_translate_table	c-src/emacs/src/keyboard.c	/^kset_keyboard_translate_table (struct kboard *kb, /
++kset_last_prefix_arg	c-src/emacs/src/keyboard.c	/^kset_last_prefix_arg (struct kboard *kb, Lisp_Obje/
++kset_last_repeatable_command	c-src/emacs/src/keyboard.c	/^kset_last_repeatable_command (struct kboard *kb, L/
++kset_local_function_key_map	c-src/emacs/src/keyboard.c	/^kset_local_function_key_map (struct kboard *kb, Li/
++kset_overriding_terminal_local_map	c-src/emacs/src/keyboard.c	/^kset_overriding_terminal_local_map (struct kboard /
++kset_real_last_command	c-src/emacs/src/keyboard.c	/^kset_real_last_command (struct kboard *kb, Lisp_Ob/
++kset_system_key_syms	c-src/emacs/src/keyboard.c	/^kset_system_key_syms (struct kboard *kb, Lisp_Obje/
++LabeledEntry	pyt-src/server.py	/^class LabeledEntry(Frame):$/
++\labelspace	tex-src/texinfo.tex	/^\\def\\labelspace{\\hskip1em \\relax}$/
++lang	c-src/etags.c	208
++lang	c-src/etags.c	251
++lang	c-src/etags.c	259
++Lang_function	c-src/etags.c	182
++Lang_function	c-src/h.h	6
++lang_names	c-src/etags.c	718
++language	c-src/etags.c	199
++last_abbrev_point	c-src/abbrev.c	79
++lasta	c.c	272
++lastargmargin	tex-src/texinfo.tex	/^\\newskip\\deflastargmargin \\deflastargmargin=18pt$/
++lastargmargin	tex-src/texinfo.tex	/^\\setbox0=\\hbox{\\hskip \\deflastargmargin{\\rm #2}\\hs/
++last_auto_save	c-src/emacs/src/keyboard.c	214
++lastb	c.c	278
++last_heapinfo	c-src/emacs/src/gmalloc.c	402
++last_mouse_button	c-src/emacs/src/keyboard.c	5215
++last_mouse_x	c-src/emacs/src/keyboard.c	5216
++last_mouse_y	c-src/emacs/src/keyboard.c	5217
++last_non_minibuf_size	c-src/emacs/src/keyboard.c	207
++last_point_position	c-src/emacs/src/keyboard.c	217
++last_state_size	c-src/emacs/src/gmalloc.c	401
++last-tag	el-src/emacs/lisp/progmodes/etags.el	/^(defvar last-tag nil$/
++last_undo_boundary	c-src/emacs/src/keyboard.c	1287
++LATEST	make-src/Makefile	/^LATEST=17$/
++lb	c-src/etags.c	2923
++\lbrb	tex-src/texinfo.tex	/^\\def\\lbrb{{\\bf\\char`\\[}} \\def\\rbrb{{\\bf\\char`\\]}}$/
++lbs	c-src/etags.c	2924
++lce_bindtextdomain	php-src/lce_functions.php	/^      function lce_bindtextdomain($d_name, $d_path/
++lce_bindtextdomain	php-src/lce_functions.php	/^      function lce_bindtextdomain($domain, $path)$/
++LCE_COMMENT	php-src/lce_functions.php	13
++LCE_COMMENT_TOOL	php-src/lce_functions.php	17
++LCE_COMMENT_USER	php-src/lce_functions.php	15
++lce_dgettext	php-src/lce_functions.php	/^      function lce_dgettext($domain, $msgid)$/
++LCE_FUNCTIONS	php-src/lce_functions.php	4
++lce_geteditcode	php-src/lce_functions.php	/^  function lce_geteditcode($type, $name, $text, $r/
++lce_gettext	php-src/lce_functions.php	/^      function lce_gettext($msgid)$/
++L_CELL	y-src/parse.c	10
++LCE_MSGID	php-src/lce_functions.php	19
++LCE_MSGSTR	php-src/lce_functions.php	21
++lce	php-src/lce_functions.php	/^      function lce()$/
++lce_textdomain	php-src/lce_functions.php	/^      function lce_textdomain($domain)$/
++LCE_TEXT	php-src/lce_functions.php	23
++LCE_UNKNOWN	php-src/lce_functions.php	9
++LCE_WS	php-src/lce_functions.php	11
++L_CONST	y-src/parse.c	13
++LDFLAGS	make-src/Makefile	/^LDFLAGS=#-static -lc_p$/
++leasqr	html-src/software.html	/^Leasqr$/
++left	c-src/etags.c	216
++left_shift	y-src/cccp.y	/^left_shift (a, b)$/
++len	c-src/etags.c	237
++length	c-src/etags.c	2495
++length	y-src/cccp.y	113
++length	y-src/cccp.y	44
++LEQ	y-src/cccp.c	14
++/less	ps-src/rfc1245.ps	/^\/less \/equal \/greater \/question \/at \/A \/B \/C \/D \/E/
++\less	tex-src/texinfo.tex	/^\\def\\less{\\realbackslash less}%$/
++\less	tex-src/texinfo.tex	/^\\def\\less{\\realbackslash less}$/
++let	c-src/emacs/src/lisp.h	2981
++letter	tex-src/texinfo.tex	/^  {#1}{Appendix \\appendixletter}{\\noexpand\\folio}}/
++letter	tex-src/texinfo.tex	/^{#1}{\\appendixletter}{\\the\\secno}{\\noexpand\\folio}/
++letter	tex-src/texinfo.tex	/^{#1}{\\appendixletter}{\\the\\secno}{\\the\\subsecno}{\\/
++letter	tex-src/texinfo.tex	/^  {\\appendixletter}$/
++letter	tex-src/texinfo.tex	/^  {\\appendixletter}{\\the\\secno}{\\the\\subsecno}{\\th/
++letter	tex-src/texinfo.tex	/^\\chapmacro {#1}{Appendix \\appendixletter}%$/
++letter	tex-src/texinfo.tex	/^\\gdef\\thissection{#1}\\secheading {#1}{\\appendixlet/
++letter	tex-src/texinfo.tex	/^\\subsecheading {#1}{\\appendixletter}{\\the\\secno}{\\/
++letter:	tex-src/texinfo.tex	/^\\xdef\\thischapter{Appendix \\appendixletter: \\noexp/
++level	c-src/emacs/src/lisp.h	3153
++lex	prol-src/natded.prolog	/^lex(W,SynOut,Sem):-$/
++lexptr	y-src/cccp.y	332
++LE	y-src/parse.c	7
++L_FN0	y-src/parse.c	14
++L_FN1R	y-src/parse.c	20
++L_FN1	y-src/parse.c	15
++L_FN2R	y-src/parse.c	21
++L_FN2	y-src/parse.c	16
++L_FN3R	y-src/parse.c	22
++L_FN3	y-src/parse.c	17
++L_FN4R	y-src/parse.c	23
++L_FN4	y-src/parse.c	18
++L_FNNR	y-src/parse.c	24
++L_FNN	y-src/parse.c	19
++L_getit	c-src/etags.c	/^L_getit (void)$/
++L_GE	y-src/parse.c	27
++__libc_atexit	c-src/exit.c	30
++__libc_atexit	c-src/exit.strange_suffix	30
++libs	merc-src/accumulator.m	/^:- import_module libs.$/
++licenze	html-src/softwarelibero.html	/^Licenze d'uso di un programma$/
++LIGHTBLUE	cp-src/screen.hpp	21
++LIGHTCYAN	cp-src/screen.hpp	23
++LIGHTGRAY	cp-src/screen.hpp	19
++LIGHTGREEN	cp-src/screen.hpp	22
++LIGHTMAGENTA	cp-src/screen.hpp	25
++LIGHTRED	cp-src/screen.hpp	24
++limit	cp-src/Range.h	/^  double limit (void) const { return rng_limit; }$/
++linebuffer	c-src/etags.c	239
++linebuffer_init	c-src/etags.c	/^linebuffer_init (linebuffer *lbp)$/
++linebuffer_setlen	c-src/etags.c	/^linebuffer_setlen (linebuffer *lbp, int toksize)$/
++lineCount	php-src/lce_functions.php	/^      function lineCount($entry)$/
++line	c-src/etags.c	2493
++lineno	c-src/emacs/src/lisp.h	3147
++lineno	c-src/etags.c	2506
++\linenumber	tex-src/texinfo.tex	/^  \\def\\linenumber{\\the\\inputlineno:\\space}$/
++line	perl-src/htlmify-cystic	37
++linepos	c-src/etags.c	2507
++linepos	c-src/etags.c	2922
++line	y-src/parse.y	87
++links	html-src/software.html	/^Links to interesting software$/
++Lisp_Bits	c-src/emacs/src/lisp.h	239
++Lisp_Boolfwd	c-src/emacs/src/lisp.h	2284
++Lisp_Bool_Vector	c-src/emacs/src/lisp.h	1384
++Lisp_Buffer_Local_Value	c-src/emacs/src/lisp.h	2334
++Lisp_Buffer_Objfwd	c-src/emacs/src/lisp.h	2302
++Lisp_Char_Table	c-src/emacs/src/lisp.h	1575
++Lisp_Compiled	c-src/emacs/src/lisp.h	2429
++Lisp_Cons	c-src/emacs/src/lisp.h	475
++lisp_eval_depth	c-src/emacs/src/lisp.h	3045
++Lisp_Finalizer	c-src/emacs/src/lisp.h	2186
++Lisp_Float	c-src/emacs/src/lisp.h	2391
++Lisp_Float	c-src/emacs/src/lisp.h	477
++Lisp_Free	c-src/emacs/src/lisp.h	2201
++Lisp_functions	c-src/etags.c	/^Lisp_functions (FILE *inf)$/
++Lisp_Fwd_Bool	c-src/emacs/src/lisp.h	505
++Lisp_Fwd_Buffer_Obj	c-src/emacs/src/lisp.h	507
++Lisp_Fwd	c-src/emacs/src/lisp.h	2368
++Lisp_Fwd_Int	c-src/emacs/src/lisp.h	504
++Lisp_Fwd_Kboard_Obj	c-src/emacs/src/lisp.h	508
++Lisp_Fwd_Obj	c-src/emacs/src/lisp.h	506
++Lisp_Fwd_Type	c-src/emacs/src/lisp.h	502
++Lisp_Hash_Table	c-src/emacs/src/lisp.h	1823
++lisp_h_check_cons_list	c-src/emacs/src/lisp.h	/^# define lisp_h_check_cons_list() ((void) 0)$/
++lisp_h_CHECK_LIST_CONS	c-src/emacs/src/lisp.h	/^#define lisp_h_CHECK_LIST_CONS(x, y) CHECK_TYPE (C/
++lisp_h_CHECK_NUMBER	c-src/emacs/src/lisp.h	/^#define lisp_h_CHECK_NUMBER(x) CHECK_TYPE (INTEGER/
++lisp_h_CHECK_SYMBOL	c-src/emacs/src/lisp.h	/^#define lisp_h_CHECK_SYMBOL(x) CHECK_TYPE (SYMBOLP/
++lisp_h_CHECK_TYPE	c-src/emacs/src/lisp.h	/^#define lisp_h_CHECK_TYPE(ok, predicate, x) \\$/
++lisp_h_CONSP	c-src/emacs/src/lisp.h	/^#define lisp_h_CONSP(x) (XTYPE (x) == Lisp_Cons)$/
++Lisp_help	c-src/etags.c	591
++lisp_h_EQ	c-src/emacs/src/lisp.h	/^#define lisp_h_EQ(x, y) (XLI (x) == XLI (y))$/
++lisp_h_FLOATP	c-src/emacs/src/lisp.h	/^#define lisp_h_FLOATP(x) (XTYPE (x) == Lisp_Float)/
++lisp_h_INTEGERP	c-src/emacs/src/lisp.h	/^#define lisp_h_INTEGERP(x) ((XTYPE (x) & (Lisp_Int/
++lisp_h_make_number	c-src/emacs/src/lisp.h	/^# define lisp_h_make_number(n) \\$/
++lisp_h_MARKERP	c-src/emacs/src/lisp.h	/^#define lisp_h_MARKERP(x) (MISCP (x) && XMISCTYPE /
++lisp_h_MISCP	c-src/emacs/src/lisp.h	/^#define lisp_h_MISCP(x) (XTYPE (x) == Lisp_Misc)$/
++lisp_h_NILP	c-src/emacs/src/lisp.h	/^#define lisp_h_NILP(x) EQ (x, Qnil)$/
++lisp_h_SET_SYMBOL_VAL	c-src/emacs/src/lisp.h	/^#define lisp_h_SET_SYMBOL_VAL(sym, v) \\$/
++lisp_h_SYMBOL_CONSTANT_P	c-src/emacs/src/lisp.h	/^#define lisp_h_SYMBOL_CONSTANT_P(sym) (XSYMBOL (sy/
++lisp_h_SYMBOLP	c-src/emacs/src/lisp.h	/^#define lisp_h_SYMBOLP(x) (XTYPE (x) == Lisp_Symbo/
++lisp_h_SYMBOL_VAL	c-src/emacs/src/lisp.h	/^#define lisp_h_SYMBOL_VAL(sym) \\$/
++lisp_h_VECTORLIKEP	c-src/emacs/src/lisp.h	/^#define lisp_h_VECTORLIKEP(x) (XTYPE (x) == Lisp_V/
++lisp_h_XCAR	c-src/emacs/src/lisp.h	/^#define lisp_h_XCAR(c) XCONS (c)->car$/
++lisp_h_XCDR	c-src/emacs/src/lisp.h	/^#define lisp_h_XCDR(c) XCONS (c)->u.cdr$/
++lisp_h_XCONS	c-src/emacs/src/lisp.h	/^#define lisp_h_XCONS(a) \\$/
++lisp_h_XFASTINT	c-src/emacs/src/lisp.h	/^# define lisp_h_XFASTINT(a) XINT (a)$/
++lisp_h_XHASH	c-src/emacs/src/lisp.h	/^#define lisp_h_XHASH(a) XUINT (a)$/
++lisp_h_XIL	c-src/emacs/src/lisp.h	/^# define lisp_h_XIL(i) (i)$/
++lisp_h_XIL	c-src/emacs/src/lisp.h	/^# define lisp_h_XIL(i) ((Lisp_Object) { i })$/
++lisp_h_XINT	c-src/emacs/src/lisp.h	/^# define lisp_h_XINT(a) (XLI (a) >> INTTYPEBITS)$/
++lisp_h_XLI	c-src/emacs/src/lisp.h	/^# define lisp_h_XLI(o) (o)$/
++lisp_h_XLI	c-src/emacs/src/lisp.h	/^# define lisp_h_XLI(o) ((o).i)$/
++lisp_h_XPNTR	c-src/emacs/src/lisp.h	/^#define lisp_h_XPNTR(a) \\$/
++lisp_h_XSYMBOL	c-src/emacs/src/lisp.h	/^# define lisp_h_XSYMBOL(a) \\$/
++lisp_h_XTYPE	c-src/emacs/src/lisp.h	/^# define lisp_h_XTYPE(a) ((enum Lisp_Type) (XLI (a/
++lisp_h_XUNTAG	c-src/emacs/src/lisp.h	/^# define lisp_h_XUNTAG(a, type) ((void *) (intptr_/
++LISP_INITIALLY	c-src/emacs/src/lisp.h	/^#define LISP_INITIALLY(i) (i)$/
++LISP_INITIALLY	c-src/emacs/src/lisp.h	/^#define LISP_INITIALLY(i) {i}$/
++LISP_INITIALLY_ZERO	c-src/emacs/src/lisp.h	582
++Lisp_Int0	c-src/emacs/src/lisp.h	461
++Lisp_Int1	c-src/emacs/src/lisp.h	462
++Lisp_Intfwd	c-src/emacs/src/lisp.h	2274
++Lisp_Kboard_Objfwd	c-src/emacs/src/lisp.h	2362
++LISP_MACRO_DEFUN	c-src/emacs/src/lisp.h	/^#define LISP_MACRO_DEFUN(name, type, argdecls, arg/
++LISP_MACRO_DEFUN	c-src/emacs/src/lisp.h	/^LISP_MACRO_DEFUN (CONSP, bool, (Lisp_Object x), (x/
++LISP_MACRO_DEFUN	c-src/emacs/src/lisp.h	/^LISP_MACRO_DEFUN (NILP, bool, (Lisp_Object x), (x)/
++LISP_MACRO_DEFUN	c-src/emacs/src/lisp.h	/^LISP_MACRO_DEFUN (SYMBOL_VAL, Lisp_Object, (struct/
++LISP_MACRO_DEFUN	c-src/emacs/src/lisp.h	/^LISP_MACRO_DEFUN (XCAR, Lisp_Object, (Lisp_Object /
++LISP_MACRO_DEFUN	c-src/emacs/src/lisp.h	/^LISP_MACRO_DEFUN (XCONS, struct Lisp_Cons *, (Lisp/
++LISP_MACRO_DEFUN	c-src/emacs/src/lisp.h	/^LISP_MACRO_DEFUN (XHASH, EMACS_INT, (Lisp_Object a/
++LISP_MACRO_DEFUN	c-src/emacs/src/lisp.h	/^LISP_MACRO_DEFUN (XLI, EMACS_INT, (Lisp_Object o),/
++LISP_MACRO_DEFUN	c-src/emacs/src/lisp.h	/^LISP_MACRO_DEFUN (XPNTR, void *, (Lisp_Object a), /
++LISP_MACRO_DEFUN_VOID	c-src/emacs/src/lisp.h	/^#define LISP_MACRO_DEFUN_VOID(name, argdecls, args/
++LISP_MACRO_DEFUN_VOID	c-src/emacs/src/lisp.h	/^LISP_MACRO_DEFUN_VOID (CHECK_LIST_CONS, (Lisp_Obje/
++LISP_MACRO_DEFUN_VOID	c-src/emacs/src/lisp.h	/^LISP_MACRO_DEFUN_VOID (CHECK_TYPE,$/
++LISP_MACRO_DEFUN_VOID	c-src/emacs/src/lisp.h	/^LISP_MACRO_DEFUN_VOID (SET_SYMBOL_VAL,$/
++Lisp_Marker	c-src/emacs/src/lisp.h	1978
++Lisp_Misc_Any	c-src/emacs/src/lisp.h	1971
++Lisp_Misc	c-src/emacs/src/lisp.h	2212
++Lisp_Misc	c-src/emacs/src/lisp.h	458
++Lisp_Misc_Finalizer	c-src/emacs/src/lisp.h	491
++Lisp_Misc_Float	c-src/emacs/src/lisp.h	494
++Lisp_Misc_Free	c-src/emacs/src/lisp.h	487
++Lisp_Misc_Limit	c-src/emacs/src/lisp.h	496
++Lisp_Misc_Marker	c-src/emacs/src/lisp.h	488
++Lisp_Misc_Overlay	c-src/emacs/src/lisp.h	489
++Lisp_Misc_Save_Value	c-src/emacs/src/lisp.h	490
++Lisp_Misc_Type	c-src/emacs/src/lisp.h	485
++Lisp_Object	c-src/emacs/src/lisp.h	567
++Lisp_Object	c-src/emacs/src/lisp.h	577
++Lisp_Objfwd	c-src/emacs/src/lisp.h	2294
++Lisp_Overlay	c-src/emacs/src/lisp.h	2021
++Lisp_Save_Type	c-src/emacs/src/lisp.h	2064
++Lisp_Save_Value	c-src/emacs/src/lisp.h	2110
++Lisp_String	c-src/emacs/src/lisp.h	466
++Lisp_Sub_Char_Table	c-src/emacs/src/lisp.h	1606
++Lisp_Subr	c-src/emacs/src/lisp.h	1670
++Lisp_suffixes	c-src/etags.c	589
++Lisp_Symbol	c-src/emacs/src/lisp.h	454
++Lisp_Symbol	c-src/emacs/src/lisp.h	654
++\lisp	tex-src/texinfo.tex	/^\\def\\lisp{\\aboveenvbreak$/
++Lisp_Type	c-src/emacs/src/lisp.h	451
++Lisp_Vector	c-src/emacs/src/lisp.h	1369
++Lisp_Vectorlike	c-src/emacs/src/lisp.h	472
++lispy_accent_codes	c-src/emacs/src/keyboard.c	4634
++lispy_accent_keys	c-src/emacs/src/keyboard.c	4741
++lispy_drag_n_drop_names	c-src/emacs/src/keyboard.c	5181
++lispy_function_keys	c-src/emacs/src/keyboard.c	4768
++lispy_function_keys	c-src/emacs/src/keyboard.c	5065
++lispy_kana_keys	c-src/emacs/src/keyboard.c	5026
++lispy_modifier_list	c-src/emacs/src/keyboard.c	/^lispy_modifier_list (int modifiers)$/
++lispy_multimedia_keys	c-src/emacs/src/keyboard.c	4962
++lispy_wheel_names	c-src/emacs/src/keyboard.c	5174
++list2i	c-src/emacs/src/lisp.h	/^list2i (EMACS_INT x, EMACS_INT y)$/
++list3i	c-src/emacs/src/lisp.h	/^list3i (EMACS_INT x, EMACS_INT y, EMACS_INT w)$/
++list4i	c-src/emacs/src/lisp.h	/^list4i (EMACS_INT x, EMACS_INT y, EMACS_INT w, EMA/
++LISTCONTENTSBUTTON	objc-src/PackInsp.m	48
++LISTCONTENTS	objc-src/PackInsp.m	39
++list	c-src/emacs/src/gmalloc.c	186
++LISTDESCRIPTIONBUTTON	objc-src/PackInsp.m	49
++ListEdit	pyt-src/server.py	/^class ListEdit(Frame):$/
++list	merc-src/accumulator.m	/^:- import_module list.$/
++list-tags	el-src/emacs/lisp/progmodes/etags.el	/^(defun list-tags (file &optional _next-match)$/
++list-tags-function	el-src/emacs/lisp/progmodes/etags.el	/^(defvar list-tags-function nil$/
++list_to_ord_set	prol-src/ordsets.prolog	/^list_to_ord_set(List, Set) :-$/
++LL_Assert/p	ada-src/2ataspri.adb	/^   procedure LL_Assert (B : Boolean; M : String) i/
++LL_Assert/p	ada-src/2ataspri.ads	/^   procedure LL_Assert (B : Boolean; M : String);$/
++L_LE	y-src/parse.c	25
++LL_Task_Procedure_Access/t	ada-src/2ataspri.ads	/^   type LL_Task_Procedure_Access is access procedu/
++LL_Task_Procedure_Access/t	ada-src/etags-test-for.ada	/^   type LL_Task_Procedure_Access is access procedu/
++LL_Wrapper/p	ada-src/2ataspri.adb	/^   procedure LL_Wrapper (T : TCB_Ptr);$/
++LL_Wrapper/p	ada-src/2ataspri.adb	/^   procedure LL_Wrapper (T : TCB_Ptr) is$/
++LL_Wrapper/p	ada-src/etags-test-for.ada	/^   procedure LL_Wrapper (T : TCB_Ptr);$/
++L_NE	y-src/parse.c	26
++lno	c-src/etags.c	223
++/lnormalize	ps-src/rfc1245.ps	/^\/lnormalize { $/
++loadContentsOf	objc-src/PackInsp.m	/^-loadContentsOf:(const char *)type inTable:(HashTa/
++loadImage	objc-src/PackInsp.m	/^-loadImage$/
++loadKeyValuesFrom	objc-src/PackInsp.m	/^-loadKeyValuesFrom:(const char *)type inTable:(Has/
++load	objc-src/PackInsp.m	/^-load$/
++loadPORManager	php-src/lce_functions.php	/^  function &loadPORManager()$/
++local_if_set	c-src/emacs/src/lisp.h	2338
++LOCALIZE_ARCH	objc-src/PackInsp.m	/^#define LOCALIZE_ARCH(s)	NXLoadLocalizedStringFrom/
++LOCALIZE	objc-src/PackInsp.m	/^#define LOCALIZE(s)		NXLoadLocalizedStringFromTabl/
++Locate	pas-src/common.pas	/^function Locate; (*($/
++location	cp-src/clheir.hpp	33
++location	cp-src/clheir.hpp	/^    location() { }$/
++LOCK_ALIGNED_BLOCKS	c-src/emacs/src/gmalloc.c	/^#define LOCK_ALIGNED_BLOCKS()				\\$/
++LOCK_ALIGNED_BLOCKS	c-src/emacs/src/gmalloc.c	/^#define LOCK_ALIGNED_BLOCKS()$/
++LOCK	c-src/emacs/src/gmalloc.c	/^#define LOCK()					\\$/
++LOCK	c-src/emacs/src/gmalloc.c	/^#define LOCK()$/
++Lock/t	ada-src/2ataspri.ads	/^   type Lock is$/
++Lock/t	ada-src/2ataspri.ads	/^   type Lock is private;$/
++\loggingall	tex-src/texinfo.tex	/^\\def\\loggingall{\\tracingcommands2 \\tracingstats2 $/
++LONG_TYPE_SIZE	y-src/cccp.y	95
++LOOKING_AT	c-src/etags.c	/^#define LOOKING_AT(cp, kw)  \/* kw is the keyword, /
++LOOKING_AT_NOCASE	c-src/etags.c	/^#define LOOKING_AT_NOCASE(cp, kw) \/* the keyword i/
++lookup_call	merc-src/accumulator.m	/^:- pred lookup_call(accu_goal_store::in, accu_goal/
++LOOKUP	objc-src/PackInsp.m	176
++LOOKUP	objc-src/PackInsp.m	/^#define LOOKUP(key, notfound)	([table isKey:key] ?/
++lookup	y-src/cccp.y	/^lookup (name, len, hash)$/
++LOOP_ON_INPUT_LINES	c-src/etags.c	/^#define LOOP_ON_INPUT_LINES(file_pointer, line_buf/
++\losespace	tex-src/texinfo.tex	/^\\def\\losespace #1{#1}$/
++lowcase	c-src/etags.c	/^#define lowcase(c)	tolower (CHAR (c))$/
++\lowercaseenumerate	tex-src/texinfo.tex	/^\\def\\lowercaseenumerate{%$/
++LowerCaseNmStr	pas-src/common.pas	/^function LowerCaseNmStr; (*($/
++/L	ps-src/rfc1245.ps	/^\/L { $/
++/L	ps-src/rfc1245.ps	/^\/L \/M \/N \/O \/P \/Q \/R \/S \/T \/U \/V \/W \/X \/Y \/Z \/brac/
++L_RANGE	y-src/parse.c	11
++LSH	y-src/cccp.c	16
++\l	tex-src/texinfo.tex	/^\\def\\l#1{{\\li #1}\\null}		% $/
++LTGT	cp-src/MDiagArray2.h	144
++LTGT	cp-src/MDiagArray2.h	35
++LTGT	cp-src/MDiagArray2.h	39
++LTGT	cp-src/MDiagArray2.h	42
++Lua_functions	c-src/etags.c	/^Lua_functions (FILE *inf)$/
++Lua_help	c-src/etags.c	600
++LUASRC	make-src/Makefile	/^LUASRC=allegro.lua$/
++Lua_suffixes	c-src/etags.c	598
++lucid_event_type_list_p	c-src/emacs/src/keyboard.c	/^lucid_event_type_list_p (Lisp_Object object)$/
++L_VAR	y-src/parse.c	12
++\lvvmode	tex-src/texinfo.tex	/^\\def\\lvvmode{\\vbox to 0pt{}}$/
++mabort	c-src/emacs/src/gmalloc.c	/^mabort (enum mcheck_status status)$/
++mach_host_self	c-src/machsyscalls.h	/^SYSCALL (mach_host_self, -29,$/
++Machine_Exceptions/t	ada-src/2ataspri.ads	/^   type Machine_Exceptions is new Interfaces.C.POS/
++Machin_T/b	ada-src/waroquiers.ada	/^  protected body Machin_T is$/
++Machin_T/t	ada-src/etags-test-for.ada	/^  protected Machin_T is$/
++Machin_T/t	ada-src/etags-test-for.ada	/^  protected type Machin_T is$/
++Machin_T/t	ada-src/waroquiers.ada	/^  protected type Machin_T is$/
++mach_msg_trap	c-src/machsyscalls.h	/^SYSCALL (mach_msg_trap, -25,$/
++mach_reply_port	c-src/machsyscalls.h	/^SYSCALL (mach_reply_port, -26,$/
++mach_task_self	c-src/machsyscalls.h	/^SYSCALL (mach_task_self, -28,$/
++mach_thread_self	c-src/machsyscalls.h	/^SYSCALL (mach_thread_self, -27,$/
++MAGENTA	cp-src/screen.hpp	17
++MAGICBYTE	c-src/emacs/src/gmalloc.c	1856
++magic	c-src/emacs/src/gmalloc.c	1863
++MAGICFREE	c-src/emacs/src/gmalloc.c	1855
++MAGICWORD	c-src/emacs/src/gmalloc.c	1854
++maintaining.info	make-src/Makefile	/^maintaining.info: maintaining.texi$/
++\majorheading	tex-src/texinfo.tex	/^\\def\\majorheading{\\parsearg\\majorheadingzzz}$/
++\majorheadingzzz	tex-src/texinfo.tex	/^\\def\\majorheadingzzz #1{%$/
++make-abbrev-table	c-src/abbrev.c	/^DEFUN ("make-abbrev-table", Fmake_abbrev_table, Sm/
++make_coor	prol-src/natded.prolog	/^make_coor(s(_),Alpha,Sem1,Sem2,Alpha@Sem1@Sem2).$/
++make_C_tag	c-src/etags.c	/^make_C_tag (bool isfun)$/
++make_ctrl_char	c-src/emacs/src/keyboard.c	/^make_ctrl_char (int c)$/
++MakeDispose	pyt-src/server.py	/^    def MakeDispose(self):$/
++Makefile_filenames	c-src/etags.c	603
++Makefile_help	c-src/etags.c	605
++Makefile_targets	c-src/etags.c	/^Makefile_targets (FILE *inf)$/
++make_fixnum_or_float	c-src/emacs/src/lisp.h	/^#define make_fixnum_or_float(val) \\$/
++make_formatted_string	c-src/emacs/src/lisp.h	/^extern Lisp_Object make_formatted_string (char *, /
++make_lisp_ptr	c-src/emacs/src/lisp.h	/^make_lisp_ptr (void *ptr, enum Lisp_Type type)$/
++make_lisp_symbol	c-src/emacs/src/lisp.h	/^make_lisp_symbol (struct Lisp_Symbol *sym)$/
++make_lispy_event	c-src/emacs/src/keyboard.c	/^make_lispy_event (struct input_event *event)$/
++make_lispy_focus_in	c-src/emacs/src/keyboard.c	/^make_lispy_focus_in (Lisp_Object frame)$/
++make_lispy_focus_out	c-src/emacs/src/keyboard.c	/^make_lispy_focus_out (Lisp_Object frame)$/
++make_lispy_movement	c-src/emacs/src/keyboard.c	/^make_lispy_movement (struct frame *frame, Lisp_Obj/
++make_lispy_position	c-src/emacs/src/keyboard.c	/^make_lispy_position (struct frame *f, Lisp_Object /
++make_lispy_switch_frame	c-src/emacs/src/keyboard.c	/^make_lispy_switch_frame (Lisp_Object frame)$/
++MAKE	make-src/Makefile	/^MAKE:=$(MAKE) --no-print-directory$/
++make_number	c-src/emacs/src/lisp.h	/^#  define make_number(n) lisp_h_make_number (n)$/
++make_pointer_integer	c-src/emacs/src/lisp.h	/^make_pointer_integer (void *p)$/
++make_scroll_bar_position	c-src/emacs/src/keyboard.c	/^make_scroll_bar_position (struct input_event *ev, /
++MakeSitelist	pyt-src/server.py	/^    def MakeSitelist(self, master):$/
++MAKESRC	make-src/Makefile	/^MAKESRC=Makefile$/
++make_tag	c-src/etags.c	/^make_tag (const char *name, 	\/* tag name, or NULL /
++make_uninit_sub_char_table	c-src/emacs/src/lisp.h	/^make_uninit_sub_char_table (int depth, int min_cha/
++make_uninit_vector	c-src/emacs/src/lisp.h	/^make_uninit_vector (ptrdiff_t size)$/
++malloc_atfork_handler_child	c-src/emacs/src/gmalloc.c	/^malloc_atfork_handler_child (void)$/
++malloc_atfork_handler_parent	c-src/emacs/src/gmalloc.c	/^malloc_atfork_handler_parent (void)$/
++malloc_atfork_handler_prepare	c-src/emacs/src/gmalloc.c	/^malloc_atfork_handler_prepare (void)$/
++malloc	c-src/emacs/src/gmalloc.c	1715
++malloc	c-src/emacs/src/gmalloc.c	64
++malloc	c-src/emacs/src/gmalloc.c	68
++malloc	c-src/emacs/src/gmalloc.c	/^extern void *malloc (size_t size) ATTRIBUTE_MALLOC/
++_malloc	c-src/emacs/src/gmalloc.c	/^_malloc (size_t size)$/
++malloc	c-src/emacs/src/gmalloc.c	/^malloc (size_t size)$/
++malloc_enable_thread	c-src/emacs/src/gmalloc.c	/^malloc_enable_thread (void)$/
++__malloc_extra_blocks	c-src/emacs/src/gmalloc.c	381
++MALLOCFLOOD	c-src/emacs/src/gmalloc.c	1857
++mallochook	c-src/emacs/src/gmalloc.c	/^mallochook (size_t size)$/
++malloc_info	c-src/emacs/src/gmalloc.c	167
++malloc_initialize_1	c-src/emacs/src/gmalloc.c	/^malloc_initialize_1 (void)$/
++__malloc_initialize	c-src/emacs/src/gmalloc.c	/^__malloc_initialize (void)$/
++__malloc_initialized	c-src/emacs/src/gmalloc.c	379
++_malloc_internal	c-src/emacs/src/gmalloc.c	/^_malloc_internal (size_t size)$/
++_malloc_internal_nolock	c-src/emacs/src/gmalloc.c	/^_malloc_internal_nolock (size_t size)$/
++_malloc_mutex	c-src/emacs/src/gmalloc.c	517
++_malloc_thread_enabled_p	c-src/emacs/src/gmalloc.c	519
++man manpage	make-src/Makefile	/^man manpage: etags.1.man$/
++/manualpapersize	ps-src/rfc1245.ps	/^\/manualpapersize {$/
++MANY	c-src/emacs/src/lisp.h	2833
++mao	c-src/h.h	101
++map	c-src/emacs/src/keyboard.c	8748
++map	merc-src/accumulator.m	/^:- import_module map.$/
++mapping	html-src/algrthms.html	/^Mapping the Channel Symbols$/
++mapsyn	prol-src/natded.prolog	/^mapsyn(A\/B,AM\/BM):-$/
++map_word	prol-src/natded.prolog	/^map_word([[_]|Ws],Exp):-$/
++MARKERP	c-src/emacs/src/lisp.h	/^# define MARKERP(x) lisp_h_MARKERP (x)$/
++mark_kboards	c-src/emacs/src/keyboard.c	/^mark_kboards (void)$/
++\math	tex-src/texinfo.tex	/^\\def\\math#1{\\implicitmath #1\\implicitmath}$/
++MAX_ALLOCA	c-src/emacs/src/lisp.h	4556
++max_args	c-src/emacs/src/lisp.h	1686
++maxargs	c-src/emacs/src/lisp.h	2831
++max	c.c	/^__attribute__ ((always_inline)) max (int a, int b)/
++max	c.c	/^max (int a, int b)$/
++max	cp-src/conway.cpp	/^#define max(x,y)  ((x > y) ? x : y)$/
++max	c-src/emacs/src/lisp.h	58
++max	c-src/emacs/src/lisp.h	/^#define max(a, b) ((a) > (b) ? (a) : (b))$/
++MAX_ENCODED_BYTES	c-src/emacs/src/keyboard.c	2254
++MAX_HASH_VALUE	c-src/etags.c	2329
++max_num_directions	cp-src/clheir.hpp	31
++max_num_generic_objects	cp-src/clheir.cpp	9
++MAXPATHLEN	c-src/etags.c	115
++/max	ps-src/rfc1245.ps	/^\/max {2 copy lt {exch} if pop} bind def$/
++MAX_WORD_LENGTH	c-src/etags.c	2327
++maybe_gc	c-src/emacs/src/lisp.h	/^maybe_gc (void)$/
++maybe	merc-src/accumulator.m	/^:- import_module maybe.$/
++MAYBEREL	y-src/parse.y	/^#define MAYBEREL(p) (*(p)=='[' && (isdigit((p)[1])/
++MBYTES	objc-src/PackInsp.m	59
++Mcccp	y-src/cccp.y	/^main ()$/
++Mc	cp-src/c.C	/^int main (void) { my_function0(0); my_function1(1)/
++mcCSC	cp-src/c.C	6
++mcheck	c-src/emacs/src/gmalloc.c	/^mcheck (void (*func) (enum mcheck_status))$/
++MCHECK_DISABLED	c-src/emacs/src/gmalloc.c	285
++MCHECK_FREE	c-src/emacs/src/gmalloc.c	287
++MCHECK_HEAD	c-src/emacs/src/gmalloc.c	288
++MCHECK_OK	c-src/emacs/src/gmalloc.c	286
++mcheck_status	c-src/emacs/src/gmalloc.c	283
++MCHECK_TAIL	c-src/emacs/src/gmalloc.c	289
++mcheck_used	c-src/emacs/src/gmalloc.c	2012
++Mconway.cpp	cp-src/conway.cpp	/^void main(void)$/
++mdbcomp	merc-src/accumulator.m	/^:- import_module mdbcomp.$/
++MDiagArray2	cp-src/MDiagArray2.h	78
++MDiagArray2	cp-src/MDiagArray2.h	/^  MDiagArray2 (const Array<T>& a) : DiagArray2<T> /
++MDiagArray2	cp-src/MDiagArray2.h	/^  MDiagArray2 (const DiagArray2<T>& a) : DiagArray/
++MDiagArray2	cp-src/MDiagArray2.h	/^  MDiagArray2 (const MDiagArray2<T>& a) : DiagArra/
++MDiagArray2	cp-src/MDiagArray2.h	/^  MDiagArray2 (int r, int c, const T& val) : DiagA/
++MDiagArray2	cp-src/MDiagArray2.h	/^  MDiagArray2 (int r, int c) : DiagArray2<T> (r, c/
++MDiagArray2	cp-src/MDiagArray2.h	/^  MDiagArray2 (T *d, int r, int c) : DiagArray2<T>/
++~MDiagArray2	cp-src/MDiagArray2.h	/^  ~MDiagArray2 (void) { }$/
++MDiagArray2	cp-src/MDiagArray2.h	/^  MDiagArray2 (void) : DiagArray2<T> () { }$/
++me_22a	lua-src/test.lua	/^   function test.me_22a(one, two)$/
++me22b	lua-src/test.lua	/^   local function test.me22b (one)$/
++memalign	c-src/emacs/src/gmalloc.c	/^memalign (size_t alignment, size_t size)$/
++member_lessthan_goalid	merc-src/accumulator.m	/^:- pred member_lessthan_goalid(accu_goal_store::in/
++member	prol-src/natded.prolog	/^member(X,[X|_]).$/
++memclear	c-src/emacs/src/lisp.h	/^memclear (void *p, ptrdiff_t nbytes)$/
++menu_bar_item	c-src/emacs/src/keyboard.c	/^menu_bar_item (Lisp_Object key, Lisp_Object item, /
++menu_bar_items	c-src/emacs/src/keyboard.c	/^menu_bar_items (Lisp_Object old)$/
++menu_bar_items_index	c-src/emacs/src/keyboard.c	7369
++menu_bar_items_vector	c-src/emacs/src/keyboard.c	7368
++menu_bar_one_keymap_changed_items	c-src/emacs/src/keyboard.c	7363
++menu_item_eval_property_1	c-src/emacs/src/keyboard.c	/^menu_item_eval_property_1 (Lisp_Object arg)$/
++menu_item_eval_property	c-src/emacs/src/keyboard.c	/^menu_item_eval_property (Lisp_Object sexpr)$/
++menu_separator_name_p	c-src/emacs/src/keyboard.c	/^menu_separator_name_p (const char *label)$/
++\menu	tex-src/texinfo.tex	/^\\long\\def\\menu #1\\end menu{}$/
++Metags	c-src/etags.c	/^main (int argc, char **argv)$/
++metasource	c-src/etags.c	198
++Mfail	cp-src/fail.C	/^main()$/
++min_args	c-src/emacs/src/lisp.h	1686
++min_char	c-src/emacs/src/lisp.h	1621
++min	cp-src/conway.cpp	/^#define min(x,y)  ((x > y) ? y : x)$/
++min	c-src/emacs/src/gmalloc.c	/^#define min(a, b) ((a) < (b) ? (a) : (b))$/
++min	c-src/emacs/src/lisp.h	57
++min	c-src/emacs/src/lisp.h	/^#define min(a, b) ((a) < (b) ? (a) : (b))$/
++MIN_HASH_VALUE	c-src/etags.c	2328
++/min	ps-src/rfc1245.ps	/^\/min {2 copy gt {exch} if pop} bind def$/
++minus	cp-src/functions.cpp	/^void Date::minus ( int days , int month , int year/
++\minus	tex-src/texinfo.tex	/^\\def\\minus{$-$}$/
++MIN_WORD_LENGTH	c-src/etags.c	2326
++MISCP	c-src/emacs/src/lisp.h	/^# define MISCP(x) lisp_h_MISCP (x)$/
++miti	html-src/softwarelibero.html	/^Sfatiamo alcuni miti$/
++Mkai-test.pl	perl-src/kai-test.pl	/^package main;$/
++modifier_names	c-src/emacs/src/keyboard.c	6319
++modifier_symbols	c-src/emacs/src/keyboard.c	6327
++modify_event_symbol	c-src/emacs/src/keyboard.c	/^modify_event_symbol (ptrdiff_t symbol_num, int mod/
++module_class_method	ruby-src/test.rb	/^    def ModuleExample.module_class_method$/
++ModuleExample	ruby-src/test.rb	/^module ModuleExample$/
++module_instance_method	ruby-src/test.rb	/^    def module_instance_method$/
++more_aligned_int	c.c	165
++morecore_nolock	c-src/emacs/src/gmalloc.c	/^morecore_nolock (size_t size)$/
++morecore_recursing	c-src/emacs/src/gmalloc.c	604
++More_Lisp_Bits	c-src/emacs/src/lisp.h	801
++more=	ruby-src/test1.ru	/^                :more$/
++MOST_NEGATIVE_FIXNUM	c-src/emacs/src/lisp.h	835
++MOST_POSITIVE_FIXNUM	c-src/emacs/src/lisp.h	834
++mouse_syms	c-src/emacs/src/keyboard.c	4627
++move	cp-src/clheir.cpp	/^void agent::move(int direction)$/
++MOVE	c-src/sysdep.h	/^#define MOVE(x,y)	movl x, y$/
++MoveLayerAfter	lua-src/allegro.lua	/^function MoveLayerAfter (this_one)$/
++MoveLayerBefore	lua-src/allegro.lua	/^function MoveLayerBefore (this_one)$/
++MoveLayerBottom	lua-src/allegro.lua	/^function MoveLayerBottom ()$/
++MoveLayerTop	lua-src/allegro.lua	/^function MoveLayerTop ()$/
++mprobe	c-src/emacs/src/gmalloc.c	/^mprobe (void *ptr)$/
++/M	ps-src/rfc1245.ps	/^\/M {newpath moveto} bind def$/
++MSDOS	c-src/etags.c	100
++MSDOS	c-src/etags.c	106
++MSDOS	c-src/etags.c	107
++MSDOS	c-src/etags.c	110
++msgid	php-src/lce_functions.php	/^      function msgid($line, $class)$/
++MSGSEL	f-src/entry.for	/^       ENTRY  MSGSEL ( TYPE )$/
++MSGSEL	f-src/entry.strange	/^       ENTRY  MSGSEL ( TYPE )$/
++MSGSEL	f-src/entry.strange_suffix	/^       ENTRY  MSGSEL ( TYPE )$/
++msgstr	php-src/lce_functions.php	/^      function msgstr($line, $class)$/
++/ms	ps-src/rfc1245.ps	/^\/ms { $/
++mstats	c-src/emacs/src/gmalloc.c	308
++Mtest1.go	go-src/test1.go	1
++Mtest1.go	go-src/test1.go	/^func main() {$/
++Mtest.go	go-src/test.go	1
++Mtest.go	go-src/test.go	/^func main() {$/
++Mtest.rs	rs-src/test.rs	/^fn main() {$/
++mtg	html-src/software.html	/^MTG$/
++mt	prol-src/natded.prolog	/^mt:-$/
++multibyte	c-src/emacs/src/regex.h	403
++MULTI_LETTER_MOD	c-src/emacs/src/keyboard.c	6231
++MULTI_LETTER_MOD	c-src/emacs/src/keyboard.c	6764
++MULTI_LETTER_MOD	c-src/emacs/src/keyboard.c	/^#define MULTI_LETTER_MOD(BIT, NAME, LEN)			\\$/
++MULTI_LETTER_MOD	c-src/emacs/src/keyboard.c	/^#define MULTI_LETTER_MOD(BIT, NAME, LEN)		\\$/
++multi_line	c-src/etags.c	267
++Mx.cc	cp-src/x.cc	/^main(int argc, char *argv[])$/
++\mylbrace	tex-src/texinfo.tex	/^\\def\\mylbrace {{\\tt \\char '173}}$/
++mypi	forth-src/test-forth.fth	/^synonym mypi fconst$/
++my_printf	c.c	/^my_printf (void *my_object, const char *my_format,/
++\myrbrace	tex-src/texinfo.tex	/^\\def\\myrbrace {{\\tt \\char '175}}$/
++my_struct	c.c	226
++my_struct	c-src/h.h	91
++my_typedef	c.c	228
++my_typedef	c-src/h.h	93
++name	c-src/emacs/src/keyboard.c	7241
++name	c-src/emacs/src/lisp.h	1808
++name	c-src/emacs/src/lisp.h	3144
++name	c-src/emacs/src/lisp.h	682
++name	c-src/etags.c	192
++name	c-src/etags.c	218
++name	c-src/etags.c	2271
++name	c-src/etags.c	261
++name	c-src/getopt.h	76
++name	c-src/getopt.h	78
++named	c-src/etags.c	2505
++NameHasChar	pas-src/common.pas	/^function NameHasChar; (* (TheName : NameString; Th/
++name	perl-src/htlmify-cystic	357
++namestringequal	pas-src/common.pas	/^function namestringequal;(*(var Name1,Name2 : Name/
++NameStringLess	pas-src/common.pas	/^function NameStringLess;(*(var Name1,Name2 : NameS/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {#1}{Function}%$/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {#1}{Macro}%$/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {#1}{Special Form}%$/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {#1}{User Option}%$/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {#1}{Variable}%$/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {#2}{#1}\\deftpargs{#3}\\endgrou/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {#2}{#1}\\defunargs{#3}\\endgrou/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {#2}{#1}\\defvarargs{#3}\\endgro/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {#2}{\\defcvtype{} of #1}%$/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {#2}{\\defoptype{} on #1}%$/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {#2}{Instance Variable of #1}%/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {#2}{Method on #1}%$/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {\\code{#1} #2}{Function}%$/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {\\code{#1} #2}{Variable}%$/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {\\code{#2} #3}{#1}%$/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {\\code{#2} #3}{#1}$/
++NAME	y-src/cccp.c	8
++name	y-src/cccp.y	113
++name	y-src/cccp.y	43
++nargs	c-src/emacs/src/lisp.h	2987
++NATNUMP	c-src/emacs/src/lisp.h	/^NATNUMP (Lisp_Object x)$/
++/nbluet	ps-src/rfc1245.ps	/^\/nbluet 256 array def$/
++n	c-src/exit.c	28
++n	c-src/exit.strange_suffix	28
++NDEBUG	c-src/etags.c	88
++need_adjustment	c-src/emacs/src/lisp.h	1986
++\need	tex-src/texinfo.tex	/^\\def\\need{\\parsearg\\needx}$/
++\needx	tex-src/texinfo.tex	/^\\def\\needx#1{%$/
++NEG	y-src/parse.c	9
++neighbors	cp-src/clheir.hpp	59
++nelem	cp-src/Range.h	/^  int nelem (void) const { return rng_nelem; }$/
++nestlev	c-src/etags.c	2525
++\newcodeindex	tex-src/texinfo.tex	/^\\def\\newcodeindex #1{$/
++\newindex	tex-src/texinfo.tex	/^\\def\\newindex #1{$/
++NewLayer	lua-src/allegro.lua	/^function NewLayer (name, x, y, w, h)$/
++NewLayerSet	lua-src/allegro.lua	/^function NewLayerSet (name)$/
++newlb	c-src/etags.c	2930
++newlinepos	c-src/etags.c	2932
++NewNameString	pas-src/common.pas	/^procedure NewNameString; (* (var NSP: NameStringPo/
++new	objc-src/PackInsp.m	/^+new$/
++new	perl-src/htlmify-cystic	163
++new_tag	perl-src/htlmify-cystic	18
++newtextstring	pas-src/common.pas	/^function newtextstring; (*: TextString;*)$/
++next_alive	cp-src/conway.hpp	7
++next_almost_prime	c-src/emacs/src/lisp.h	/^extern EMACS_INT next_almost_prime (EMACS_INT) ATT/
++NEXT_ALMOST_PRIME_LIMIT	c-src/emacs/src/lisp.h	3573
++next	c.c	174
++next	c-src/emacs/src/gmalloc.c	164
++next	c-src/emacs/src/gmalloc.c	188
++next	c-src/emacs/src/gmalloc.c	198
++next	c-src/emacs/src/keyboard.c	7246
++next	c-src/emacs/src/keyboard.c	861
++next	c-src/emacs/src/lisp.h	1848
++next	c-src/emacs/src/lisp.h	2009
++next	c-src/emacs/src/lisp.h	2037
++next	c-src/emacs/src/lisp.h	2192
++next	c-src/emacs/src/lisp.h	3028
++next	c-src/emacs/src/lisp.h	3134
++next	c-src/emacs/src/lisp.h	700
++next	c-src/etags.c	203
++next-file	el-src/emacs/lisp/progmodes/etags.el	/^(defun next-file (&optional initialize novisit)$/
++next-file-list	el-src/emacs/lisp/progmodes/etags.el	/^(defvar next-file-list nil$/
++next_free	c-src/emacs/src/lisp.h	1851
++nextfree	c-src/emacs/src/lisp.h	3029
++\next	tex-src/texinfo.tex	/^\\def\\next##1{}\\next}$/
++next_weak	c-src/emacs/src/lisp.h	1875
++next	y-src/cccp.y	42
++NE	y-src/parse.c	6
++nfree	c-src/emacs/src/gmalloc.c	150
++/ngrayt	ps-src/rfc1245.ps	/^\/ngrayt 256 array def$/
++/ngreent	ps-src/rfc1245.ps	/^\/ngreent 256 array def$/
++NIL_IS_ZERO	c-src/emacs/src/lisp.h	1515
++NILP	c-src/emacs/src/lisp.h	/^# define NILP(x) lisp_h_NILP (x)$/
++nl	c-src/etags.c	2521
++NmStrToErrStr	pas-src/common.pas	/^function NmStrToErrStr;(*($/
++NmStrToInteger	pas-src/common.pas	/^function NmStrToInteger; (* (Str : NameString) : i/
++\nm	tex-src/testenv.tex	/^\\newcommand{\\nm}[2]{\\nomenclature{#1}{#2}}$/
++no_argument	c-src/getopt.h	89
++nocase_tail	c-src/etags.c	/^nocase_tail (const char *cp)$/
++node	c-src/etags.c	225
++noderef	tex-src/texinfo.tex	/^\\appendixnoderef %$/
++node_st	c-src/etags.c	214
++\node	tex-src/texinfo.tex	/^\\def\\node{\\ENVcheck\\parsearg\\nodezzz}$/
++\nodexxx[	tex-src/texinfo.tex	/^\\def\\nodexxx[#1,#2]{\\gdef\\lastnode{#1}}$/
++\nodezzz	tex-src/texinfo.tex	/^\\def\\nodezzz#1{\\nodexxx [#1,]}$/
++\nofillexdent	tex-src/texinfo.tex	/^\\def\\nofillexdent{\\parsearg\\nofillexdentyyy}$/
++\nofillexdentyyy	tex-src/texinfo.tex	/^\\def\\nofillexdentyyy #1{{\\advance \\leftskip by -\\e/
++nofonts%	tex-src/texinfo.tex	/^{\\chapternofonts%$/
++nofonts	tex-src/texinfo.tex	/^{\\indexnofonts$/
++no_lang_help	c-src/etags.c	707
++none_help	c-src/etags.c	703
++NONPOINTER_BITS	c-src/emacs/src/lisp.h	78
++NONPOINTER_BITS	c-src/emacs/src/lisp.h	80
++NONSRCS	make-src/Makefile	/^NONSRCS=entry.strange lists.erl clheir.hpp.gz$/
++\normalbackslash	tex-src/texinfo.tex	/^\\def\\normalbackslash{{\\tt\\rawbackslashxx}}$/
++\normalcaret	tex-src/texinfo.tex	/^\\def\\normalcaret{^}$/
++\normaldoublequote	tex-src/texinfo.tex	/^\\def\\normaldoublequote{"}$/
++\normalgreater	tex-src/texinfo.tex	/^\\def\\normalgreater{>}$/
++normalize_fresh	prol-src/natded.prolog	/^normalize_fresh(M,N):-$/
++normalize	prol-src/natded.prolog	/^normalize(M,MNorm):-$/
++/normalize	ps-src/rfc1245.ps	/^\/normalize {$/
++normalize_tree	prol-src/natded.prolog	/^normalize_tree(tree(Rule,Syn:Sem,Trees),$/
++normalize_trees	prol-src/natded.prolog	/^normalize_trees([],[]).$/
++\normalless	tex-src/texinfo.tex	/^\\def\\normalless{<}$/
++\normalplus	tex-src/texinfo.tex	/^\\def\\normalplus{+}$/
++\normaltilde	tex-src/texinfo.tex	/^\\def\\normaltilde{~}$/
++\normalunderscore	tex-src/texinfo.tex	/^\\def\\normalunderscore{_}$/
++\normalverticalbar	tex-src/texinfo.tex	/^\\def\\normalverticalbar{|}$/
++nosave	pyt-src/server.py	/^    def nosave(self):$/
++no_sub	c-src/emacs/src/regex.h	387
++notag2	c-src/dostorture.c	26
++notag2	c-src/torture.c	26
++notag4	c-src/dostorture.c	45
++notag4	c-src/torture.c	45
++not_bol	c-src/emacs/src/regex.h	391
++/.notdef	ps-src/rfc1245.ps	/^\/.notdef \/.notdef \/.notdef \/.notdef \/.notdef \/.not/
++/.notdef	ps-src/rfc1245.ps	/^\/.notdef \/.notdef \/.notdef \/.notdef \/space \/exclam/
++not_eol	c-src/emacs/src/regex.h	394
++NOTEQUAL	y-src/cccp.c	13
++no	tex-src/texinfo.tex	/^\\global\\advance \\appendixno by 1 \\message{Appendix/
++no	tex-src/texinfo.tex	/^\\ifnum\\secno=0 Appendix\\xreftie'char\\the\\appendixn/
++no	tex-src/texinfo.tex	/^\\newcount \\appendixno  \\appendixno = `\\@$/
++no.\the\secno	tex-src/texinfo.tex	/^\\else \\ifnum \\subsecno=0 Section\\xreftie'char\\the\\/
++no.\the\secno.\the\subsecno	tex-src/texinfo.tex	/^Section\\xreftie'char\\the\\appendixno.\\the\\secno.\\th/
++no.\the\secno.\the\subsecno.\the\subsubsecno	tex-src/texinfo.tex	/^Section\\xreftie'char\\the\\appendixno.\\the\\secno.\\th/
++notinname	c-src/etags.c	/^#define notinname(c)	(_nin[CHAR (c)]) \/* c is not /
++not_single_kboard_state	c-src/emacs/src/keyboard.c	/^not_single_kboard_state (KBOARD *kboard)$/
++npending	c-src/emacs/src/keyboard.c	7244
++/N	ps-src/rfc1245.ps	/^\/N { $/
++/nredt	ps-src/rfc1245.ps	/^\/nredt 256 array def$/
++\nsbot	tex-src/texinfo.tex	/^\\def\\nsbot{\\vbox$/
++\nstop	tex-src/texinfo.tex	/^\\def\\nstop{\\vbox$/
++/Ntilde	ps-src/rfc1245.ps	/^\/Ntilde \/Odieresis \/Udieresis \/aacute \/agrave \/aci/
++ntool_bar_items	c-src/emacs/src/keyboard.c	7974
++NULL_PTR	y-src/cccp.y	63
++NULL	y-src/cccp.y	51
++\numberedsec	tex-src/texinfo.tex	/^\\outer\\def\\numberedsec{\\parsearg\\seczzz}$/
++\numberedsubsec	tex-src/texinfo.tex	/^\\outer\\def\\numberedsubsec{\\parsearg\\numberedsubsec/
++\numberedsubseczzz	tex-src/texinfo.tex	/^\\def\\numberedsubseczzz #1{\\seccheck{subsection}%$/
++\numberedsubsubsec	tex-src/texinfo.tex	/^\\outer\\def\\numberedsubsubsec{\\parsearg\\numberedsub/
++\numberedsubsubseczzz	tex-src/texinfo.tex	/^\\def\\numberedsubsubseczzz #1{\\seccheck{subsubsecti/
++numberKeys	objcpp-src/SimpleCalc.M	/^- numberKeys:sender$/
++number_len	c-src/etags.c	/^static int number_len (long) ATTRIBUTE_CONST;$/
++/numbersign	ps-src/rfc1245.ps	/^\/numbersign \/dollar \/percent \/ampersand \/quotesing/
++numbervars	prol-src/natded.prolog	/^numbervars(X):-$/
++num_columns	cp-src/conway.cpp	16
++\numericenumerate	tex-src/texinfo.tex	/^\\def\\numericenumerate{%$/
++num_input_events	c-src/emacs/src/keyboard.c	210
++NUM_MOD_NAMES	c-src/emacs/src/keyboard.c	6325
++numOfChannels	cp-src/c.C	1
++NUM_RECENT_KEYS	c-src/emacs/src/keyboard.c	91
++num_regs	c-src/emacs/src/regex.h	430
++num_rows	cp-src/conway.cpp	15
++NUMSTATS	objc-src/PackInsp.h	36
++nvars	c-src/emacs/src/lisp.h	3140
++Objc_help	c-src/etags.c	613
++OBJCPPSRC	make-src/Makefile	/^OBJCPPSRC=SimpleCalc.H SimpleCalc.M$/
++OBJCSRC	make-src/Makefile	/^OBJCSRC=Subprocess.h Subprocess.m PackInsp.h PackI/
++Objc_suffixes	c-src/etags.c	609
++objdef	c-src/etags.c	2484
++object	c-src/emacs/src/lisp.h	2128
++object_registry	cp-src/clheir.cpp	10
++OBJS	make-src/Makefile	/^OBJS=${GETOPTOBJS} ${REGEXOBJS} ${CHECKOBJS}$/
++objtag	c-src/etags.c	2453
++objvar	c-src/emacs/src/lisp.h	2297
++obstack_chunk_alloc	y-src/parse.y	47
++obstack_chunk_free	y-src/parse.y	48
++ocatseen	c-src/etags.c	2477
++/ocircumflex	ps-src/rfc1245.ps	/^\/ocircumflex \/odieresis \/otilde \/uacute \/ugrave \/u/
++octave_MDiagArray2_h	cp-src/MDiagArray2.h	29
++octave_Range_h	cp-src/Range.h	24
++\oddfooting	tex-src/texinfo.tex	/^\\def\\oddfooting{\\parsearg\\oddfootingxxx}$/
++\oddheading	tex-src/texinfo.tex	/^\\def\\oddheading{\\parsearg\\oddheadingxxx}$/
++oediff	make-src/Makefile	/^oediff: OTAGS ETAGS ${infiles}$/
++offset	c-src/emacs/src/lisp.h	2305
++offset	c-src/emacs/src/lisp.h	2365
++offset	c-src/etags.c	2494
++oignore	c-src/etags.c	2483
++oimplementation	c-src/etags.c	2474
++oinbody	c-src/etags.c	2478
++ok	objc-src/PackInsp.m	/^-ok:sender$/
++ok_to_echo_at_next_pause	c-src/emacs/src/keyboard.c	159
++old_value	c-src/emacs/src/lisp.h	2980
++omethodcolon	c-src/etags.c	2481
++omethodparm	c-src/etags.c	2482
++omethodsign	c-src/etags.c	2479
++omethodtag	c-src/etags.c	2480
++\onepageout	tex-src/texinfo.tex	/^\\def\\onepageout#1{\\hoffset=\\normaloffset$/
++onone	c-src/etags.c	2472
++oparenseen	c-src/etags.c	2476
++OPENBUTTON	objc-src/PackInsp.m	47
++\opencontents	tex-src/texinfo.tex	/^\\def\\opencontents{\\openout \\contentsfile = \\jobnam/
++open-dribble-file	c-src/emacs/src/keyboard.c	/^DEFUN ("open-dribble-file", Fopen_dribble_file, So/
++\openindices	tex-src/texinfo.tex	/^\\def\\openindices{%$/
++openInWorkspace	objc-src/PackInsp.m	/^static void openInWorkspace(const char *filename)$/
++open	objc-src/PackInsp.m	/^-open:sender$/
++operationKeys	objcpp-src/SimpleCalc.M	/^- operationKeys:sender$/
++operator+	cp-src/c.C	/^  A operator+(A& a) {};$/
++operator+	cp-src/c.C	/^const A& A::operator+(const A&) { }$/
++operator -	cp-src/c.C	/^void operator -(int, int) {}$/
++operator+	cp-src/c.C	/^void operator+(int, int) {}$/
++operator =	cp-src/functions.cpp	/^Date & Date::operator = ( Date d ){$/
++operator +=	cp-src/functions.cpp	/^Date & Date::operator += ( int days ){$/
++operator -=	cp-src/functions.cpp	/^Date & Date::operator -= ( int days ){$/
++operator ++	cp-src/functions.cpp	/^Date & Date::operator ++ ( void ){$/
++operator --	cp-src/functions.cpp	/^Date & Date::operator -- ( void ){$/
++operator -	cp-src/functions.cpp	/^int Date::operator - ( Date d ){$/
++operator <	cp-src/functions.cpp	/^int Date::operator < ( Date d ) {$/
++operator ==	cp-src/functions.cpp	/^int Date::operator == ( Date d ) {$/
++operator >	cp-src/functions.cpp	/^int Date::operator > ( Date d ) {$/
++operator >>	cp-src/functions.cpp	/^istream& operator >> ( istream &i, Date & dd ){$/
++operator <<	cp-src/functions.cpp	/^ostream& operator <<  ( ostream &c, Date d ) {$/
++operator =	cp-src/MDiagArray2.h	/^  MDiagArray2<T>& operator = (const MDiagArray2<T>/
++OperatorFun	c-src/h.h	88
++operator int	cp-src/c.C	/^void operator int(int, int) {}$/
++operator int	cp-src/fail.C	/^			   operator int() const {return x;}$/
++operator MArray2<T>	cp-src/MDiagArray2.h	/^  operator MArray2<T> () const$/
++operator	y-src/cccp.y	438
++\opnr	tex-src/texinfo.tex	/^\\def\\opnr{{\\sf\\char`\\(}} \\def\\clnr{{\\sf\\char`\\)}} /
++opparsebody\Edefop\defopx\defopheader\defoptype	tex-src/texinfo.tex	/^\\defopparsebody\\Edefop\\defopx\\defopheader\\defoptyp/
++oprotocol	c-src/etags.c	2473
++/O	ps-src/rfc1245.ps	/^\/O {closepath} bind def$/
++optional_argument	c-src/getopt.h	91
++option	c-src/getopt.h	73
++OPTIONS	make-src/Makefile	/^OPTIONS=--members --declarations --regex=@regexfil/
++opvarparsebody\Edefcv\defcvx\defcvarheader\defcvtype	tex-src/texinfo.tex	/^\\defopvarparsebody\\Edefcv\\defcvx\\defcvarheader\\def/
++ord_add_element	prol-src/ordsets.prolog	/^ord_add_element([], Element, [Element]).$/
++ord_del_element	prol-src/ordsets.prolog	/^ord_del_element([], _, []).$/
++ord_disjoint	prol-src/ordsets.prolog	/^ord_disjoint(Set1, Set2) :-$/
++/ordfeminine	ps-src/rfc1245.ps	/^\/ordfeminine \/ordmasculine \/.notdef \/ae \/oslash \/q/
++ord_intersection2	prol-src/ordsets.prolog	/^ord_intersection2(1, [Set|Sets], Set0, Sets0) :- !/
++ord_intersection3	prol-src/ordsets.prolog	/^ord_intersection3(<, _, Set1, Head2, Tail2, Inters/
++ord_intersection4	prol-src/ordsets.prolog	/^ord_intersection4(<, _, Set1, Head2, Tail2, Inters/
++ord_intersection	prol-src/ordsets.prolog	/^ord_intersection([], _, []).$/
++ord_intersection	prol-src/ordsets.prolog	/^ord_intersection([], Set2, [], Set2).$/
++ord_intersection	prol-src/ordsets.prolog	/^ord_intersection(Sets, Intersection) :- $/
++ord_intersect	prol-src/ordsets.prolog	/^ord_intersect([Head1|Tail1], [Head2|Tail2]) :-$/
++ord_member	prol-src/ordsets.prolog	/^ord_member(X, [E|Es]) :-$/
++ord_seteq	prol-src/ordsets.prolog	/^ord_seteq(Set1, Set2) :-$/
++ord_setproduct	prol-src/ordsets.prolog	/^ord_setproduct([], _, []).$/
++ord_subset	prol-src/ordsets.prolog	/^ord_subset([], _).$/
++ord_subtract	prol-src/ordsets.prolog	/^ord_subtract(Set1, Set2, Union) :-$/
++ord_symdiff	prol-src/ordsets.prolog	/^ord_symdiff([], Set2, Set2).$/
++ord_union4	prol-src/ordsets.prolog	/^ord_union4(<, Head, Set1, Head2, Tail2, [Head|Unio/
++ord_union_all	prol-src/ordsets.prolog	/^ord_union_all(1, [Set|Sets], Set, Sets) :- !.$/
++ord_union	prol-src/ordsets.prolog	/^ord_union(Set1, Set2, Union) :-$/
++ord_union	prol-src/ordsets.prolog	/^ord_union([], Union) :- !, Union = [].$/
++OR	y-src/cccp.c	10
++oss	html-src/softwarelibero.html	/^Il movimento open source$/
++otagseen	c-src/etags.c	2475
++OTAGS	make-src/Makefile	/^OTAGS: oetags ${SRCS} srclist$/
++/Otilde	ps-src/rfc1245.ps	/^\/Otilde \/OE \/oe \/endash \/emdash \/quotedblleft \/quo/
++output_file	perl-src/htlmify-cystic	35
++output_files	perl-src/htlmify-cystic	32
++outputtable	html-src/algrthms.html	/^Output$/
++outputTime	cp-src/c.C	9
++outsyn	prol-src/natded.prolog	/^outsyn(['Any'],_).$/
++OVERLAYP	c-src/emacs/src/lisp.h	/^OVERLAYP (Lisp_Object x)$/
++Overview	tex-src/gzip.texi	/^@node Overview, Sample, Copying, Top$/
++PackageInspector	objc-src/PackInsp.h	/^@interface PackageInspector:WMInspector$/
++\pagebody	tex-src/texinfo.tex	/^\\def\\pagebody#1{\\vbox to\\pageheight{\\boxmaxdepth=\\/
++/pagedimen	ps-src/rfc1245.ps	/^\/pagedimen { $/
++pagesize	c-src/emacs/src/gmalloc.c	1703
++\pagesofar	tex-src/texinfo.tex	/^\\def\\pagesofar{\\unvbox\\partialpage %$/
++\page	tex-src/texinfo.tex	/^   \\def\\page{%$/
++\page	tex-src/texinfo.tex	/^\\def\\page{\\par\\vfill\\supereject}$/
++pair	merc-src/accumulator.m	/^:- import_module pair.$/
++/papersize	ps-src/rfc1245.ps	/^\/papersize {$/
++/paragraph	ps-src/rfc1245.ps	/^\/paragraph \/germandbls \/registered \/copyright \/tra/
++/parenright	ps-src/rfc1245.ps	/^\/parenright \/asterisk \/plus \/comma \/hyphen \/period/
++parent	c-src/emacs/src/keyboard.c	8745
++parent	c-src/emacs/src/lisp.h	1590
++\parseargline	tex-src/texinfo.tex	/^\\def\\parseargline{\\begingroup \\obeylines \\parsearg/
++\parsearg	tex-src/texinfo.tex	/^\\def\\parsearg #1{\\let\\next=#1\\begingroup\\obeylines/
++\parseargx	tex-src/texinfo.tex	/^\\def\\parseargx{%$/
++parse_c_expression	y-src/cccp.y	/^parse_c_expression (string)$/
++parse_cgi	prol-src/natded.prolog	/^parse_cgi(TokenList,KeyVals):-$/
++parse_error	y-src/parse.y	82
++parse_escape	y-src/cccp.y	/^parse_escape (string_ptr)$/
++parseFromVars	php-src/lce_functions.php	/^      function parseFromVars($prefix)$/
++parse_hash	y-src/parse.y	64
++parse_menu_item	c-src/emacs/src/keyboard.c	/^parse_menu_item (Lisp_Object item, int inmenubar)$/
++parse_modifiers	c-src/emacs/src/keyboard.c	/^parse_modifiers (Lisp_Object symbol)$/
++parse_modifiers_uncached	c-src/emacs/src/keyboard.c	/^parse_modifiers_uncached (Lisp_Object symbol, ptrd/
++parse_number	y-src/cccp.y	/^parse_number (olen)$/
++parse	prol-src/natded.prolog	/^parse(Ws,Cat):-$/
++parse_return_error	y-src/cccp.y	70
++parse_return	y-src/parse.y	74
++parse_solitary_modifier	c-src/emacs/src/keyboard.c	/^parse_solitary_modifier (Lisp_Object symbol)$/
++parse_tool_bar_item	c-src/emacs/src/keyboard.c	/^parse_tool_bar_item (Lisp_Object key, Lisp_Object /
++parse_tree	merc-src/accumulator.m	/^:- import_module parse_tree.$/
++Pascal_functions	c-src/etags.c	/^Pascal_functions (FILE *inf)$/
++Pascal_help	c-src/etags.c	621
++Pascal_suffixes	c-src/etags.c	619
++PASSRC	make-src/Makefile	/^PASSRC=common.pas$/
++pat	c-src/etags.c	262
++pattern	c-src/etags.c	260
++p	c-src/emacs/src/lisp.h	4673
++p	c-src/emacs/src/lisp.h	4679
++pD	c-src/emacs/src/lisp.h	165
++pD	c-src/emacs/src/lisp.h	167
++pD	c-src/emacs/src/lisp.h	169
++pD	c-src/emacs/src/lisp.h	171
++pdlcount	c-src/emacs/src/lisp.h	3046
++PDT	c-src/h.h	/^  Date 04 May 87 235311 PDT (Mon)$/
++pending-delete-mode	el-src/TAGTEST.EL	/^(defalias 'pending-delete-mode 'delete-selection-m/
++pending_funcalls	c-src/emacs/src/keyboard.c	4377
++pending_signals	c-src/emacs/src/keyboard.c	80
++/periodcentered	ps-src/rfc1245.ps	/^\/periodcentered \/quotesinglbase \/quotedblbase \/per/
++Perl_functions	c-src/etags.c	/^Perl_functions (FILE *inf)$/
++Perl_help	c-src/etags.c	630
++Perl_interpreters	c-src/etags.c	628
++PERLSRC	make-src/Makefile	/^PERLSRC=htlmify-cystic yagrip.pl kai-test.pl mirro/
++Perl_suffixes	c-src/etags.c	626
++p/f	ada-src/etags-test-for.ada	/^function p ("p");$/
++p/f	ada-src/etags-test-for.ada	/^   function p pragma Import (C,$/
++pfatal	c-src/etags.c	/^pfatal (const char *s1)$/
++pfdset	c-src/h.h	57
++pfnote	c-src/etags.c	/^pfnote (char *name, bool is_func, char *linestart,/
++/PF	ps-src/rfc1245.ps	/^\/PF { $/
++PHP_functions	c-src/etags.c	/^PHP_functions (FILE *inf)$/
++PHP_help	c-src/etags.c	639
++PHPSRC	make-src/Makefile	/^PHPSRC=lce_functions.php ptest.php sendmail.php$/
++PHP_suffixes	c-src/etags.c	637
++pI	c-src/emacs/src/lisp.h	106
++pI	c-src/emacs/src/lisp.h	94
++pI	c-src/emacs/src/lisp.h	99
++\pindex	tex-src/texinfo.tex	/^\\def\\pindex {\\pgindex}$/
++pinned	c-src/emacs/src/lisp.h	679
++Pkg1/b	ada-src/etags-test-for.ada	/^package body Pkg1 is$/
++Pkg1/b	ada-src/waroquiers.ada	/^package body Pkg1 is$/
++Pkg1_Func1/f	ada-src/etags-test-for.ada	/^  function Pkg1_Func1 return Boolean;$/
++Pkg1_Func1/f	ada-src/etags-test-for.ada	/^function  Pkg1_Func1 return Boolean is$/
++Pkg1_Func1/f	ada-src/etags-test-for.ada	/^  function Pkg1_Func1 return Boolean is separate;$/
++Pkg1_Func1/f	ada-src/waroquiers.ada	/^  function Pkg1_Func1 return Boolean;$/
++Pkg1_Func1/f	ada-src/waroquiers.ada	/^function  Pkg1_Func1 return Boolean is$/
++Pkg1_Func1/f	ada-src/waroquiers.ada	/^  function Pkg1_Func1 return Boolean is separate;$/
++Pkg1_Func2/f	ada-src/etags-test-for.ada	/^  function Pkg1_Func2 (Ijk : Integer; Z : Integer)/
++Pkg1_Func2/f	ada-src/waroquiers.ada	/^  function Pkg1_Func2 (Ijk : Integer; Z : Integer)/
++Pkg1_Pkg1/b	ada-src/etags-test-for.ada	/^package body Pkg1_Pkg1 is$/
++Pkg1_Pkg1/b	ada-src/etags-test-for.ada	/^  package body Pkg1_Pkg1 is separate;$/
++Pkg1_Pkg1/b	ada-src/waroquiers.ada	/^package body Pkg1_Pkg1 is$/
++Pkg1_Pkg1/b	ada-src/waroquiers.ada	/^  package body Pkg1_Pkg1 is separate;$/
++Pkg1_Pkg1_Proc1/p	ada-src/etags-test-for.ada	/^    procedure Pkg1_Pkg1_Proc1;$/
++Pkg1_Pkg1_Proc1/p	ada-src/etags-test-for.ada	/^  procedure Pkg1_Pkg1_Proc1 is$/
++Pkg1_Pkg1_Proc1/p	ada-src/waroquiers.ada	/^    procedure Pkg1_Pkg1_Proc1;$/
++Pkg1_Pkg1_Proc1/p	ada-src/waroquiers.ada	/^  procedure Pkg1_Pkg1_Proc1 is$/
++Pkg1_Pkg1/s	ada-src/etags-test-for.ada	/^  package Pkg1_Pkg1 is$/
++Pkg1_Pkg1/s	ada-src/waroquiers.ada	/^  package Pkg1_Pkg1 is$/
++Pkg1_Proc1/p	ada-src/etags-test-for.ada	/^  procedure Pkg1_Proc1;$/
++Pkg1_Proc1/p	ada-src/etags-test-for.ada	/^  procedure Pkg1_Proc1 is$/
++Pkg1_Proc1/p	ada-src/waroquiers.ada	/^  procedure Pkg1_Proc1;$/
++Pkg1_Proc1/p	ada-src/waroquiers.ada	/^  procedure Pkg1_Proc1 is$/
++Pkg1_Proc2/p	ada-src/etags-test-for.ada	/^  procedure Pkg1_Proc2 (I : Integer);$/
++Pkg1_Proc2/p	ada-src/etags-test-for.ada	/^  procedure Pkg1_Proc2 (I : Integer) is$/
++Pkg1_Proc2/p	ada-src/waroquiers.ada	/^  procedure Pkg1_Proc2 (I : Integer);$/
++Pkg1_Proc2/p	ada-src/waroquiers.ada	/^  procedure Pkg1_Proc2 (I : Integer) is$/
++Pkg1/s	ada-src/etags-test-for.ada	/^package Pkg1 is$/
++Pkg1/s	ada-src/waroquiers.ada	/^package Pkg1 is$/
++plainc	c-src/etags.c	2934
++plain_C_entries	c-src/etags.c	/^plain_C_entries (FILE *inf)$/
++plain_C_suffixes	c-src/etags.c	643
++\plainsecheading	tex-src/texinfo.tex	/^\\def\\plainsecheading #1{\\secheadingi {#1}}$/
++plist	c-src/emacs/src/lisp.h	2040
++plist	c-src/emacs/src/lisp.h	697
++plus	cp-src/functions.cpp	/^void Date::plus ( int days , int month , int year /
++plus	go-src/test1.go	5
++plusvalseq	prol-src/natded.prolog	/^plusvalseq([]) --> [].$/
++pMd	c-src/emacs/src/lisp.h	150
++pMd	c-src/emacs/src/lisp.h	155
++pMu	c-src/emacs/src/lisp.h	151
++pMu	c-src/emacs/src/lisp.h	156
++p_next	c-src/etags.c	258
++POEntryAD	php-src/lce_functions.php	29
++POEntry	php-src/lce_functions.php	105
++POEntry	php-src/lce_functions.php	/^      function POEntry()$/
++pointer	c-src/emacs/src/lisp.h	2125
++point	forth-src/test-forth.fth	/^BEGIN-STRUCTURE point \\ create the named structure/
++\point	tex-src/texinfo.tex	/^\\def\\point{$\\star$}$/
++poll_for_input_1	c-src/emacs/src/keyboard.c	/^poll_for_input_1 (void)$/
++poll_for_input	c-src/emacs/src/keyboard.c	/^poll_for_input (struct atimer *timer)$/
++poll_suppress_count	c-src/emacs/src/keyboard.c	1908
++poll_suppress_count	c-src/emacs/src/lisp.h	3047
++poll_timer	c-src/emacs/src/keyboard.c	1915
++popclass_above	c-src/etags.c	/^popclass_above (int bracelev)$/
++pop_kboard	c-src/emacs/src/keyboard.c	/^pop_kboard (void)$/
++pop-tag-mark	el-src/emacs/lisp/progmodes/etags.el	/^(defalias 'pop-tag-mark 'xref-pop-marker-stack)$/
++POReader	php-src/lce_functions.php	163
++POReader	php-src/lce_functions.php	/^      function POReader($domain, $filename)$/
++PORManager	php-src/lce_functions.php	498
++PORManager	php-src/lce_functions.php	/^      function PORManager()$/
++position_to_Time	c-src/emacs/src/keyboard.c	/^position_to_Time (ptrdiff_t pos)$/
++posix_memalign	c-src/emacs/src/gmalloc.c	/^posix_memalign (void **memptr, size_t alignment, s/
++posn-at-point	c-src/emacs/src/keyboard.c	/^DEFUN ("posn-at-point", Fposn_at_point, Sposn_at_p/
++posn-at-x-y	c-src/emacs/src/keyboard.c	/^DEFUN ("posn-at-x-y", Fposn_at_x_y, Sposn_at_x_y, /
++possible_sum_sign	y-src/cccp.y	/^#define possible_sum_sign(a, b, sum) ((((a) ^ (b))/
++PostControls	pyt-src/server.py	/^    def PostControls(self):$/
++post	pyt-src/server.py	/^    def post(self):$/
++POSTSCRIPTFLAGS	make-src/Makefile	/^POSTSCRIPTFLAGS=--language=none --regex='#\/[^ \\t{]/
++pot_etags_version	c-src/etags.c	81
++pp1	c-src/dostorture.c	/^int pp1($/
++pp1	c-src/torture.c	/^int pp1($/
++pp2	c-src/dostorture.c	/^pp2$/
++pp2	c-src/torture.c	/^pp2$/
++pp3	c-src/dostorture.c	/^pp3(int bar)$/
++pp3	c-src/torture.c	/^pp3(int bar)$/
++pp_bas_cat	prol-src/natded.prolog	/^pp_bas_cat(Cat):-$/
++pp_cat	prol-src/natded.prolog	/^pp_cat(Syn:Sem):-$/
++pp_exp	prol-src/natded.prolog	/^pp_exp('NIL'):-$/
++pp_exps	prol-src/natded.prolog	/^pp_exps([]).$/
++pp_html_fitch_tree	prol-src/natded.prolog	/^pp_html_fitch_tree(tree(der,Root,[ders(Words)]),M,/
++pp_html_table_fitch_tree	prol-src/natded.prolog	/^pp_html_table_fitch_tree(T):-$/
++pp_html_table_tree	prol-src/natded.prolog	/^pp_html_table_tree(T):-$/
++pp_html_tree	prol-src/natded.prolog	/^pp_html_tree(ass(Syn,V,'$VAR'(N))):-$/
++pp_html_trees	prol-src/natded.prolog	/^pp_html_trees([T|Ts],N,M):-$/
++pp_lam_bracket	prol-src/natded.prolog	/^pp_lam_bracket(A^B):-$/
++pp_lam_paren	prol-src/natded.prolog	/^pp_lam_paren(Var^Alpha):-$/
++pp_lam	prol-src/natded.prolog	/^pp_lam(Var^Alpha):-$/
++pp_paren	prol-src/natded.prolog	/^pp_paren(C):-$/
++pp_rule	prol-src/natded.prolog	/^pp_rule(fe):-write('\/E').$/
++/P	ps-src/rfc1245.ps	/^\/P { $/
++pp_syn_back	prol-src/natded.prolog	/^pp_syn_back(A\/B):-$/
++pp_syn_paren	prol-src/natded.prolog	/^pp_syn_paren(A\/B):-$/
++pp_syn	prol-src/natded.prolog	/^pp_syn(A\/B):-$/
++pp_tree	prol-src/natded.prolog	/^pp_tree(T):-$/
++pp_trees	prol-src/natded.prolog	/^pp_trees([T|Ts],Column):-$/
++pp_word_list	prol-src/natded.prolog	/^pp_word_list([]).$/
++pp_word_list_rest	prol-src/natded.prolog	/^pp_word_list_rest([]).$/
++pp_word	prol-src/natded.prolog	/^pp_word(W):-$/
++Pre_Call_State/t	ada-src/2ataspri.ads	/^   type Pre_Call_State is new System.Address;$/
++.PRECIOUS	make-src/Makefile	/^.PRECIOUS: ETAGS CTAGS ETAGS16 CTAGS16 ETAGS17 CTA/
++predicate	c-src/emacs/src/lisp.h	2307
++prev	c.c	175
++prev	c-src/emacs/src/gmalloc.c	165
++prev	c-src/emacs/src/gmalloc.c	189
++prev	c-src/emacs/src/lisp.h	2191
++\primary	tex-src/texinfo.tex	/^\\def\\primary #1{\\line{#1\\hfil}}$/
++PrintAdd	go-src/test1.go	/^func (n intNumber) PrintAdd() {$/
++PrintAdd	go-src/test1.go	/^func (s str) PrintAdd() {$/
++printClassification	php-src/lce_functions.php	/^      function printClassification()$/
++\printedmanual	tex-src/texinfo.tex	/^\\def\\printedmanual{\\ignorespaces #5}%$/
++\printedmanual	tex-src/texinfo.tex	/^section ``\\printednodename'' in \\cite{\\printedmanu/
++\printednodename	tex-src/texinfo.tex	/^\\def\\printednodename{\\ignorespaces #1}%$/
++\printednodename	tex-src/texinfo.tex	/^\\def\\printednodename{\\ignorespaces #3}%$/
++print_help	c-src/etags.c	/^print_help (argument *argbuffer)$/
++\printindex	tex-src/texinfo.tex	/^\\def\\printindex{\\parsearg\\doprintindex}$/
++print_language_names	c-src/etags.c	/^print_language_names (void)$/
++printmax_t	c-src/emacs/src/lisp.h	148
++printmax_t	c-src/emacs/src/lisp.h	153
++\print	tex-src/texinfo.tex	/^\\def\\print{\\leavevmode\\lower.1ex\\hbox to 1em{\\hfil/
++\print	tex-src/texinfo.tex	/^\\def\\print{\\realbackslash print}$/
++PRINT_UNDOCUMENTED_OPTIONS_HELP	c-src/etags.c	804
++print_version	c-src/etags.c	/^print_version (void)$/
++Private	objc-src/Subprocess.m	/^@interface Subprocess(Private)$/
++Private_T/b	ada-src/etags-test-for.ada	/^    task body Private_T is$/
++Private_T/b	ada-src/waroquiers.ada	/^    task body Private_T is$/
++Private_T/k	ada-src/etags-test-for.ada	/^    task Private_T;$/
++Private_T/k	ada-src/waroquiers.ada	/^    task Private_T;$/
++Private_T/p	ada-src/etags-test-for.ada	/^    procedure Private_T;$/
++Private_T/p	ada-src/etags-test-for.ada	/^    procedure Private_T is$/
++Private_T/p	ada-src/waroquiers.ada	/^    procedure Private_T;$/
++Private_T/p	ada-src/waroquiers.ada	/^    procedure Private_T is$/
++Private_T/t	ada-src/etags-test-for.ada	/^  type Private_T is$/
++Private_T/t	ada-src/etags-test-for.ada	/^  type Private_T is private;$/
++Private_T/t	ada-src/waroquiers.ada	/^  type Private_T is$/
++Private_T/t	ada-src/waroquiers.ada	/^  type Private_T is private;$/
++Problems	tex-src/gzip.texi	/^@node Problems, Concept Index, Tapes, Top$/
++proc	c-src/h.h	87
++process_file	c-src/etags.c	/^process_file (FILE *fh, char *fn, language *lang)$/
++process_file_name	c-src/etags.c	/^process_file_name (char *file, language *lang)$/
++PROCESSP	c-src/emacs/src/lisp.h	/^PROCESSP (Lisp_Object a)$/
++process_pending_signals	c-src/emacs/src/keyboard.c	/^process_pending_signals (void)$/
++process_special_events	c-src/emacs/src/keyboard.c	/^process_special_events (void)$/
++process_tool_bar_item	c-src/emacs/src/keyboard.c	/^process_tool_bar_item (Lisp_Object key, Lisp_Objec/
++Proc/t	ada-src/2ataspri.ads	/^   type Proc is access procedure (Addr : System.Ad/
++prof	make-src/Makefile	/^prof: ETAGS$/
++prolog_atom	c-src/etags.c	/^prolog_atom (char *s, size_t pos)$/
++Prolog_functions	c-src/etags.c	/^Prolog_functions (FILE *inf)$/
++Prolog_help	c-src/etags.c	654
++prolog_pr	c-src/etags.c	/^prolog_pr (char *s, char *last)$/
++prolog_skip_comment	c-src/etags.c	/^prolog_skip_comment (linebuffer *plb, FILE *inf)$/
++Prolog_suffixes	c-src/etags.c	652
++PROLSRC	make-src/Makefile	/^PROLSRC=ordsets.prolog natded.prolog$/
++PROP	c-src/emacs/src/keyboard.c	8379
++PROP	c-src/emacs/src/keyboard.c	/^#define PROP(IDX) AREF (tool_bar_item_properties, /
++prop	c-src/etags.c	209
++PROTECT_MALLOC_STATE	c-src/emacs/src/gmalloc.c	/^#define PROTECT_MALLOC_STATE(PROT)	\/* empty *\/$/
++PROTECT_MALLOC_STATE	c-src/emacs/src/gmalloc.c	/^#define PROTECT_MALLOC_STATE(PROT) protect_malloc_/
++protect_malloc_state	c-src/emacs/src/gmalloc.c	/^protect_malloc_state (int protect_p)$/
++PRTPKG	f-src/entry.for	/^      LOGICAL FUNCTION PRTPKG ( SHORT, LONG, EXPL,/
++PRTPKG	f-src/entry.strange	/^      LOGICAL FUNCTION PRTPKG ( SHORT, LONG, EXPL,/
++PRTPKG	f-src/entry.strange_suffix	/^      LOGICAL FUNCTION PRTPKG ( SHORT, LONG, EXPL,/
++PSEUDO	c-src/sysdep.h	/^#define	PSEUDO(name, syscall_name, args)				      /
++PSEUDOVECSIZE	c-src/emacs/src/lisp.h	/^#define PSEUDOVECSIZE(type, nonlispfield)			\\$/
++PSEUDOVECTOR_AREA_BITS	c-src/emacs/src/lisp.h	818
++PSEUDOVECTOR_FLAG	c-src/emacs/src/lisp.h	774
++PSEUDOVECTORP	c-src/emacs/src/lisp.h	/^PSEUDOVECTORP (Lisp_Object a, int code)$/
++PSEUDOVECTOR_REST_BITS	c-src/emacs/src/lisp.h	813
++PSEUDOVECTOR_REST_MASK	c-src/emacs/src/lisp.h	814
++PSEUDOVECTOR_SIZE_BITS	c-src/emacs/src/lisp.h	808
++PSEUDOVECTOR_SIZE_MASK	c-src/emacs/src/lisp.h	809
++PSEUDOVECTOR_TYPEP	c-src/emacs/src/lisp.h	/^PSEUDOVECTOR_TYPEP (struct vectorlike_header *a, i/
++PS_functions	c-src/etags.c	/^PS_functions (FILE *inf)$/
++PS_help	c-src/etags.c	649
++PSSRC	make-src/Makefile	/^PSSRC=rfc1245.ps$/
++PS_suffixes	c-src/etags.c	647
++pthread_mutexattr_setprio_ceiling/f	ada-src/2ataspri.adb	/^   function pthread_mutexattr_setprio_ceiling$/
++pthread_mutexattr_setprotocol/f	ada-src/2ataspri.adb	/^   function pthread_mutexattr_setprotocol$/
++PTY_LENGTH	objc-src/Subprocess.m	21
++PTY_TEMPLATE	objc-src/Subprocess.m	20
++Public_T/t	ada-src/etags-test-for.ada	/^  type Public_T is$/
++Public_T/t	ada-src/waroquiers.ada	/^  type Public_T is$/
++purpose	c-src/emacs/src/lisp.h	1594
++pushclass_above	c-src/etags.c	/^pushclass_above (int bracelev, char *str, int len)/
++PUSH_C_STR	c-src/emacs/src/keyboard.c	/^#define PUSH_C_STR(str, listvar) \\$/
++PUSH_HANDLER	c-src/emacs/src/lisp.h	/^#define PUSH_HANDLER(c, tag_ch_val, handlertype)	\\/
++push_kboard	c-src/emacs/src/keyboard.c	/^push_kboard (struct kboard *k)$/
++put_entries	c-src/etags.c	/^put_entries (register node *np)$/
++PVEC_BOOL_VECTOR	c-src/emacs/src/lisp.h	787
++PVEC_BUFFER	c-src/emacs/src/lisp.h	788
++PVEC_CHAR_TABLE	c-src/emacs/src/lisp.h	796
++PVEC_COMPILED	c-src/emacs/src/lisp.h	795
++PVEC_FONT	c-src/emacs/src/lisp.h	798
++PVEC_FRAME	c-src/emacs/src/lisp.h	785
++PVEC_FREE	c-src/emacs/src/lisp.h	783
++PVEC_HASH_TABLE	c-src/emacs/src/lisp.h	789
++PVEC_NORMAL_VECTOR	c-src/emacs/src/lisp.h	782
++PVEC_OTHER	c-src/emacs/src/lisp.h	793
++PVEC_PROCESS	c-src/emacs/src/lisp.h	784
++PVEC_SUB_CHAR_TABLE	c-src/emacs/src/lisp.h	797
++PVEC_SUBR	c-src/emacs/src/lisp.h	792
++PVEC_TERMINAL	c-src/emacs/src/lisp.h	790
++pvec_type	c-src/emacs/src/lisp.h	780
++PVEC_TYPE_MASK	c-src/emacs/src/lisp.h	819
++PVEC_WINDOW_CONFIGURATION	c-src/emacs/src/lisp.h	791
++PVEC_WINDOW	c-src/emacs/src/lisp.h	786
++p.x	forth-src/test-forth.fth	/^  1 CELLS +FIELD p.x    \\ A single cell filed name/
++\pxref	tex-src/texinfo.tex	/^\\def\\pxref#1{see \\xrefX[#1,,,,,,,]}$/
++p.y	forth-src/test-forth.fth	/^  1 CELLS +FIELD p.y    \\ A single cell field name/
++Python_functions	c-src/etags.c	/^Python_functions (FILE *inf)$/
++Python_help	c-src/etags.c	660
++Python_suffixes	c-src/etags.c	658
++PYTSRC	make-src/Makefile	/^PYTSRC=server.py$/
++quantizing	html-src/algrthms.html	/^Quantizing the Received$/
++questo	../c/c.web	34
++quiettest	make-src/Makefile	/^quiettest:$/
++quit_char	c-src/emacs/src/keyboard.c	192
++QUIT	c-src/emacs/src/lisp.h	3101
++QUITP	c-src/emacs/src/lisp.h	3112
++quit_throw_to_read_char	c-src/emacs/src/keyboard.c	/^quit_throw_to_read_char (bool from_signal)$/
++\quotation	tex-src/texinfo.tex	/^\\def\\quotation{%$/
++/quoteleft	ps-src/rfc1245.ps	/^\/quoteleft \/quoteright \/.notdef \/.notdef \/ydieresi/
++qux1	ruby-src/test1.ru	/^                :qux1)$/
++qux	ruby-src/test1.ru	/^    alias_method :qux, :tee, attr_accessor(:bogus)/
++qux=	ruby-src/test1.ru	/^      def qux=(tee)$/
++r0	c-src/sysdep.h	54
++r1	c-src/sysdep.h	55
++r_alloc	c-src/emacs/src/lisp.h	/^extern void *r_alloc (void **, size_t) ATTRIBUTE_A/
++Range	cp-src/Range.h	35
++Range	cp-src/Range.h	/^  Range (const Range& r)$/
++Range	cp-src/Range.h	/^  Range (double b, double l)$/
++Range	cp-src/Range.h	/^  Range (double b, double l, double i)$/
++Range	cp-src/Range.h	/^  Range (void)$/
++RANGED_INTEGERP	c-src/emacs/src/lisp.h	/^RANGED_INTEGERP (intmax_t lo, Lisp_Object x, intma/
++range_exp_list	y-src/parse.y	273
++range_exp	y-src/parse.y	269
++\rawbackslashxx	tex-src/texinfo.tex	/^\\def\\rawbackslashxx{\\indexbackslash}%$/
++\rawbackslashxx	tex-src/texinfo.tex	/^\\def\\rawbackslashxx{\\indexbackslash}% \\indexbacksl/
++raw_keybuf_count	c-src/emacs/src/keyboard.c	117
++raw_keybuf	c-src/emacs/src/keyboard.c	116
++rbtp	c.c	240
++RCSid	objc-src/PackInsp.m	30
++read1	ruby-src/test1.ru	/^    attr_reader :read1 , :read2; attr_writer :writ/
++read2	ruby-src/test1.ru	/^    attr_reader :read1 , :read2; attr_writer :writ/
++readable_events	c-src/emacs/src/keyboard.c	/^readable_events (int flags)$/
++READABLE_EVENTS_DO_TIMERS_NOW	c-src/emacs/src/keyboard.c	346
++READABLE_EVENTS_FILTER_EVENTS	c-src/emacs/src/keyboard.c	347
++READABLE_EVENTS_IGNORE_SQUEEZABLES	c-src/emacs/src/keyboard.c	348
++\readauxfile	tex-src/texinfo.tex	/^\\def\\readauxfile{%$/
++read_char	c-src/emacs/src/keyboard.c	/^read_char (int commandflag, Lisp_Object map,$/
++read_char_help_form_unwind	c-src/emacs/src/keyboard.c	/^read_char_help_form_unwind (void)$/
++read_char_minibuf_menu_prompt	c-src/emacs/src/keyboard.c	/^read_char_minibuf_menu_prompt (int commandflag,$/
++read_char_x_menu_prompt	c-src/emacs/src/keyboard.c	/^read_char_x_menu_prompt (Lisp_Object map,$/
++read	cp-src/conway.hpp	/^    char read() { return alive; }$/
++read_decoded_event_from_main_queue	c-src/emacs/src/keyboard.c	/^read_decoded_event_from_main_queue (struct timespe/
++read_event_from_main_queue	c-src/emacs/src/keyboard.c	/^read_event_from_main_queue (struct timespec *end_t/
++read_key_sequence_cmd	c-src/emacs/src/keyboard.c	232
++read-key-sequence	c-src/emacs/src/keyboard.c	/^DEFUN ("read-key-sequence", Fread_key_sequence, Sr/
++read_key_sequence	c-src/emacs/src/keyboard.c	/^read_key_sequence (Lisp_Object *keybuf, int bufsiz/
++read_key_sequence_remapped	c-src/emacs/src/keyboard.c	233
++read-key-sequence-vector	c-src/emacs/src/keyboard.c	/^DEFUN ("read-key-sequence-vector", Fread_key_seque/
++read_key_sequence_vs	c-src/emacs/src/keyboard.c	/^read_key_sequence_vs (Lisp_Object prompt, Lisp_Obj/
++readline	c-src/etags.c	/^readline (linebuffer *lbp, FILE *stream)$/
++readline_internal	c-src/etags.c	/^readline_internal (linebuffer *lbp, register FILE /
++Read_Lock/p	ada-src/2ataspri.adb	/^   procedure Read_Lock (L : in out Lock; Ceiling_V/
++Read_Lock/p	ada-src/2ataspri.ads	/^   procedure Read_Lock (L : in out Lock; Ceiling_V/
++read_menu_command	c-src/emacs/src/keyboard.c	/^read_menu_command (void)$/
++read	php-src/lce_functions.php	/^      function read()$/
++read_toc	perl-src/htlmify-cystic	/^sub read_toc ()$/
++ReadVacation	cp-src/functions.cpp	/^void ReadVacation ( char *filename ) {$/
++realloc	c-src/emacs/src/gmalloc.c	1716
++realloc	c-src/emacs/src/gmalloc.c	65
++realloc	c-src/emacs/src/gmalloc.c	69
++_realloc	c-src/emacs/src/gmalloc.c	/^_realloc (void *ptr, size_t size)$/
++realloc	c-src/emacs/src/gmalloc.c	/^realloc (void *ptr, size_t size)$/
++reallochook	c-src/emacs/src/gmalloc.c	/^reallochook (void *ptr, size_t size)$/
++_realloc_internal	c-src/emacs/src/gmalloc.c	/^_realloc_internal (void *ptr, size_t size)$/
++_realloc_internal_nolock	c-src/emacs/src/gmalloc.c	/^_realloc_internal_nolock (void *ptr, size_t size)$/
++RE_BACKSLASH_ESCAPE_IN_LISTS	c-src/emacs/src/regex.h	47
++RE_BK_PLUS_QM	c-src/emacs/src/regex.h	52
++RECC_ALNUM	c-src/emacs/src/regex.h	610
++RECC_ALPHA	c-src/emacs/src/regex.h	610
++RECC_ASCII	c-src/emacs/src/regex.h	617
++RECC_BLANK	c-src/emacs/src/regex.h	615
++RECC_CNTRL	c-src/emacs/src/regex.h	613
++RECC_DIGIT	c-src/emacs/src/regex.h	614
++RECC_ERROR	c-src/emacs/src/regex.h	609
++RECC_GRAPH	c-src/emacs/src/regex.h	611
++RECC_LOWER	c-src/emacs/src/regex.h	612
++RECC_MULTIBYTE	c-src/emacs/src/regex.h	616
++RECC_NONASCII	c-src/emacs/src/regex.h	616
++RECC_PRINT	c-src/emacs/src/regex.h	611
++RECC_PUNCT	c-src/emacs/src/regex.h	613
++RECC_SPACE	c-src/emacs/src/regex.h	615
++RECC_UNIBYTE	c-src/emacs/src/regex.h	617
++RECC_UPPER	c-src/emacs/src/regex.h	612
++RECC_WORD	c-src/emacs/src/regex.h	610
++RECC_XDIGIT	c-src/emacs/src/regex.h	614
++recent_keys	c-src/emacs/src/keyboard.c	100
++recent-keys	c-src/emacs/src/keyboard.c	/^DEFUN ("recent-keys", Frecent_keys, Srecent_keys, /
++recent_keys_index	c-src/emacs/src/keyboard.c	94
++RE_CHAR_CLASSES	c-src/emacs/src/regex.h	58
++RE_CONTEXT_INDEP_ANCHORS	c-src/emacs/src/regex.h	72
++RE_CONTEXT_INDEP_OPS	c-src/emacs/src/regex.h	80
++RE_CONTEXT_INVALID_OPS	c-src/emacs/src/regex.h	84
++record_asynch_buffer_change	c-src/emacs/src/keyboard.c	/^record_asynch_buffer_change (void)$/
++record_auto_save	c-src/emacs/src/keyboard.c	/^record_auto_save (void)$/
++record_char	c-src/emacs/src/keyboard.c	/^record_char (Lisp_Object c)$/
++record_menu_key	c-src/emacs/src/keyboard.c	/^record_menu_key (Lisp_Object c)$/
++record_single_kboard_state	c-src/emacs/src/keyboard.c	/^record_single_kboard_state ()$/
++record_xmalloc	c-src/emacs/src/lisp.h	/^extern void *record_xmalloc (size_t) ATTRIBUTE_ALL/
++recover_top_level_message	c-src/emacs/src/keyboard.c	138
++Rectangle.getPos	lua-src/test.lua	/^function Rectangle.getPos ()$/
++recursion-depth	c-src/emacs/src/keyboard.c	/^DEFUN ("recursion-depth", Frecursion_depth, Srecur/
++recursive_edit_1	c-src/emacs/src/keyboard.c	/^recursive_edit_1 (void)$/
++recursive-edit	c-src/emacs/src/keyboard.c	/^DEFUN ("recursive-edit", Frecursive_edit, Srecursi/
++recursive_edit_unwind	c-src/emacs/src/keyboard.c	/^recursive_edit_unwind (Lisp_Object buffer)$/
++RED	cp-src/screen.hpp	16
++RE_DEBUG	c-src/emacs/src/regex.h	161
++redirect	c-src/emacs/src/lisp.h	663
++RE_DOT_NEWLINE	c-src/emacs/src/regex.h	88
++RE_DOT_NOT_NULL	c-src/emacs/src/regex.h	92
++reduce	prol-src/natded.prolog	/^reduce((X^M)@N,L):-     % beta reduction$/
++reduce_subterm	prol-src/natded.prolog	/^reduce_subterm(M,M2):-$/
++RE_DUP_MAX	c-src/emacs/src/regex.h	253
++RE_DUP_MAX	c-src/emacs/src/regex.h	256
++/ReEncode	ps-src/rfc1245.ps	/^\/ReEncode { $/
++refreshPort	pyt-src/server.py	/^    def refreshPort(self):$/
++RE_FRUGAL	c-src/emacs/src/regex.h	147
++\ref	tex-src/texinfo.tex	/^\\def\\ref#1{\\xrefX[#1,,,,,,,]}$/
++\refx	tex-src/texinfo.tex	/^\\def\\refx#1#2{%$/
++REG_BADBR	c-src/emacs/src/regex.h	313
++REG_BADPAT	c-src/emacs/src/regex.h	305
++REG_BADRPT	c-src/emacs/src/regex.h	316
++REG_EBRACE	c-src/emacs/src/regex.h	312
++REG_EBRACK	c-src/emacs/src/regex.h	310
++REG_ECOLLATE	c-src/emacs/src/regex.h	306
++REG_ECTYPE	c-src/emacs/src/regex.h	307
++REG_EEND	c-src/emacs/src/regex.h	319
++REG_EESCAPE	c-src/emacs/src/regex.h	308
++REG_ENOSYS	c.c	279
++REG_ENOSYS	c-src/emacs/src/regex.h	297
++REG_EPAREN	c-src/emacs/src/regex.h	311
++REG_ERANGE	c-src/emacs/src/regex.h	314
++REG_ERANGEX	c-src/emacs/src/regex.h	322
++REG_ERPAREN	c-src/emacs/src/regex.h	321
++reg_errcode_t	c.c	279
++reg_errcode_t	c-src/emacs/src/regex.h	323
++REG_ESIZE	c-src/emacs/src/regex.h	320
++REG_ESPACE	c-src/emacs/src/regex.h	315
++REG_ESUBREG	c-src/emacs/src/regex.h	309
++regex	c-src/etags.c	219
++regexfile	make-src/Makefile	/^regexfile: Makefile$/
++_REGEX_H	c-src/emacs/src/regex.h	21
++REGEX	make-src/Makefile	/^REGEX=\/[ \\t]*DEFVAR_[A-Z_ \\t\\n(]+"\\([^"]+\\)"\/$/
++REGEXOBJS	make-src/Makefile	/^REGEXOBJS=regex.o$/
++regex.o	make-src/Makefile	/^regex.o: emacs\/src\/regex.c$/
++regexp	c-src/etags.c	256
++regexp	c-src/etags.c	268
++regex_tag_multiline	c-src/etags.c	/^regex_tag_multiline (void)$/
++regex_t	c-src/emacs/src/regex.h	416
++REG_EXTENDED	c-src/emacs/src/regex.h	263
++REG_ICASE	c-src/emacs/src/regex.h	267
++registerAction	objcpp-src/SimpleCalc.M	/^- registerAction:(SEL)action$/
++register_heapinfo	c-src/emacs/src/gmalloc.c	/^register_heapinfo (void)$/
++regmatch_t	c-src/emacs/src/regex.h	451
++REG_NEWLINE	c-src/emacs/src/regex.h	272
++REG_NOERROR	c-src/emacs/src/regex.h	300
++REG_NOMATCH	c-src/emacs/src/regex.h	301
++REG_NOSUB	c-src/emacs/src/regex.h	276
++REG_NOTBOL	c-src/emacs/src/regex.h	286
++REG_NOTEOL	c-src/emacs/src/regex.h	289
++regoff_t	c-src/emacs/src/regex.h	423
++regs_allocated	c-src/emacs/src/regex.h	379
++regs	cp-src/screen.cpp	16
++regs	c-src/etags.c	263
++regset	c-src/h.h	31
++REGS_FIXED	c-src/emacs/src/regex.h	378
++REGS_REALLOCATE	c-src/emacs/src/regex.h	377
++REGS_UNALLOCATED	c-src/emacs/src/regex.h	376
++reg_syntax_t	c-src/emacs/src/regex.h	43
++regular_top_level_message	c-src/emacs/src/keyboard.c	143
++rehash_size	c-src/emacs/src/lisp.h	1835
++rehash_threshold	c-src/emacs/src/lisp.h	1839
++RE_HAT_LISTS_NOT_NEWLINE	c-src/emacs/src/regex.h	96
++RE_INTERVALS	c-src/emacs/src/regex.h	101
++re_iswctype	c-src/emacs/src/regex.h	602
++relative_filename	c-src/etags.c	/^relative_filename (char *file, char *dir)$/
++=\relax	tex-src/texinfo.tex	/^\\let\\appendix=\\relax$/
++=\relax	tex-src/texinfo.tex	/^\\let\\chapter=\\relax$/
++=\relax	tex-src/texinfo.tex	/^\\let\\section=\\relax$/
++=\relax	tex-src/texinfo.tex	/^\\let\\subsection=\\relax$/
++=\relax	tex-src/texinfo.tex	/^\\let\\subsubsection=\\relax$/
++release distrib	make-src/Makefile	/^release distrib: web$/
++RELEASELIST	make-src/Makefile	/^RELEASELIST=pot@gnu.org xemacs-review@xemacs.org j/
++ReleaseNameString	pas-src/common.pas	/^procedure ReleaseNameString; (* (var NSP: NameStri/
++RE_LIMITED_OPS	c-src/emacs/src/regex.h	105
++removeexp	prol-src/natded.prolog	/^removeexp(E,E,'NIL'):-!.$/
++RemoveLayer	lua-src/allegro.lua	/^function RemoveLayer ()$/
++RemoveUnderlineControl	pas-src/common.pas	/^function RemoveUnderlineControl; (*($/
++RE_NEWLINE_ALT	c-src/emacs/src/regex.h	109
++RE_NO_BK_BRACES	c-src/emacs/src/regex.h	114
++RE_NO_BK_PARENS	c-src/emacs/src/regex.h	118
++RE_NO_BK_REFS	c-src/emacs/src/regex.h	122
++RE_NO_BK_VBAR	c-src/emacs/src/regex.h	126
++RE_NO_EMPTY_RANGES	c-src/emacs/src/regex.h	132
++RE_NO_GNU_OPS	c-src/emacs/src/regex.h	144
++RE_NO_NEWLINE_ANCHOR	c-src/emacs/src/regex.h	153
++RE_NO_POSIX_BACKTRACKING	c-src/emacs/src/regex.h	140
++RE_NREGS	c-src/emacs/src/regex.h	440
++re_nsub	c-src/emacs/src/regex.h	364
++reorder_modifiers	c-src/emacs/src/keyboard.c	/^reorder_modifiers (Lisp_Object symbol)$/
++re_pattern_buffer	c-src/emacs/src/regex.h	335
++re_pattern_buffer	c-src/h.h	119
++ReprOfChar	pas-src/common.pas	/^function ReprOfChar; (*( ch : char) : NameString;*/
++__repr__	pyt-src/server.py	/^    def __repr__(self):$/
++request	c.c	/^request request (a, b)$/
++requeued_events_pending_p	c-src/emacs/src/keyboard.c	/^requeued_events_pending_p (void)$/
++required_argument	c-src/getopt.h	90
++require	merc-src/accumulator.m	/^:- import_module require.$/
++re_registers	c-src/emacs/src/regex.h	428
++\resetmathfonts	tex-src/texinfo.tex	/^\\def\\resetmathfonts{%$/
++reset-this-command-lengths	c-src/emacs/src/keyboard.c	/^DEFUN ("reset-this-command-lengths", Freset_this_c/
++RE_SHY_GROUPS	c-src/emacs/src/regex.h	150
++restore_getcjmp	c-src/emacs/src/keyboard.c	/^restore_getcjmp (sys_jmp_buf temp)$/
++restore_kboard_configuration	c-src/emacs/src/keyboard.c	/^restore_kboard_configuration (int was_locked)$/
++/restorematrix	ps-src/rfc1245.ps	/^\/restorematrix {$/
++_Restrict_arr_	c-src/emacs/src/regex.h	555
++_Restrict_arr_	c-src/emacs/src/regex.h	557
++_Restrict_	c-src/emacs/src/regex.h	540
++_Restrict_	c-src/emacs/src/regex.h	542
++_Restrict_	c-src/emacs/src/regex.h	544
++\result	tex-src/texinfo.tex	/^\\def\\result{\\leavevmode\\raise.15ex\\hbox to 1em{\\hf/
++\result	tex-src/texinfo.tex	/^\\def\\result{\\realbackslash result}$/
++RESUME_POLLING	c-src/emacs/src/keyboard.c	2170
++RE_SYNTAX_AWK	c-src/emacs/src/regex.h	186
++RE_SYNTAX_ED	c-src/emacs/src/regex.h	216
++RE_SYNTAX_EGREP	c-src/emacs/src/regex.h	206
++RE_SYNTAX_EMACS	c-src/emacs/src/regex.h	183
++RE_SYNTAX_GNU_AWK	c-src/emacs/src/regex.h	193
++RE_SYNTAX_GREP	c-src/emacs/src/regex.h	201
++RE_SYNTAX_POSIX_AWK	c-src/emacs/src/regex.h	197
++RE_SYNTAX_POSIX_BASIC	c-src/emacs/src/regex.h	225
++_RE_SYNTAX_POSIX_COMMON	c-src/emacs/src/regex.h	221
++RE_SYNTAX_POSIX_EGREP	c-src/emacs/src/regex.h	212
++RE_SYNTAX_POSIX_EXTENDED	c-src/emacs/src/regex.h	234
++RE_SYNTAX_POSIX_MINIMAL_BASIC	c-src/emacs/src/regex.h	231
++RE_SYNTAX_POSIX_MINIMAL_EXTENDED	c-src/emacs/src/regex.h	242
++RE_SYNTAX_SED	c-src/emacs/src/regex.h	218
++RE_TRANSLATE_TYPE	c-src/emacs/src/regex.h	332
++return_to_command_loop	c-src/emacs/src/keyboard.c	135
++RETURN_UNGCPRO	c-src/emacs/src/lisp.h	/^#define RETURN_UNGCPRO(expr)			\\$/
++RE_UNMATCHED_RIGHT_PAREN_ORD	c-src/emacs/src/regex.h	136
++reverse	prol-src/natded.prolog	/^reverse([],Ws,Ws).$/
++revert	objc-src/PackInsp.m	/^-revert:sender$/
++re_wchar_t	c-src/emacs/src/regex.h	600
++re_wchar_t	c-src/emacs/src/regex.h	623
++re_wctype	c-src/emacs/src/regex.h	601
++re_wctype_t	c-src/emacs/src/regex.h	599
++re_wctype_t	c-src/emacs/src/regex.h	618
++re_wctype_to_bit	c-src/emacs/src/regex.h	/^# define re_wctype_to_bit(cc) 0$/
++/RF	ps-src/rfc1245.ps	/^\/RF { $/
++right	c-src/etags.c	216
++right_shift	y-src/cccp.y	/^right_shift (a, b)$/
++ring1	c.c	241
++ring2	c.c	242
++rm_eo	c-src/emacs/src/regex.h	450
++rm_so	c-src/emacs/src/regex.h	449
++\rm	tex-src/texinfo.tex	/^\\def\\rm{\\realbackslash rm }%$/
++rng_base	cp-src/Range.h	79
++rng_inc	cp-src/Range.h	81
++rng_limit	cp-src/Range.h	80
++rng_nelem	cp-src/Range.h	83
++rosso	cp-src/c.C	40
++/R	ps-src/rfc1245.ps	/^\/R { $/
++/RR	ps-src/rfc1245.ps	/^\/RR { $/
++RSH	y-src/cccp.c	17
++rsyncfromfly	make-src/Makefile	/^rsyncfromfly:$/
++rsynctofly	make-src/Makefile	/^rsynctofly:$/
++RTE/s	ada-src/2ataspri.adb	/^   package RTE renames Interfaces.C.POSIX_RTE;$/
++\r	tex-src/texinfo.tex	/^\\def\\r##1{\\realbackslash r {##1}}%$/
++\r	tex-src/texinfo.tex	/^\\def\\r##1{\\realbackslash r {##1}}$/
++\r	tex-src/texinfo.tex	/^\\def\\r#1{{\\rm #1}}		% roman font$/
++rtint	c-src/h.h	60
++rtint	c-src/h.h	68
++rtstr	c-src/h.h	61
++rtstr	c-src/h.h	69
++rtunion_def	c-src/h.h	58
++rtunion_def	c-src/h.h	64
++rtx	c-src/h.h	62
++rtxnp	c-src/h.h	71
++rtxp	c-src/h.h	70
++`	ruby-src/test.rb	/^        def `(command)$/
+++	ruby-src/test.rb	/^        def +(y)$/
++<<	ruby-src/test.rb	/^        def <<(y)$/
++<=	ruby-src/test.rb	/^        def <=(y)$/
++<=>	ruby-src/test.rb	/^        def <=>(y)$/
++==	ruby-src/test.rb	/^        def ==(y)$/
++===	ruby-src/test.rb	/^        def ===(y)$/
++[]	ruby-src/test.rb	/^        def [](y)$/
++[]=	ruby-src/test.rb	/^        def []=(y, val)$/
++RUN	make-src/Makefile	/^RUN=$/
++RUN	make-src/Makefile	/^RUN=time --quiet --format '%U + %S: %E'$/
++RXINCLUDE	make-src/Makefile	/^RXINCLUDE=-Iemacs\/src$/
++s1	cp-src/c.C	32
++/s1	ps-src/rfc1245.ps	/^\/s1 1 string def$/
++s2	cp-src/c.C	35
++SAFE_ALLOCA	c-src/emacs/src/lisp.h	/^#define SAFE_ALLOCA(size) ((size) <= sa_avail				\\/
++SAFE_ALLOCA_LISP	c-src/emacs/src/lisp.h	/^#define SAFE_ALLOCA_LISP(buf, nelt)			       \\$/
++SAFE_ALLOCA_STRING	c-src/emacs/src/lisp.h	/^#define SAFE_ALLOCA_STRING(ptr, string)			\\$/
++SAFE_FREE	c-src/emacs/src/lisp.h	/^#define SAFE_FREE()			\\$/
++SAFE_NALLOCA	c-src/emacs/src/lisp.h	/^#define SAFE_NALLOCA(buf, multiplier, nitems)			 \\/
++safe_run_hook_funcall	c-src/emacs/src/keyboard.c	/^safe_run_hook_funcall (ptrdiff_t nargs, Lisp_Objec/
++safe_run_hooks_1	c-src/emacs/src/keyboard.c	/^safe_run_hooks_1 (ptrdiff_t nargs, Lisp_Object *ar/
++safe_run_hooks	c-src/emacs/src/keyboard.c	/^safe_run_hooks (Lisp_Object hook)$/
++safe_run_hooks_error	c-src/emacs/src/keyboard.c	/^safe_run_hooks_error (Lisp_Object error, ptrdiff_t/
++Sample	tex-src/gzip.texi	/^@node Sample, Invoking gzip, Overview, Top$/
++\samp	tex-src/texinfo.tex	/^\\def\\samp##1{\\realbackslash samp {##1}}%$/
++\samp	tex-src/texinfo.tex	/^\\def\\samp##1{\\realbackslash samp {##1}}$/
++\samp	tex-src/texinfo.tex	/^\\def\\samp #1{`\\tclose{#1}'\\null}$/
++/sangle	ps-src/rfc1245.ps	/^\/sangle 1 0 dmatrix defaultmatrix dtransform exch /
++SAVE_FUNCPOINTER	c-src/emacs/src/lisp.h	2049
++save_getcjmp	c-src/emacs/src/keyboard.c	/^save_getcjmp (sys_jmp_buf temp)$/
++SAVE_INTEGER	c-src/emacs/src/lisp.h	2048
++/savematrix	ps-src/rfc1245.ps	/^\/savematrix {$/
++savenstr	c-src/etags.c	/^savenstr (const char *cp, int len)$/
++SAVE_OBJECT	c-src/emacs/src/lisp.h	2051
++SAVE_POINTER	c-src/emacs/src/lisp.h	2050
++save	pyt-src/server.py	/^    def save(self):$/
++SAVE_SLOT_BITS	c-src/emacs/src/lisp.h	2055
++savestr	c-src/etags.c	/^savestr (const char *cp)$/
++SAVE_TYPE_BITS	c-src/emacs/src/lisp.h	2062
++SAVE_TYPE_BITS	c-src/emacs/src/lisp.h	2114
++SAVE_TYPE_BITS	c-src/emacs/src/lisp.h	2123
++save_type	c-src/emacs/src/lisp.h	/^save_type (struct Lisp_Save_Value *v, int n)$/
++SAVE_TYPE_FUNCPTR_PTR_OBJ	c-src/emacs/src/lisp.h	2076
++SAVE_TYPE_INT_INT	c-src/emacs/src/lisp.h	2066
++SAVE_TYPE_INT_INT_INT	c-src/emacs/src/lisp.h	2067
++SAVE_TYPE_MEMORY	c-src/emacs/src/lisp.h	2080
++SAVE_TYPE_OBJ_OBJ	c-src/emacs/src/lisp.h	2069
++SAVE_TYPE_OBJ_OBJ_OBJ	c-src/emacs/src/lisp.h	2070
++SAVE_TYPE_OBJ_OBJ_OBJ_OBJ	c-src/emacs/src/lisp.h	2071
++SAVE_TYPE_PTR_INT	c-src/emacs/src/lisp.h	2073
++SAVE_TYPE_PTR_OBJ	c-src/emacs/src/lisp.h	2074
++SAVE_TYPE_PTR_PTR	c-src/emacs/src/lisp.h	2075
++SAVE_UNUSED	c-src/emacs/src/lisp.h	2047
++SAVE_VALUEP	c-src/emacs/src/lisp.h	/^SAVE_VALUEP (Lisp_Object x)$/
++SAVE_VALUE_SLOTS	c-src/emacs/src/lisp.h	2058
++say	go-src/test.go	/^func say(msg string) {$/
++__sbrk	c-src/emacs/src/gmalloc.c	1513
++SBYTES	c-src/emacs/src/lisp.h	/^SBYTES (Lisp_Object string)$/
++scan_separators	c-src/etags.c	/^scan_separators (char *name)$/
++S	c.c	156
++SCHARS	c-src/emacs/src/lisp.h	/^SCHARS (Lisp_Object string)$/
++Scheme_functions	c-src/etags.c	/^Scheme_functions (FILE *inf)$/
++Scheme_help	c-src/etags.c	667
++Scheme_suffixes	c-src/etags.c	665
++scolonseen	c-src/etags.c	2447
++scratch	c-src/sysdep.h	56
++SCREEN_FP	cp-src/screen.hpp	/^#define SCREEN_FP(x,y) \\$/
++SCREEN_START	cp-src/screen.hpp	33
++scroll_bar_parts	c-src/emacs/src/keyboard.c	5189
++s	c-src/emacs/src/lisp.h	4672
++s	c-src/emacs/src/lisp.h	4678
++\sc	tex-src/texinfo.tex	/^\\def\\sc#1{{\\smallcaps#1}}	% smallcaps font$/
++SDATA	c-src/emacs/src/lisp.h	/^SDATA (Lisp_Object string)$/
++SDTrefGetInteger	pas-src/common.pas	/^function SDTrefGetInteger : integer;$/
++SDTrefIsEnd	pas-src/common.pas	/^function SDTrefIsEnd : Boolean;$/
++SDTrefRecToString	pas-src/common.pas	/^procedure SDTrefRecToString  (* ($/
++SDTrefSkipSpaces	pas-src/common.pas	/^procedure SDTrefSkipSpaces;$/
++SDTrefStringToRec	pas-src/common.pas	/^procedure SDTrefStringToRec (* ($/
++\seccheck	tex-src/texinfo.tex	/^\\def\\seccheck#1{\\if \\pageno<0 %$/
++\secentryfonts	tex-src/texinfo.tex	/^\\def\\secentryfonts{\\textfonts}$/
++\secentry	tex-src/texinfo.tex	/^      \\def\\secentry ##1##2##3##4{}$/
++\secentry	tex-src/texinfo.tex	/^\\def\\secentry#1#2#3#4{\\dosecentry{#2.#3\\labelspace/
++\secfonts	tex-src/texinfo.tex	/^\\def\\secfonts{%$/
++\secheadingbreak	tex-src/texinfo.tex	/^\\def\\secheadingbreak{\\dobreak \\secheadingskip {-10/
++\secheadingi	tex-src/texinfo.tex	/^\\def\\secheadingi #1{{\\advance \\secheadingskip by \\/
++\secheading	tex-src/texinfo.tex	/^\\def\\secheading #1#2#3{\\secheadingi {#2.#3\\enspace/
++\secondary	tex-src/texinfo.tex	/^\\def\\secondary #1#2{$/
++sec=\relax	tex-src/texinfo.tex	/^\\let\\appendixsec=\\relax$/
++section_href	perl-src/htlmify-cystic	/^sub section_href ($)$/
++section_name	perl-src/htlmify-cystic	12
++section_name	perl-src/htlmify-cystic	/^sub section_name ($)$/
++section	perl-src/htlmify-cystic	25
++section=\relax	tex-src/texinfo.tex	/^\\let\\appendixsection=\\relax$/
++section_toc	perl-src/htlmify-cystic	15
++section_url_base	perl-src/htlmify-cystic	/^sub section_url_base ()$/
++section_url_name	perl-src/htlmify-cystic	/^sub section_url_name ()$/
++section_url	perl-src/htlmify-cystic	/^sub section_url ()$/
++\seczzz	tex-src/texinfo.tex	/^\\def\\seczzz #1{\\seccheck{section}%$/
++select_last	prol-src/natded.prolog	/^select_last([X],X,[]).$/
++SelectLayer	lua-src/allegro.lua	/^function SelectLayer (layer)$/
++select	prol-src/natded.prolog	/^select(X,[X|Xs],Xs).$/
++select-tags-table	el-src/emacs/lisp/progmodes/etags.el	/^(defun select-tags-table ()$/
++select-tags-table-mode	el-src/emacs/lisp/progmodes/etags.el	/^(define-derived-mode select-tags-table-mode specia/
++select-tags-table-mode-map	el-src/emacs/lisp/progmodes/etags.el	/^(defvar select-tags-table-mode-map ; Doc string?$/
++select-tags-table-quit	el-src/emacs/lisp/progmodes/etags.el	/^(defun select-tags-table-quit ()$/
++select-tags-table-select	el-src/emacs/lisp/progmodes/etags.el	/^(defun select-tags-table-select (button)$/
++Self/f	ada-src/2ataspri.adb	/^   function Self return TCB_Ptr is$/
++Self/f	ada-src/2ataspri.ads	/^   function Self return TCB_Ptr;$/
++send	objc-src/Subprocess.m	/^- send:(const char *)string$/
++send	objc-src/Subprocess.m	/^- send:(const char *)string withNewline:(BOOL)want/
++separator_names	c-src/emacs/src/keyboard.c	7372
++serializeToVars	php-src/lce_functions.php	/^      function serializeToVars($prefix)$/
++ServerEdit	pyt-src/server.py	/^class ServerEdit(Frame):$/
++Server	pyt-src/server.py	/^class Server:$/
++set_base	cp-src/Range.h	/^  void set_base (double b) { rng_base = b;  }$/
++\setchapternewpage	tex-src/texinfo.tex	/^\\def\\setchapternewpage #1 {\\csname CHAPPAG#1\\endcs/
++\setchapterstyle	tex-src/texinfo.tex	/^\\def\\setchapterstyle #1 {\\csname CHAPF#1\\endcsname/
++set_char_table_contents	c-src/emacs/src/lisp.h	/^set_char_table_contents (Lisp_Object table, ptrdif/
++set_char_table_defalt	c-src/emacs/src/lisp.h	/^set_char_table_defalt (Lisp_Object table, Lisp_Obj/
++set_char_table_extras	c-src/emacs/src/lisp.h	/^set_char_table_extras (Lisp_Object table, ptrdiff_/
++set_char_table_purpose	c-src/emacs/src/lisp.h	/^set_char_table_purpose (Lisp_Object table, Lisp_Ob/
++set	cp-src/conway.hpp	/^    void set(void) { alive = 1; }$/
++setDate	cp-src/functions.cpp	/^void Date::setDate ( int d , int m , int y ){$/
++\setdeffont	tex-src/texinfo.tex	/^\\def\\setdeffont #1 {\\csname DEF#1\\endcsname}$/
++setDelegate	objc-src/Subprocess.m	/^- setDelegate:anObject$/
++\setfilename	tex-src/texinfo.tex	/^\\def\\setfilename{%$/
++set_hash_key_slot	c-src/emacs/src/lisp.h	/^set_hash_key_slot (struct Lisp_Hash_Table *h, ptrd/
++set_hash_value_slot	c-src/emacs/src/lisp.h	/^set_hash_value_slot (struct Lisp_Hash_Table *h, pt/
++set_inc	cp-src/Range.h	/^  void set_inc (double i) { rng_inc = i;   }$/
++set-input-interrupt-mode	c-src/emacs/src/keyboard.c	/^DEFUN ("set-input-interrupt-mode", Fset_input_inte/
++set-input-meta-mode	c-src/emacs/src/keyboard.c	/^DEFUN ("set-input-meta-mode", Fset_input_meta_mode/
++set-input-mode	c-src/emacs/src/keyboard.c	/^DEFUN ("set-input-mode", Fset_input_mode, Sset_inp/
++set_limit	cp-src/Range.h	/^  void set_limit (double l) { rng_limit = l; }$/
++/setmanualfeed	ps-src/rfc1245.ps	/^\/setmanualfeed {$/
++set	merc-src/accumulator.m	/^:- import_module set.$/
++set-output-flow-control	c-src/emacs/src/keyboard.c	/^DEFUN ("set-output-flow-control", Fset_output_flow/
++set_overlay_plist	c-src/emacs/src/lisp.h	/^set_overlay_plist (Lisp_Object overlay, Lisp_Objec/
++Set_Own_Priority/p	ada-src/2ataspri.adb	/^   procedure Set_Own_Priority (Prio : System.Any_P/
++Set_Own_Priority/p	ada-src/2ataspri.ads	/^   procedure Set_Own_Priority (Prio : System.Any_P/
++/setpapername	ps-src/rfc1245.ps	/^\/setpapername { $/
++/setpattern	ps-src/rfc1245.ps	/^\/setpattern {$/
++set_poll_suppress_count	c-src/emacs/src/keyboard.c	/^set_poll_suppress_count (int count)$/
++Set_Priority/p	ada-src/2ataspri.adb	/^   procedure Set_Priority$/
++Set_Priority/p	ada-src/2ataspri.ads	/^   procedure Set_Priority (T : TCB_Ptr; Prio : Sys/
++set_prop	c-src/emacs/src/keyboard.c	/^set_prop (ptrdiff_t idx, Lisp_Object val)$/
++SETPRT	f-src/entry.for	/^       ENTRY  SETPRT ( SHORT, EXPL, LONG, TRACE, D/
++SETPRT	f-src/entry.strange	/^       ENTRY  SETPRT ( SHORT, EXPL, LONG, TRACE, D/
++SETPRT	f-src/entry.strange_suffix	/^       ENTRY  SETPRT ( SHORT, EXPL, LONG, TRACE, D/
++set-quit-char	c-src/emacs/src/keyboard.c	/^DEFUN ("set-quit-char", Fset_quit_char, Sset_quit_/
++\setref	tex-src/texinfo.tex	/^\\def\\setref#1{%$/
++setref	tex-src/texinfo.tex	/^\\expandafter\\expandafter\\expandafter\\appendixsetre/
++setRevertButtonTitle	objc-src/PackInsp.m	/^-setRevertButtonTitle$/
++set_save_integer	c-src/emacs/src/lisp.h	/^set_save_integer (Lisp_Object obj, int n, ptrdiff_/
++set_save_pointer	c-src/emacs/src/lisp.h	/^set_save_pointer (Lisp_Object obj, int n, void *va/
++set_string_intervals	c-src/emacs/src/lisp.h	/^set_string_intervals (Lisp_Object s, INTERVAL i)$/
++set_sub_char_table_contents	c-src/emacs/src/lisp.h	/^set_sub_char_table_contents (Lisp_Object table, pt/
++SET_SYMBOL_BLV	c-src/emacs/src/lisp.h	/^SET_SYMBOL_BLV (struct Lisp_Symbol *sym, struct Li/
++set_symbol_function	c-src/emacs/src/lisp.h	/^set_symbol_function (Lisp_Object sym, Lisp_Object /
++SET_SYMBOL_FWD	c-src/emacs/src/lisp.h	/^SET_SYMBOL_FWD (struct Lisp_Symbol *sym, union Lis/
++set_symbol_next	c-src/emacs/src/lisp.h	/^set_symbol_next (Lisp_Object sym, struct Lisp_Symb/
++set_symbol_plist	c-src/emacs/src/lisp.h	/^set_symbol_plist (Lisp_Object sym, Lisp_Object pli/
++SET_SYMBOL_VAL	c-src/emacs/src/lisp.h	/^# define SET_SYMBOL_VAL(sym, v) lisp_h_SET_SYMBOL_/
++\set	tex-src/texinfo.tex	/^\\def\\set{\\parsearg\\setxxx}$/
++\settitle	tex-src/texinfo.tex	/^\\def\\settitle{\\parsearg\\settitlezzz}$/
++\settitlezzz	tex-src/texinfo.tex	/^\\def\\settitlezzz #1{\\gdef\\thistitle{#1}}$/
++setup	cp-src/c.C	5
++set_upto	merc-src/accumulator.m	/^:- func set_upto(accu_case, int) = set(accu_goal_i/
++set_waiting_for_input	c-src/emacs/src/keyboard.c	/^set_waiting_for_input (struct timespec *time_to_cl/
++\setxxx	tex-src/texinfo.tex	/^\\def\\setxxx #1{$/
++/SF	ps-src/rfc1245.ps	/^\/SF { $/
++\sf	tex-src/texinfo.tex	/^\\def\\sf{\\fam=\\sffam \\tensf}$/
++\sf	tex-src/texinfo.tex	/^\\def\\sf{\\realbackslash sf}%$/
++shift	cp-src/functions.cpp	/^void Date::shift ( void ){\/\/Shift this date to pre/
++\shortchapentry	tex-src/texinfo.tex	/^\\def\\shortchapentry#1#2#3{%$/
++\shortunnumberedentry	tex-src/texinfo.tex	/^\\def\\shortunnumberedentry#1#2{%$/
++should_attempt_accu_transform_2	merc-src/accumulator.m	/^:- pred should_attempt_accu_transform_2(module_inf/
++should_attempt_accu_transform	merc-src/accumulator.m	/^:- pred should_attempt_accu_transform(module_info:/
++shouldLoad	objc-src/PackInsp.m	/^-(BOOL)shouldLoad$/
++should_see_this_array_type	cp-src/c.C	156
++should_see_this_function_pointer	cp-src/c.C	153
++should_see_this_one_enclosed_in_extern_C	cp-src/c.C	149
++show	erl-src/gs_dialog.erl	/^show(Module, Title, Message, Args) ->$/
++showError	objc-src/Subprocess.m	/^showError (const char *errorString, id theDelegate/
++show_help_echo	c-src/emacs/src/keyboard.c	/^show_help_echo (Lisp_Object help, Lisp_Object wind/
++showInfo	objc-src/PackInsp.m	/^-showInfo:sender$/
++sig	c-src/emacs/src/keyboard.c	7238
++signal_handler1	c-src/h.h	83
++signal_handler	c-src/h.h	82
++signal_handler_t	c-src/h.h	94
++SimpleCalc	objcpp-src/SimpleCalc.H	/^@interface SimpleCalc:Object$/
++simulation	html-src/software.html	/^Software that I wrote for supporting my research a/
++\singlecodeindexer	tex-src/texinfo.tex	/^\\def\\singlecodeindexer #1{\\doind{\\indexname}{\\code/
++\singleindexer	tex-src/texinfo.tex	/^\\def\\singleindexer #1{\\doind{\\indexname}{#1}}$/
++single_kboard	c-src/emacs/src/keyboard.c	89
++single_kboard_state	c-src/emacs/src/keyboard.c	/^single_kboard_state ()$/
++SINGLE_LETTER_MOD	c-src/emacs/src/keyboard.c	6212
++SINGLE_LETTER_MOD	c-src/emacs/src/keyboard.c	6763
++SINGLE_LETTER_MOD	c-src/emacs/src/keyboard.c	/^#define SINGLE_LETTER_MOD(BIT)				\\$/
++\singlespace	tex-src/texinfo.tex	/^\\def\\singlespace{%$/
++site	cp-src/conway.hpp	5
++site	cp-src/conway.hpp	/^    site(int xi, int yi): x(xi), y(yi), alive(0) {/
++size	c-src/emacs/src/gmalloc.c	156
++size	c-src/emacs/src/gmalloc.c	163
++size	c-src/emacs/src/gmalloc.c	1862
++size	c-src/emacs/src/lisp.h	1364
++size	c-src/emacs/src/lisp.h	1390
++size	c-src/etags.c	236
++size	c-src/etags.c	2522
++SIZEFORMAT	objc-src/PackInsp.m	57
++skeyseen	c-src/etags.c	2445
++SkipBlanks	pas-src/common.pas	/^function SkipBlanks; (*($/
++SkipChars	pas-src/common.pas	/^function SkipChars; (*($/
++skip_name	c-src/etags.c	/^skip_name (char *cp)$/
++skip_non_spaces	c-src/etags.c	/^skip_non_spaces (char *cp)$/
++skip_spaces	c-src/etags.c	/^skip_spaces (char *cp)$/
++SkipSpaces	pas-src/common.pas	/^procedure SkipSpaces; (* (Str : NameString; var I /
++\sl	tex-src/texinfo.tex	/^\\def\\sl{\\realbackslash sl }%$/
++\smallbook	tex-src/texinfo.tex	/^\\def\\smallbook{$/
++\smalllispx	tex-src/texinfo.tex	/^\\def\\smalllispx{\\aboveenvbreak\\begingroup\\inENV$/
++\smartitalic	tex-src/texinfo.tex	/^\\def\\smartitalic#1{{\\sl #1}\\futurelet\\next\\smartit/
++=\smartitalic	tex-src/texinfo.tex	/^\\let\\cite=\\smartitalic$/
++\smartitalicx	tex-src/texinfo.tex	/^\\def\\smartitalicx{\\ifx\\next,\\else\\ifx\\next-\\else\\i/
++snarf-tag-function	el-src/emacs/lisp/progmodes/etags.el	/^(defvar snarf-tag-function nil$/
++snone	c-src/etags.c	2443
++solutions	merc-src/accumulator.m	/^:- import_module solutions.$/
++some_mouse_moved	c-src/emacs/src/keyboard.c	/^some_mouse_moved (void)$/
++#some-storage	forth-src/test-forth.fth	/^2000 buffer: #some-storage$/
++spacer	c-src/emacs/src/lisp.h	1975
++spacer	c-src/emacs/src/lisp.h	1982
++spacer	c-src/emacs/src/lisp.h	2036
++spacer	c-src/emacs/src/lisp.h	2205
++space	tex-src/texinfo.tex	/^    {#2\\labelspace #1}\\dotfill\\doshortpageno{#3}}%/
++space	tex-src/texinfo.tex	/^  \\dosubsubsecentry{#2.#3.#4.#5\\labelspace#1}{#6}}/
++specbinding	c-src/emacs/src/lisp.h	2955
++specbind_tag	c-src/emacs/src/lisp.h	2943
++specialsymbol	prol-src/natded.prolog	/^specialsymbol(C1,C2,S):-$/
++SPECPDL_BACKTRACE	c-src/emacs/src/lisp.h	2948
++SPECPDL_INDEX	c-src/emacs/src/lisp.h	/^SPECPDL_INDEX (void)$/
++SPECPDL_LET	c-src/emacs/src/lisp.h	2949
++SPECPDL_LET_DEFAULT	c-src/emacs/src/lisp.h	2952
++SPECPDL_LET_LOCAL	c-src/emacs/src/lisp.h	2951
++SPECPDL_UNWIND	c-src/emacs/src/lisp.h	2944
++SPECPDL_UNWIND_INT	c-src/emacs/src/lisp.h	2946
++SPECPDL_UNWIND_PTR	c-src/emacs/src/lisp.h	2945
++SPECPDL_UNWIND_VOID	c-src/emacs/src/lisp.h	2947
++splitexp	prol-src/natded.prolog	/^splitexp(E,E,('NIL','NIL')):-!.$/
++\splitoff	tex-src/texinfo.tex	/^\\def\\splitoff#1#2\\endmark{\\def\\first{#1}\\def\\rest{/
++/S	ps-src/rfc1245.ps	/^\/S { $/
++\sp	tex-src/texinfo.tex	/^\\def\\sp{\\parsearg\\spxxx}$/
++\spxxx	tex-src/texinfo.tex	/^\\def\\spxxx #1{\\par \\vskip #1\\baselineskip}$/
++Square.something:Bar	lua-src/test.lua	/^function Square.something:Bar ()$/
++srclist	make-src/Makefile	/^srclist: Makefile$/
++SRCS	make-src/Makefile	/^SRCS=Makefile ${ADASRC} ${ASRC} ${CSRC} ${CPSRC} $/
++SREF	c-src/emacs/src/lisp.h	/^SREF (Lisp_Object string, ptrdiff_t index)$/
++ss3	c.c	255
++SSDATA	c-src/emacs/src/lisp.h	/^SSDATA (Lisp_Object string)$/
++SSET	c-src/emacs/src/lisp.h	/^SSET (Lisp_Object string, ptrdiff_t index, unsigne/
++sss1	c.c	252
++sss2	c.c	253
++sstab	prol-src/natded.prolog	/^sstab(2,'C',',').$/
++stack	c.c	155
++STACK_CONS	c-src/emacs/src/lisp.h	/^#define STACK_CONS(a, b) \\$/
++stagseen	c-src/etags.c	2446
++standalone	make-src/Makefile	/^standalone:$/
++\startcontents	tex-src/texinfo.tex	/^\\def\\startcontents#1{%$/
++start	c-src/emacs/src/keyboard.c	8753
++start	c-src/emacs/src/lisp.h	2038
++start	c-src/emacs/src/regex.h	431
++StartDay	cp-src/functions.cpp	/^Date StartDay(Date a,int days){\/\/Function to calcu/
++\startenumeration	tex-src/texinfo.tex	/^\\def\\startenumeration#1{%$/
++start	php-src/lce_functions.php	/^      function start($line, $class)$/
++start_polling	c-src/emacs/src/keyboard.c	/^start_polling (void)$/
++=starts-with-equals!	scm-src/test.scm	/^(define =starts-with-equals! #t)$/
++start_up	prol-src/natded.prolog	/^start_up:-$/
++start	y-src/cccp.y	143
++STATE_ABORT	php-src/lce_functions.php	25
++STATE_COMPRESSD	objc-src/PackInsp.m	54
++STATE_INSTALLED	objc-src/PackInsp.m	53
++STATE_LOOP	php-src/lce_functions.php	27
++STATE_OK	php-src/lce_functions.php	26
++state_protected_p	c-src/emacs/src/gmalloc.c	400
++STAT_EQ	objc-src/PackInsp.m	/^#define STAT_EQ(s1, s2)	((s1)->st_ino == (s2)->st_/
++statetable	html-src/algrthms.html	/^Next$/
++STATE_UNINSTALLED	objc-src/PackInsp.m	52
++staticetags	make-src/Makefile	/^staticetags:$/
++st_C_attribute	c-src/etags.c	2209
++st_C_class	c-src/etags.c	2212
++st_C_define	c-src/etags.c	2213
++st_C_enum	c-src/etags.c	2213
++st_C_extern	c-src/etags.c	2213
++st_C_gnumacro	c-src/etags.c	2208
++st_C_ignore	c-src/etags.c	2209
++st_C_javastruct	c-src/etags.c	2210
++st_C_objend	c-src/etags.c	2207
++st_C_objimpl	c-src/etags.c	2207
++st_C_objprot	c-src/etags.c	2207
++st_C_operator	c-src/etags.c	2211
++st_C_struct	c-src/etags.c	2213
++st_C_template	c-src/etags.c	2212
++st_C_typedef	c-src/etags.c	2213
++STDIN	c-src/etags.c	408
++STDIN	c-src/etags.c	411
++step	cp-src/clheir.hpp	/^    virtual void step(void) { }$/
++step	cp-src/conway.hpp	/^    void step(void) { alive = next_alive; }$/
++step_everybody	cp-src/clheir.cpp	/^void step_everybody(void)$/
++st_none	c-src/etags.c	2206
++STOP_POLLING	c-src/emacs/src/keyboard.c	2166
++stop_polling	c-src/emacs/src/keyboard.c	/^stop_polling (void)$/
++stored_goal_plain_call	merc-src/accumulator.m	/^:- inst stored_goal_plain_call for goal_store.stor/
++store_info	merc-src/accumulator.m	/^:- type store_info$/
++store_user_signal_events	c-src/emacs/src/keyboard.c	/^store_user_signal_events (void)$/
++strcaseeq	c-src/etags.c	/^#define strcaseeq(s,t)	(assert ((s)!=NULL && (t)!=/
++streq	c-src/etags.c	/^#define streq(s,t)	(assert ((s)!=NULL || (t)!=NULL/
++str	go-src/test1.go	9
++STRING_BYTES_BOUND	c-src/emacs/src/lisp.h	1261
++STRING_BYTES	c-src/emacs/src/lisp.h	/^STRING_BYTES (struct Lisp_String *s)$/
++string_intervals	c-src/emacs/src/lisp.h	/^string_intervals (Lisp_Object s)$/
++string	merc-src/accumulator.m	/^:- import_module string.$/
++STRING_MULTIBYTE	c-src/emacs/src/lisp.h	/^STRING_MULTIBYTE (Lisp_Object str)$/
++STRING_SET_CHARS	c-src/emacs/src/lisp.h	/^STRING_SET_CHARS (Lisp_Object string, ptrdiff_t ne/
++STRING_SET_MULTIBYTE	c-src/emacs/src/lisp.h	/^#define STRING_SET_MULTIBYTE(STR)			\\$/
++STRING_SET_UNIBYTE	c-src/emacs/src/lisp.h	/^#define STRING_SET_UNIBYTE(STR)				\\$/
++stripLine	php-src/lce_functions.php	/^      function stripLine($line, $class)$/
++stripname	pas-src/common.pas	/^function stripname; (* ($/
++StripPath	pas-src/common.pas	/^function StripPath; (*($/
++strncaseeq	c-src/etags.c	/^#define strncaseeq(s,t,n) (assert ((s)!=NULL && (t/
++strneq	c-src/etags.c	/^#define strneq(s,t,n)	(assert ((s)!=NULL || (t)!=N/
++__str__	pyt-src/server.py	/^    def __str__(self):$/
++structdef	c-src/etags.c	2448
++stuff_buffered_input	c-src/emacs/src/keyboard.c	/^stuff_buffered_input (Lisp_Object stuffstring)$/
++SUB_CHAR_TABLE_OFFSET	c-src/emacs/src/lisp.h	1701
++SUB_CHAR_TABLE_P	c-src/emacs/src/lisp.h	/^SUB_CHAR_TABLE_P (Lisp_Object a)$/
++\subheading	tex-src/texinfo.tex	/^\\def\\subheading{\\parsearg\\subsecheadingi}$/
++subprocessDone	objc-src/PackInsp.m	/^-subprocessDone:(Subprocess *)sender$/
++subprocess	objc-src/PackInsp.m	/^-subprocess:(Subprocess *)sender output:(char *)bu/
++Subprocess	objc-src/Subprocess.h	41
++Subprocess	objc-src/Subprocess.h	/^@interface Subprocess:Object$/
++SUBRP	c-src/emacs/src/lisp.h	/^SUBRP (Lisp_Object a)$/
++\subsecentry	tex-src/texinfo.tex	/^      \\def\\subsecentry ##1##2##3##4##5{}$/
++\subsecentry	tex-src/texinfo.tex	/^\\def\\subsecentry#1#2#3#4#5{\\dosubsecentry{#2.#3.#4/
++\subsecfonts	tex-src/texinfo.tex	/^\\def\\subsecfonts{%$/
++\subsecheadingbreak	tex-src/texinfo.tex	/^\\def\\subsecheadingbreak{\\dobreak \\subsecheadingski/
++\subsecheadingi	tex-src/texinfo.tex	/^\\def\\subsecheadingi #1{{\\advance \\subsecheadingski/
++\subsecheading	tex-src/texinfo.tex	/^\\def\\subsecheading #1#2#3#4{\\subsecheadingi {#2.#3/
++subsec=\relax	tex-src/texinfo.tex	/^\\let\\appendixsubsec=\\relax$/
++subsection_marker	perl-src/htlmify-cystic	161
++subsection	perl-src/htlmify-cystic	26
++subsection=\relax	tex-src/texinfo.tex	/^\\let\\appendixsubsection=\\relax$/
++substitute	c-src/etags.c	/^substitute (char *in, char *out, struct re_registe/
++subst	prol-src/natded.prolog	/^subst(var(Y),var(X),M,N):-$/
++SubString	pas-src/common.pas	/^function SubString; (*($/
++\subsubheading	tex-src/texinfo.tex	/^\\def\\subsubheading{\\parsearg\\subsubsecheadingi}$/
++\subsubsecentry	tex-src/texinfo.tex	/^      \\def\\subsubsecentry ##1##2##3##4##5##6{}$/
++\subsubsecentry	tex-src/texinfo.tex	/^\\def\\subsubsecentry#1#2#3#4#5#6{%$/
++\subsubsecfonts	tex-src/texinfo.tex	/^\\def\\subsubsecfonts{\\subsecfonts} % Maybe this sho/
++\subsubsecheadingi	tex-src/texinfo.tex	/^\\def\\subsubsecheadingi #1{{\\advance \\subsecheading/
++\subsubsecheading	tex-src/texinfo.tex	/^\\def\\subsubsecheading #1#2#3#4#5{\\subsubsecheading/
++subsubsec=\relax	tex-src/texinfo.tex	/^\\let\\appendixsubsubsec=\\relax$/
++subsubsection	perl-src/htlmify-cystic	27
++subsubsection=\relax	tex-src/texinfo.tex	/^\\let\\appendixsubsubsection=\\relax$/
++\subtitlefont	tex-src/texinfo.tex	/^   \\def\\subtitlefont{\\subtitlerm \\normalbaselinesk/
++\subtitle	tex-src/texinfo.tex	/^   \\def\\subtitle{\\parsearg\\subtitlezzz}%$/
++\subtitlezzz	tex-src/texinfo.tex	/^   \\def\\subtitlezzz##1{{\\subtitlefont \\rightline{#/
++subtle	ruby-src/test1.ru	/^                 :tee ; attr_reader :subtle$/
++subtree	prol-src/natded.prolog	/^subtree(T,T).$/
++suffix	c-src/etags.c	186
++suffixes	c-src/etags.c	195
++suggest_asking_for_help	c-src/etags.c	/^suggest_asking_for_help (void)$/
++\summarycontents	tex-src/texinfo.tex	/^\\outer\\def\\summarycontents{%$/
++\supereject	tex-src/texinfo.tex	/^\\def\\supereject{\\par\\penalty -20000\\footnoteno =0 /
++suspend-emacs	c-src/emacs/src/keyboard.c	/^DEFUN ("suspend-emacs", Fsuspend_emacs, Ssuspend_e/
++sval	y-src/cccp.y	116
++swallow_events	c-src/emacs/src/keyboard.c	/^swallow_events (bool do_display)$/
++switch_line_buffers	c-src/etags.c	/^#define switch_line_buffers() (curndx = 1 - curndx/
++sxhash_combine	c-src/emacs/src/lisp.h	/^sxhash_combine (EMACS_UINT x, EMACS_UINT y)$/
++SXHASH_REDUCE	c-src/emacs/src/lisp.h	/^SXHASH_REDUCE (EMACS_UINT x)$/
++SYMBOL_BLV	c-src/emacs/src/lisp.h	/^SYMBOL_BLV (struct Lisp_Symbol *sym)$/
++SYMBOL_CONSTANT_P	c-src/emacs/src/lisp.h	/^# define SYMBOL_CONSTANT_P(sym) lisp_h_SYMBOL_CONS/
++symbol	c-src/emacs/src/lisp.h	2980
++SYMBOL_FORWARDED	c-src/emacs/src/lisp.h	651
++SYMBOL_FWD	c-src/emacs/src/lisp.h	/^SYMBOL_FWD (struct Lisp_Symbol *sym)$/
++SYMBOL_INDEX	c-src/emacs/src/lisp.h	/^#define SYMBOL_INDEX(sym) i##sym$/
++symbol_interned	c-src/emacs/src/lisp.h	639
++SYMBOL_INTERNED	c-src/emacs/src/lisp.h	642
++SYMBOL_INTERNED_IN_INITIAL_OBARRAY	c-src/emacs/src/lisp.h	643
++SYMBOL_INTERNED_IN_INITIAL_OBARRAY_P	c-src/emacs/src/lisp.h	/^SYMBOL_INTERNED_IN_INITIAL_OBARRAY_P (Lisp_Object /
++SYMBOL_INTERNED_P	c-src/emacs/src/lisp.h	/^SYMBOL_INTERNED_P (Lisp_Object sym)$/
++SYMBOL_LOCALIZED	c-src/emacs/src/lisp.h	650
++symbol_name	c-src/emacs/src/lisp.h	1687
++SYMBOL_NAME	c-src/emacs/src/lisp.h	/^SYMBOL_NAME (Lisp_Object sym)$/
++SYMBOLP	c-src/emacs/src/lisp.h	/^# define SYMBOLP(x) lisp_h_SYMBOLP (x)$/
++SYMBOL_PLAINVAL	c-src/emacs/src/lisp.h	648
++symbol_redirect	c-src/emacs/src/lisp.h	646
++SYMBOL_UNINTERNED	c-src/emacs/src/lisp.h	641
++SYMBOL_VAL	c-src/emacs/src/lisp.h	/^# define SYMBOL_VAL(sym) lisp_h_SYMBOL_VAL (sym)$/
++SYMBOL_VARALIAS	c-src/emacs/src/lisp.h	649
++syms_of_abbrev	c-src/abbrev.c	/^syms_of_abbrev ()$/
++syms_of_keyboard	c-src/emacs/src/keyboard.c	/^syms_of_keyboard (void)$/
++sym_type	c-src/etags.c	2204
++synchronize_system_messages_locale	c-src/emacs/src/lisp.h	/^INLINE void synchronize_system_messages_locale (vo/
++synchronize_system_time_locale	c-src/emacs/src/lisp.h	/^INLINE void synchronize_system_time_locale (void) /
++\syncodeindex	tex-src/texinfo.tex	/^\\def\\syncodeindex #1 #2 {%$/
++\synindex	tex-src/texinfo.tex	/^\\def\\synindex #1 #2 {%$/
++syntax	c-src/emacs/src/regex.h	350
++SYSCALL	c-src/machsyscalls.c	/^#define	SYSCALL(name, number, type, args, typed_ar/
++syscall_error	c-src/sysdep.h	34
++sys_jmp_buf	c-src/emacs/src/lisp.h	2906
++sys_jmp_buf	c-src/emacs/src/lisp.h	2910
++sys_jmp_buf	c-src/emacs/src/lisp.h	2916
++sys_longjmp	c-src/emacs/src/lisp.h	/^# define sys_longjmp(j, v) _longjmp (j, v)$/
++sys_longjmp	c-src/emacs/src/lisp.h	/^# define sys_longjmp(j, v) longjmp (j, v)$/
++sys_longjmp	c-src/emacs/src/lisp.h	/^# define sys_longjmp(j, v) siglongjmp (j, v)$/
++sys_setjmp	c-src/emacs/src/lisp.h	/^# define sys_setjmp(j) _setjmp (j)$/
++sys_setjmp	c-src/emacs/src/lisp.h	/^# define sys_setjmp(j) setjmp (j)$/
++sys_setjmp	c-src/emacs/src/lisp.h	/^# define sys_setjmp(j) sigsetjmp (j, 0)$/
++System.Task_Primitives/b	ada-src/2ataspri.adb	/^package body System.Task_Primitives is$/
++System.Task_Primitives/s	ada-src/2ataspri.ads	/^package System.Task_Primitives is$/
++t1	cp-src/c.C	34
++t2	cp-src/c.C	38
++T2	cp-src/fail.C	16
++T3	c.c	163
++tab_count_words	c-src/tab.c	/^int			tab_count_words(char **tab)$/
++tab_delete_first	c-src/tab.c	/^int			tab_delete_first(char **tab)$/
++tab_fill	c-src/tab.c	/^char			**tab_fill(char *str, char delim)$/
++tab_free	c-src/tab.c	/^void			tab_free(char **tab)$/
++\table	tex-src/texinfo.tex	/^\\def\\table{\\begingroup\\inENV\\obeylines\\obeyspaces\\/
++\tablez	tex-src/texinfo.tex	/^\\def\\tablez #1#2#3#4#5#6{%$/
++tag1	c-src/dostorture.c	/^(*tag1 (sig, handler)) ()$/
++tag1	c-src/h.h	110
++tag1	c-src/torture.c	/^(*tag1 (sig, handler)) ()$/
++tag2	c-src/dostorture.c	/^(*tag2 (sig, handler)) ()$/
++tag2	c-src/torture.c	/^(*tag2 (sig, handler)) ()$/
++tag3	c-src/dostorture.c	/^(*tag3 (int sig, void (*handler) (int))) (int)$/
++tag3	c-src/torture.c	/^(*tag3 (int sig, void (*handler) (int))) (int)$/
++tag4	c-src/dostorture.c	/^(*tag4 (int sig, void (*handler) (int))) (int)$/
++tag4	c-src/torture.c	/^(*tag4 (int sig, void (*handler) (int))) (int)$/
++tag5	c-src/dostorture.c	/^tag5 (handler, arg)$/
++tag5	c-src/torture.c	/^tag5 (handler, arg)$/
++tag6	c-src/dostorture.c	/^tag6 (void (*handler) (void *), void *arg)$/
++tag6	c-src/torture.c	/^tag6 (void (*handler) (void *), void *arg)$/
++tag-any-match-p	el-src/emacs/lisp/progmodes/etags.el	/^(defun tag-any-match-p (_tag)$/
++tag-exact-file-name-match-p	el-src/emacs/lisp/progmodes/etags.el	/^(defun tag-exact-file-name-match-p (tag)$/
++tag-exact-match-p	el-src/emacs/lisp/progmodes/etags.el	/^(defun tag-exact-match-p (tag)$/
++tag-file-name-match-p	el-src/emacs/lisp/progmodes/etags.el	/^(defun tag-file-name-match-p (tag)$/
++tag-find-file-of-tag	el-src/emacs/lisp/progmodes/etags.el	/^(defun tag-find-file-of-tag (file) ; Doc string?$/
++tag-find-file-of-tag-noselect	el-src/emacs/lisp/progmodes/etags.el	/^(defun tag-find-file-of-tag-noselect (file)$/
++taggedfname	c-src/etags.c	207
++tag-implicit-name-match-p	el-src/emacs/lisp/progmodes/etags.el	/^(defun tag-implicit-name-match-p (tag)$/
++tag-lines-already-matched	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tag-lines-already-matched nil$/
++tag_or_ch	c-src/emacs/src/lisp.h	3026
++tag-partial-file-name-match-p	el-src/emacs/lisp/progmodes/etags.el	/^(defun tag-partial-file-name-match-p (_tag)$/
++TAG_PTR	c-src/emacs/src/lisp.h	/^#define TAG_PTR(tag, ptr) \\$/
++tag-re-match-p	el-src/emacs/lisp/progmodes/etags.el	/^(defun tag-re-match-p (re)$/
++tags-add-tables	el-src/emacs/lisp/progmodes/etags.el	/^(defcustom tags-add-tables 'ask-user$/
++tags-apropos-additional-actions	el-src/emacs/lisp/progmodes/etags.el	/^(defcustom tags-apropos-additional-actions nil$/
++tags-apropos	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-apropos (regexp)$/
++tags-apropos-function	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-apropos-function nil$/
++tags-apropos-verbose	el-src/emacs/lisp/progmodes/etags.el	/^(defcustom tags-apropos-verbose nil$/
++tags-case-fold-search	el-src/emacs/lisp/progmodes/etags.el	/^(defcustom tags-case-fold-search 'default$/
++tags-complete-tags-table-file	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-complete-tags-table-file (string predi/
++tags-completion-at-point-function	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-completion-at-point-function ()$/
++tags-completion-table	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-completion-table ()$/
++tags-completion-table	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-completion-table nil$/
++tags-completion-table-function	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-completion-table-function nil$/
++tags-compression-info-list	el-src/emacs/lisp/progmodes/etags.el	/^(defcustom tags-compression-info-list$/
++tags-expand-table-name	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-expand-table-name (file)$/
++tags-file-name	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-file-name nil$/
++tags-included-tables	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-included-tables ()$/
++tags-included-tables	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-included-tables nil$/
++tags-included-tables-function	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-included-tables-function nil$/
++tags-lazy-completion-table	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-lazy-completion-table ()$/
++tags-location-ring	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-location-ring (make-ring xref-marker-/
++tags-loop-continue	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-loop-continue (&optional first-time)$/
++tags-loop-eval	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-loop-eval (form)$/
++tags-loop-operate	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-loop-operate nil$/
++tags-loop-revert-buffers	el-src/emacs/lisp/progmodes/etags.el	/^(defcustom tags-loop-revert-buffers nil$/
++tags-loop-scan	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-loop-scan$/
++TAGS	make-src/Makefile	/^TAGS: etags.c$/
++tags	make-src/Makefile	/^tags: TAGS$/
++tags-next-table	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-next-table ()$/
++tags-query-replace	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-query-replace (from to &optional delim/
++tags-recognize-empty-tags-table	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-recognize-empty-tags-table ()$/
++tags-reset-tags-tables	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-reset-tags-tables ()$/
++tags-revert-without-query	el-src/emacs/lisp/progmodes/etags.el	/^(defcustom tags-revert-without-query nil$/
++tags-search	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-search (regexp &optional file-list-for/
++tags-select-tags-table	el-src/emacs/lisp/progmodes/etags.el	/^(define-button-type 'tags-select-tags-table$/
++tags-table-check-computed-list	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-table-check-computed-list ()$/
++tags-table-computed-list	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-table-computed-list nil$/
++tags-table-computed-list-for	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-table-computed-list-for nil$/
++tags-table-extend-computed-list	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-table-extend-computed-list ()$/
++tags-table-files	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-table-files ()$/
++tags-table-files	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-table-files nil$/
++tags-table-files-function	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-table-files-function nil$/
++tags-table-format-functions	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-table-format-functions '(etags-recogn/
++tags-table-including	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-table-including (this-file core-only)$/
++tags-table-list	el-src/emacs/lisp/progmodes/etags.el	/^(defcustom tags-table-list nil$/
++tags-table-list-member	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-table-list-member (file list)$/
++tags-table-list-pointer	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-table-list-pointer nil$/
++tags-table-list-started-at	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-table-list-started-at nil$/
++tags-table-mode	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-table-mode ()$/
++tags-table-set-list	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-table-set-list nil$/
++tags-tag-face	el-src/emacs/lisp/progmodes/etags.el	/^(defcustom tags-tag-face 'default$/
++tags-verify-table	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-verify-table (file)$/
++tags-with-face	el-src/emacs/lisp/progmodes/etags.el	/^(defmacro tags-with-face (face &rest body)$/
++tag-symbol-match-p	el-src/emacs/lisp/progmodes/etags.el	/^(defun tag-symbol-match-p (tag)$/
++TAG_SYMOFFSET	c-src/emacs/src/lisp.h	/^#define TAG_SYMOFFSET(offset)				    \\$/
++tag-word-match-p	el-src/emacs/lisp/progmodes/etags.el	/^(defun tag-word-match-p (tag)$/
++Tapes	tex-src/gzip.texi	/^@node Tapes, Problems, Environment, Top$/
++target_multibyte	c-src/emacs/src/regex.h	407
++TAS_Cell/t	ada-src/2ataspri.ads	/^   type TAS_Cell is$/
++TAS_Cell/t	ada-src/2ataspri.ads	/^   type TAS_Cell is private;$/
++Task_Control_Block/t	ada-src/2ataspri.ads	/^   type Task_Control_Block is record$/
++Task_Storage_Size/t	ada-src/2ataspri.ads	/^   type Task_Storage_Size is new Interfaces.C.size/
++Task_Type/b	ada-src/etags-test-for.ada	/^  task body Task_Type is$/
++Task_Type/b	ada-src/waroquiers.ada	/^  task body Task_Type is$/
++Task_Type/k	ada-src/etags-test-for.ada	/^  task type Task_Type is$/
++Task_Type/k	ada-src/waroquiers.ada	/^  task type Task_Type is$/
++TCB_Ptr/t	ada-src/2ataspri.ads	/^   type TCB_Ptr is access all Task_Control_Block;$/
++TCLFLAGS	make-src/Makefile	/^TCLFLAGS=--lang=none --regex='\/proc[ \\t]+\\([^ \\t]+/
++\tclose	tex-src/texinfo.tex	/^\\def\\tclose##1{\\realbackslash tclose {##1}}%$/
++\tclose	tex-src/texinfo.tex	/^\\def\\tclose##1{\\realbackslash tclose {##1}}$/
++\tclose	tex-src/texinfo.tex	/^\\def\\tclose#1{{\\rm \\tcloserm=\\fontdimen2\\font \\tt /
++tcpdump	html-src/software.html	/^tcpdump$/
++t	cp-src/c.C	52
++T	cp-src/fail.C	14
++teats	cp-src/c.C	127
++tee	ruby-src/test1.ru	/^    attr_accessor :tee$/
++tee=	ruby-src/test1.ru	/^    attr_accessor :tee$/
++temporarily_switch_to_single_kboard	c-src/emacs/src/keyboard.c	/^temporarily_switch_to_single_kboard (struct frame /
++tend	c-src/etags.c	2432
++TERMINALP	c-src/emacs/src/lisp.h	/^TERMINALP (Lisp_Object a)$/
++terminateInput	objc-src/Subprocess.m	/^- terminateInput$/
++terminate	objc-src/Subprocess.m	/^- terminate:sender$/
++term	merc-src/accumulator.m	/^:- import_module term.$/
++test1	rs-src/test.rs	/^fn test1() {$/
++Test_Abort/p	ada-src/2ataspri.adb	/^   procedure Test_Abort is$/
++Test_Abort/p	ada-src/2ataspri.ads	/^   procedure Test_Abort;$/
++Test_And_Set/p	ada-src/2ataspri.adb	/^   procedure Test_And_Set (Cell : in out TAS_Cell;/
++Test_And_Set/p	ada-src/2ataspri.ads	/^   procedure Test_And_Set (Cell : in out TAS_Cell;/
++test-begin	scm-src/test.scm	/^(define-syntax test-begin$/
++test	cp-src/c.C	86
++test_crlf1	test_crlf.c	/^void test_crlf1()$/
++test_crlf2	tset_crlf.c	/^void test_crlf2()$/
++test	c-src/emacs/src/lisp.h	1871
++test	erl-src/gs_dialog.erl	/^test() ->$/
++test	go-src/test1.go	/^func test(p plus) {$/
++test	make-src/Makefile	/^test:$/
++test.me_22a	lua-src/test.lua	/^   function test.me_22a(one, two)$/
++test.me22b	lua-src/test.lua	/^   local function test.me22b (one)$/
++TEST	php-src/ptest.php	1
++test	php-src/ptest.php	/^test $/
++test_undefined	c-src/emacs/src/keyboard.c	/^test_undefined (Lisp_Object binding)$/
++TEX_clgrp	c-src/etags.c	4922
++TeX_commands	c-src/etags.c	/^TeX_commands (FILE *inf)$/
++TEX_decode_env	c-src/etags.c	/^TEX_decode_env (const char *evarname, const char */
++TEX_defenv	c-src/etags.c	4912
++TEX_esc	c-src/etags.c	4920
++TeX_help	c-src/etags.c	674
++Texinfo_help	c-src/etags.c	688
++Texinfo_nodes	c-src/etags.c	/^Texinfo_nodes (FILE *inf)$/
++Texinfo_suffixes	c-src/etags.c	686
++\texinfoversion	tex-src/texinfo.tex	/^\\def\\texinfoversion{2.73}$/
++TEX_LESC	c-src/etags.c	4986
++TEX_mode	c-src/etags.c	/^TEX_mode (FILE *inf)$/
++TEX_opgrp	c-src/etags.c	4921
++TEX_SESC	c-src/etags.c	4987
++TEXSRC	make-src/Makefile	/^TEXSRC=testenv.tex gzip.texi texinfo.tex nonewline/
++\'	tex-src/texinfo.tex	/^\\def\\'{{'}}$/
++\@	tex-src/texinfo.tex	/^\\def\\@{@}%$/
++\`	tex-src/texinfo.tex	/^\\def\\`{{`}}$/
++\	tex-src/texinfo.tex	/^\\def\\ {{\\fontdimen2\\font=\\tclosesave{} }}%$/
++\*	tex-src/texinfo.tex	/^\\def\\*{\\hfil\\break\\hbox{}\\ignorespaces}$/
++_	tex-src/texinfo.tex	/^\\def_{\\ifusingtt\\normalunderscore\\_}$/
++\_	tex-src/texinfo.tex	/^\\def\\_{\\lvvmode \\kern.06em \\vbox{\\hrule width.3em /
++\_	tex-src/texinfo.tex	/^\\def\\_{{\\realbackslash _}}%$/
++\:	tex-src/texinfo.tex	/^\\def\\:{\\spacefactor=1000 }$/
++\.	tex-src/texinfo.tex	/^\\def\\.{.\\spacefactor=3000 }$/
++\@	tex-src/texinfo.tex	/^\\def\\@{{\\tt \\char '100}}$/
++|	tex-src/texinfo.tex	/^\\def|{{\\tt \\char '174}}$/
++~	tex-src/texinfo.tex	/^\\def~{{\\tt \\char '176}}$/
+++	tex-src/texinfo.tex	/^\\def+{{\\tt \\char 43}}$/
++>	tex-src/texinfo.tex	/^\\def>{{\\tt \\gtr}}$/
++^	tex-src/texinfo.tex	/^\\def^{{\\tt \\hat}}$/
++<	tex-src/texinfo.tex	/^\\def<{{\\tt \\less}}$/
++\	tex-src/texinfo.tex	/^\\gdef\\sepspaces{\\def {\\ }}}$/
++=	tex-src/texinfo.tex	/^\\global\\def={{\\tt \\char 61}}}$/
++=	tex-src/texinfo.tex	/^\\global\\let\\section = \\appendixsec$/
++=	tex-src/texinfo.tex	/^\\global\\let\\section = \\numberedsec$/
++=	tex-src/texinfo.tex	/^\\global\\let\\section = \\unnumberedsec$/
++=	tex-src/texinfo.tex	/^\\global\\let\\subsection = \\appendixsubsec$/
++=	tex-src/texinfo.tex	/^\\global\\let\\subsection = \\numberedsubsec$/
++=	tex-src/texinfo.tex	/^\\global\\let\\subsection = \\unnumberedsubsec$/
++=	tex-src/texinfo.tex	/^\\global\\let\\subsubsection = \\appendixsubsubsec$/
++=	tex-src/texinfo.tex	/^\\global\\let\\subsubsection = \\numberedsubsubsec$/
++=	tex-src/texinfo.tex	/^\\global\\let\\subsubsection = \\unnumberedsubsubsec$/
++TeX_suffixes	c-src/etags.c	672
++\tex	tex-src/texinfo.tex	/^\\def\\tex{\\begingroup$/
++\TeX	tex-src/texinfo.tex	/^\\def\\TeX{\\realbackslash TeX}%$/
++\TeX	tex-src/texinfo.tex	/^\\def\\TeX{\\realbackslash TeX}$/
++\textfonts	tex-src/texinfo.tex	/^\\def\\textfonts{%$/
++TEX_toktab	c-src/etags.c	4908
++texttreelist	prol-src/natded.prolog	/^texttreelist([]).$/
++/TF	ps-src/rfc1245.ps	/^\/TF { $/
++\thearg	tex-src/texinfo.tex	/^  \\def\\thearg{#1}%$/
++\thearg	tex-src/texinfo.tex	/^  \\ifx\\thearg\\empty \\def\\thearg{1}\\fi$/
++there-is-a-=-in-the-middle!	scm-src/test.scm	/^(define (there-is-a-=-in-the-middle!) #t)$/
++\thischaptername	tex-src/texinfo.tex	/^\\def\\thischaptername{No Chapter Title}$/
++\thischapter	tex-src/texinfo.tex	/^\\def\\thischapter{} \\def\\thissection{}$/
++\thischapter	tex-src/texinfo.tex	/^   \\unnumbchapmacro{#1}\\def\\thischapter{}%$/
++this_command_key_count	c-src/emacs/src/keyboard.c	108
++this_command_key_count_reset	c-src/emacs/src/keyboard.c	112
++this_command_keys	c-src/emacs/src/keyboard.c	107
++this-command-keys	c-src/emacs/src/keyboard.c	/^DEFUN ("this-command-keys", Fthis_command_keys, St/
++this-command-keys-vector	c-src/emacs/src/keyboard.c	/^DEFUN ("this-command-keys-vector", Fthis_command_k/
++this	c-src/a/b/b.c	1
++\thisfile	tex-src/texinfo.tex	/^\\def\\thisfile{}$/
++this_file_toc	perl-src/htlmify-cystic	29
++this-single-command-keys	c-src/emacs/src/keyboard.c	/^DEFUN ("this-single-command-keys", Fthis_single_co/
++this_single_command_key_start	c-src/emacs/src/keyboard.c	125
++this-single-command-raw-keys	c-src/emacs/src/keyboard.c	/^DEFUN ("this-single-command-raw-keys", Fthis_singl/
++\thistitle	tex-src/texinfo.tex	/^\\def\\thistitle{No Title}$/
++\tie	tex-src/texinfo.tex	/^\\def\\tie{\\penalty 10000\\ }     % Save plain tex de/
++tignore	c-src/etags.c	2433
++timer_check_2	c-src/emacs/src/keyboard.c	/^timer_check_2 (Lisp_Object timers, Lisp_Object idl/
++timer_check	c-src/emacs/src/keyboard.c	/^timer_check (void)$/
++timer_idleness_start_time	c-src/emacs/src/keyboard.c	335
++timer_last_idleness_start_time	c-src/emacs/src/keyboard.c	340
++timer_resume_idle	c-src/emacs/src/keyboard.c	/^timer_resume_idle (void)$/
++timers_run	c-src/emacs/src/keyboard.c	320
++timer_start_idle	c-src/emacs/src/keyboard.c	/^timer_start_idle (void)$/
++timer_stop_idle	c-src/emacs/src/keyboard.c	/^timer_stop_idle (void)$/
++Time_to_position	c-src/emacs/src/keyboard.c	/^Time_to_position (Time encoded_pos)$/
++tinbody	c-src/etags.c	2431
++\tindex	tex-src/texinfo.tex	/^\\def\\tindex {\\tpindex}$/
++\titlefont	tex-src/texinfo.tex	/^\\def\\titlefont#1{{\\titlerm #1}}$/
++\titlepage	tex-src/texinfo.tex	/^\\def\\titlepage{\\begingroup \\parindent=0pt \\textfon/
++\title	tex-src/texinfo.tex	/^   \\def\\title{\\parsearg\\titlezzz}%$/
++\titlezzz	tex-src/texinfo.tex	/^   \\def\\titlezzz##1{\\leftline{\\titlefont{##1}}$/
++tkeyseen	c-src/etags.c	2429
++tnone	c-src/etags.c	2428
++toc_line	perl-src/htlmify-cystic	/^sub toc_line ($)$/
++\today	tex-src/texinfo.tex	/^\\def\\today{\\number\\day\\space$/
++toggleDescription	objc-src/PackInsp.m	/^-toggleDescription$/
++tok	c-src/etags.c	2491
++token	c-src/etags.c	2508
++tokenizeatom	prol-src/natded.prolog	/^tokenizeatom(Atom,Ws):-$/
++tokenize	prol-src/natded.prolog	/^tokenize([C1,C2,C3|Cs],Xs-Ys,TsResult):-     % spe/
++tokentab2	y-src/cccp.y	442
++token	y-src/cccp.y	437
++token	y-src/cccp.y	439
++To_Lower	pas-src/common.pas	/^function To_Lower;(*(ch:char) : char;*)$/
++tool_bar_item_properties	c-src/emacs/src/keyboard.c	7970
++tool_bar_items	c-src/emacs/src/keyboard.c	/^tool_bar_items (Lisp_Object reuse, int *nitems)$/
++tool_bar_items_vector	c-src/emacs/src/keyboard.c	7965
++toolkit_menubar_in_use	c-src/emacs/src/keyboard.c	/^toolkit_menubar_in_use (struct frame *f)$/
++top_level_1	c-src/emacs/src/keyboard.c	/^top_level_1 (Lisp_Object ignore)$/
++top_level_2	c-src/emacs/src/keyboard.c	/^top_level_2 (void)$/
++top-level	c-src/emacs/src/keyboard.c	/^DEFUN ("top-level", Ftop_level, Stop_level, 0, 0, /
++top_level	merc-src/accumulator.m	/^:- type top_level$/
++Top	tex-src/gzip.texi	/^@node Top, , , (dir)$/
++\top	tex-src/texinfo.tex	/^\\outer\\def\\top{\\parsearg\\unnumberedzzz}$/
++To_Start_Addr/f	ada-src/2ataspri.adb	/^      function To_Start_Addr is new$/
++total_keys	c-src/emacs/src/keyboard.c	97
++TOTAL_KEYWORDS	c-src/etags.c	2325
++totally_unblock_input	c-src/emacs/src/keyboard.c	/^totally_unblock_input (void)$/
++total_size_of_entries	c-src/etags.c	/^total_size_of_entries (register node *np)$/
++total_surrounding	cp-src/conway.cpp	/^int site::total_surrounding(void)$/
++To_TCB_Ptr/f	ada-src/2ataspri.adb	/^   function To_TCB_Ptr is new$/
++To_Upper	pas-src/common.pas	/^function To_Upper;(*(ch:char) : char;*)$/
++To_void_ptr/f	ada-src/2ataspri.adb	/^   function To_void_ptr is new$/
++tpcmd	c-src/h.h	15
++tpcmd	c-src/h.h	8
++/T	ps-src/rfc1245.ps	/^\/T { $/
++tracking_off	c-src/emacs/src/keyboard.c	/^tracking_off (Lisp_Object old_value)$/
++track-mouse	c-src/emacs/src/keyboard.c	/^DEFUN ("internal--track-mouse", Ftrack_mouse, Stra/
++traffic_light	cp-src/conway.cpp	/^void traffic_light(int x, int y)$/
++translate	c-src/emacs/src/regex.h	361
++treats	cp-src/c.C	131
++Truc.Bidule/b	ada-src/etags-test-for.ada	/^package body Truc.Bidule is$/
++Truc.Bidule/b	ada-src/waroquiers.ada	/^package body Truc.Bidule is$/
++Truc.Bidule/s	ada-src/etags-test-for.ada	/^package Truc.Bidule is$/
++Truc.Bidule/s	ada-src/waroquiers.ada	/^package Truc.Bidule is$/
++Truc/s	ada-src/etags-test-for.ada	/^package Truc is$/
++Truc/s	ada-src/waroquiers.ada	/^package Truc is$/
++TSL/s	ada-src/2ataspri.adb	/^   package TSL renames System.Tasking_Soft_Links;$/
++tt=cmtt10	tex-src/texinfo.tex	/^\\font\\deftt=cmtt10 scaled \\magstep1$/
++\t	tex-src/texinfo.tex	/^\\def\\t##1{\\realbackslash r {##1}}%$/
++\t	tex-src/texinfo.tex	/^\\def\\t#1{{\\tt \\exhyphenpenalty=10000\\rawbackslash /
++tt	prol-src/natded.prolog	/^tt:-$/
++\tt	tex-src/texinfo.tex	/^\\def\\tt{\\realbackslash tt}%$/
++\tt	tex-src/texinfo.tex	/^\\def\\tt{\\realbackslash tt}$/
++ttypeseen	c-src/etags.c	2430
++tty_read_avail_input	c-src/emacs/src/keyboard.c	/^tty_read_avail_input (struct terminal *terminal,$/
++\turnoffactive	tex-src/texinfo.tex	/^\\def\\turnoffactive{\\let"=\\normaldoublequote$/
++/two	ps-src/rfc1245.ps	/^\/two \/three \/four \/five \/six \/seven \/eight \/nine \//
++typdef	c-src/etags.c	2434
++type	c-src/emacs/src/gmalloc.c	145
++type	c-src/emacs/src/lisp.h	1973
++type	c-src/emacs/src/lisp.h	1980
++type	c-src/emacs/src/lisp.h	2034
++type	c-src/emacs/src/lisp.h	2112
++type	c-src/emacs/src/lisp.h	2203
++type	c-src/emacs/src/lisp.h	2276
++type	c-src/emacs/src/lisp.h	2286
++type	c-src/emacs/src/lisp.h	2296
++type	c-src/emacs/src/lisp.h	2304
++type	c-src/emacs/src/lisp.h	2364
++type	c-src/emacs/src/lisp.h	3025
++type	c-src/etags.c	2271
++typefunargs	tex-src/texinfo.tex	/^\\deftypefunargs {#3}\\endgroup %$/
++typefunargs	tex-src/texinfo.tex	/^\\deftypefunargs {#4}\\endgroup %$/
++typemargin	tex-src/texinfo.tex	/^\\newskip\\deftypemargin \\deftypemargin=12pt$/
++typemargin	tex-src/texinfo.tex	/^\\rlap{\\rightline{{\\rm #2}\\hskip \\deftypemargin}}}%/
++TYPE_RANGED_INTEGERP	c-src/emacs/src/lisp.h	/^#define TYPE_RANGED_INTEGERP(type, x) \\$/
++Type_Specific_Data/t	ada-src/etags-test-for.ada	/^   type Type_Specific_Data is record$/
++TYPESTOSTAT	objc-src/PackInsp.h	37
++/Uacute	ps-src/rfc1245.ps	/^\/Uacute \/Ucircumflex \/Ugrave \/dotlessi \/circumflex/
++u_any	c-src/emacs/src/lisp.h	2214
++u_boolfwd	c-src/emacs/src/lisp.h	2371
++u_buffer_objfwd	c-src/emacs/src/lisp.h	2373
++UCHAR	c-src/emacs/src/lisp.h	2424
++_UCHAR_T	c-src/emacs/src/lisp.h	2423
++U_CHAR	y-src/cccp.y	38
++u	c-src/emacs/src/lisp.h	2397
++/udieresis	ps-src/rfc1245.ps	/^\/udieresis \/dagger \/.notdef \/cent \/sterling \/secti/
++u_finalizer	c-src/emacs/src/lisp.h	2219
++u_free	c-src/emacs/src/lisp.h	2215
++u_intfwd	c-src/emacs/src/lisp.h	2370
++u_kboard_objfwd	c-src/emacs/src/lisp.h	2374
++u_marker	c-src/emacs/src/lisp.h	2216
++unargs	tex-src/texinfo.tex	/^\\defunargs {#2}\\endgroup %$/
++unargs	tex-src/texinfo.tex	/^\\defunargs {#3}\\endgroup %$/
++UNARY	y-src/cccp.c	18
++unblock_input	c-src/emacs/src/keyboard.c	/^unblock_input (void)$/
++unblock_input_to	c-src/emacs/src/keyboard.c	/^unblock_input_to (int level)$/
++unchar	c-src/h.h	99
++UNDEFINED	c-src/h.h	118
++UNEVALLED	c-src/emacs/src/lisp.h	2834
++unexpand-abbrev	c-src/abbrev.c	/^DEFUN ("unexpand-abbrev", Funexpand_abbrev, Sunexp/
++UNGCPRO	c-src/emacs/src/lisp.h	3202
++UNGCPRO	c-src/emacs/src/lisp.h	3257
++UNGCPRO	c-src/emacs/src/lisp.h	3353
++univ	merc-src/accumulator.m	/^:- import_module univ.$/
++UNLOCK_ALIGNED_BLOCKS	c-src/emacs/src/gmalloc.c	/^#define UNLOCK_ALIGNED_BLOCKS()				\\$/
++UNLOCK_ALIGNED_BLOCKS	c-src/emacs/src/gmalloc.c	/^#define UNLOCK_ALIGNED_BLOCKS()$/
++UNLOCK	c-src/emacs/src/gmalloc.c	/^#define UNLOCK()				\\$/
++UNLOCK	c-src/emacs/src/gmalloc.c	/^#define UNLOCK()$/
++Unlock/p	ada-src/2ataspri.adb	/^   procedure Unlock (L : in out Lock) is$/
++Unlock/p	ada-src/2ataspri.ads	/^   procedure Unlock (L : in out Lock);$/
++\unnchfopen	tex-src/texinfo.tex	/^\\def\\unnchfopen #1{%$/
++\unnchfplain	tex-src/texinfo.tex	/^\\def\\unnchfplain #1{%$/
++\unnumbchapentry	tex-src/texinfo.tex	/^\\def\\unnumbchapentry#1#2{\\dochapentry{#1}{#2}}$/
++\unnumberedsec	tex-src/texinfo.tex	/^\\outer\\def\\unnumberedsec{\\parsearg\\unnumberedseczz/
++\unnumberedseczzz	tex-src/texinfo.tex	/^\\def\\unnumberedseczzz #1{\\seccheck{unnumberedsec}%/
++\unnumberedsubsec	tex-src/texinfo.tex	/^\\outer\\def\\unnumberedsubsec{\\parsearg\\unnumberedsu/
++\unnumberedsubseczzz	tex-src/texinfo.tex	/^\\def\\unnumberedsubseczzz #1{\\seccheck{unnumberedsu/
++\unnumberedsubsubsec	tex-src/texinfo.tex	/^\\outer\\def\\unnumberedsubsubsec{\\parsearg\\unnumbere/
++\unnumberedsubsubseczzz	tex-src/texinfo.tex	/^\\def\\unnumberedsubsubseczzz #1{\\seccheck{unnumbere/
++\unnumbered	tex-src/texinfo.tex	/^\\outer\\def\\unnumbered{\\parsearg\\unnumberedzzz}$/
++\unnumberedzzz	tex-src/texinfo.tex	/^\\def\\unnumberedzzz #1{\\seccheck{unnumbered}%$/
++\unnumbnoderef	tex-src/texinfo.tex	/^\\def\\unnumbnoderef{\\ifx\\lastnode\\relax\\else$/
++\unnumbsecentry	tex-src/texinfo.tex	/^      \\def\\unnumbsecentry ##1##2{}$/
++\unnumbsecentry	tex-src/texinfo.tex	/^\\def\\unnumbsecentry#1#2{\\dosecentry{#1}{#2}}$/
++\unnumbsetref	tex-src/texinfo.tex	/^\\def\\unnumbsetref#1{%$/
++\unnumbsubsecentry	tex-src/texinfo.tex	/^      \\def\\unnumbsubsecentry ##1##2{}$/
++\unnumbsubsecentry	tex-src/texinfo.tex	/^\\def\\unnumbsubsecentry#1#2{\\dosubsecentry{#1}{#2}}/
++\unnumbsubsubsecentry	tex-src/texinfo.tex	/^      \\def\\unnumbsubsubsecentry ##1##2{}$/
++\unnumbsubsubsecentry	tex-src/texinfo.tex	/^\\def\\unnumbsubsubsecentry#1#2{\\dosubsubsecentry{#1/
++unravel_univ	merc-src/accumulator.m	/^:- some [T] pred unravel_univ(univ::in, T::out) is/
++unread_switch_frame	c-src/emacs/src/keyboard.c	204
++UNSIGNED_CMP	c-src/emacs/src/lisp.h	/^#define UNSIGNED_CMP(a, op, b)						\\$/
++unsignedp	y-src/cccp.y	112
++unwind	c-src/emacs/src/lisp.h	2962
++unwind_int	c-src/emacs/src/lisp.h	2972
++unwind_ptr	c-src/emacs/src/lisp.h	2967
++unwind_void	c-src/emacs/src/lisp.h	2976
++u_objfwd	c-src/emacs/src/lisp.h	2372
++u_overlay	c-src/emacs/src/lisp.h	2217
++__up	c.c	160
++update_accumulator_pred	merc-src/accumulator.m	/^:- pred update_accumulator_pred(pred_id::in, proc_/
++\uppercaseenumerate	tex-src/texinfo.tex	/^\\def\\uppercaseenumerate{%$/
++uprintmax_t	c-src/emacs/src/lisp.h	149
++uprintmax_t	c-src/emacs/src/lisp.h	154
++/U	ps-src/rfc1245.ps	/^\/U { $/
++usage	perl-src/yagrip.pl	/^sub usage {$/
++u_save_value	c-src/emacs/src/lisp.h	2218
++usecharno	c-src/etags.c	210
++used	c-src/emacs/src/regex.h	347
++used_syntax	c-src/emacs/src/regex.h	398
++USE_LSB_TAG	c-src/emacs/src/lisp.h	271
++USE_LSB_TAG	c-src/emacs/src/lisp.h	/^DEFINE_GDB_SYMBOL_BEGIN (bool, USE_LSB_TAG)$/
++USE_PTHREAD	c-src/emacs/src/gmalloc.c	25
++user_cmp_function	c-src/emacs/src/lisp.h	1814
++UserEdit	pyt-src/server.py	/^class UserEdit(Frame):$/
++user_error	c-src/emacs/src/keyboard.c	/^user_error (const char *msg)$/
++user_hash_function	c-src/emacs/src/lisp.h	1811
++User	pyt-src/server.py	/^class User:$/
++user_signal_info	c-src/emacs/src/keyboard.c	7235
++user_signals	c-src/emacs/src/keyboard.c	7250
++USE_SAFE_ALLOCA	c-src/emacs/src/lisp.h	4560
++USE_STACK_CONS	c-src/emacs/src/lisp.h	4689
++USE_STACK_LISP_OBJECTS	c-src/emacs/src/lisp.h	4652
++USE_STACK_LISP_OBJECTS	c-src/emacs/src/lisp.h	4658
++USE_STACK_LISP_OBJECTS	c-src/emacs/src/lisp.h	4659
++USE_STACK_STRING	c-src/emacs/src/lisp.h	4691
++usfreelock_ptr/t	ada-src/etags-test-for.ada	/^   type usfreelock_ptr is access$/
++Vabbrev_start_location_buffer	c-src/abbrev.c	66
++Vabbrev_start_location	c-src/abbrev.c	63
++Vabbrev_table_name_list	c-src/abbrev.c	43
++VALBITS	c-src/emacs/src/lisp.h	246
++valcell	c-src/emacs/src/lisp.h	2357
++val	c-src/emacs/src/lisp.h	3027
++val	c-src/emacs/src/lisp.h	691
++val	c-src/getopt.h	84
++validate	php-src/lce_functions.php	/^      function validate($value)$/
++valid	c-src/etags.c	220
++valid	c-src/etags.c	2502
++valloc	c-src/emacs/src/gmalloc.c	/^valloc (size_t size)$/
++VALMASK	c-src/emacs/src/lisp.h	829
++VALMASK	c-src/emacs/src/lisp.h	/^DEFINE_GDB_SYMBOL_BEGIN (EMACS_INT, VALMASK)$/
++VAL_MAX	c-src/emacs/src/lisp.h	263
++val	prol-src/natded.prolog	/^val(X) --> ['['], valseq(X), [']'].$/
++valseq	prol-src/natded.prolog	/^valseq([Val|Vals]) --> val(Val), plusvalseq(Vals)./
++ValToNmStr	pas-src/common.pas	/^function ValToNmStr; (*($/
++value	c-src/emacs/src/lisp.h	687
++value	y-src/cccp.y	112
++varargs	tex-src/texinfo.tex	/^\\defvarargs {#2}\\endgroup %$/
++varargs	tex-src/texinfo.tex	/^\\defvarargs {#3}\\endgroup %$/
++var	c-src/emacs/src/keyboard.c	11023
++var	c-src/emacs/src/lisp.h	3137
++varset	merc-src/accumulator.m	/^:- import_module varset.$/
++\var	tex-src/texinfo.tex	/^\\def\\var##1{\\realbackslash var {##1}}%$/
++\var	tex-src/texinfo.tex	/^\\def\\var##1{\\realbackslash var {##1}}$/
++vcopy	c-src/emacs/src/lisp.h	/^vcopy (Lisp_Object v, ptrdiff_t offset, Lisp_Objec/
++VECSIZE	c-src/emacs/src/lisp.h	/^#define VECSIZE(type)						\\$/
++vectorlike_header	c-src/emacs/src/lisp.h	1343
++VECTORLIKEP	c-src/emacs/src/lisp.h	/^# define VECTORLIKEP(x) lisp_h_VECTORLIKEP (x)$/
++VECTORP	c-src/emacs/src/lisp.h	/^VECTORP (Lisp_Object x)$/
++verde	cp-src/c.C	40
++verify_ascii	c-src/emacs/src/lisp.h	/^# define verify_ascii(str) (str)$/
++verify-tags-table-function	el-src/emacs/lisp/progmodes/etags.el	/^(defvar verify-tags-table-function nil$/
++VERSION	c-src/etags.c	789
++VERSION	erl-src/gs_dialog.erl	/^-define(VERSION, '2001.1101').$/
++VERSION	objc-src/PackInsp.m	34
++Vfundamental_mode_abbrev_table	c-src/abbrev.c	52
++Vglobal_abbrev_table	c-src/abbrev.c	48
++VHDLFLAGS	make-src/Makefile	/^VHDLFLAGS=--language=none --regex='\/[ \\t]*\\(ARCHIT/
++vignore	c-src/etags.c	2417
++\vindex	tex-src/texinfo.tex	/^\\def\\vindex {\\vrindex}$/
++visit-tags-table-buffer	el-src/emacs/lisp/progmodes/etags.el	/^(defun visit-tags-table-buffer (&optional cont)$/
++visit-tags-table	el-src/emacs/lisp/progmodes/etags.el	/^(defun visit-tags-table (file &optional local)$/
++Vlast_abbrev	c-src/abbrev.c	70
++Vlast_abbrev_text	c-src/abbrev.c	75
++Vlispy_mouse_stem	c-src/emacs/src/keyboard.c	5172
++void	c-src/emacs/src/lisp.h	/^INLINE void (check_cons_list) (void) { lisp_h_chec/
++voidfuncptr	c-src/emacs/src/lisp.h	2108
++voidval	y-src/cccp.y	115
++/V	ps-src/rfc1245.ps	/^\/V { $/
++\vritemindex	tex-src/texinfo.tex	/^\\def\\vritemindex #1{\\doind {vr}{\\code{#1}}}%$/
++\vtable	tex-src/texinfo.tex	/^\\def\\vtable{\\begingroup\\inENV\\obeylines\\obeyspaces/
++waiting_for_input	c-src/emacs/src/keyboard.c	150
++WAIT_READING_MAX	c-src/emacs/src/lisp.h	4281
++WAIT_READING_MAX	c-src/emacs/src/lisp.h	4283
++wait_status_ptr_t	c.c	161
++WARNINGS	make-src/Makefile	/^WARNINGS=-pedantic -Wall -Wpointer-arith -Winline /
++warning	y-src/cccp.y	/^warning (msg)$/
++/wbytes	ps-src/rfc1245.ps	/^\/wbytes { $/
++WCHAR_TYPE_SIZE	y-src/cccp.y	99
++weak_alias	c-src/emacs/src/gmalloc.c	/^weak_alias (free, cfree)$/
++weak	c-src/emacs/src/lisp.h	1830
++web ftp publish	make-src/Makefile	/^web ftp publish:$/
++what	c-src/etags.c	252
++wheel_syms	c-src/emacs/src/keyboard.c	4628
++where	cp-src/clheir.hpp	77
++where	c-src/emacs/src/lisp.h	2348
++where	c-src/emacs/src/lisp.h	2980
++where_in_registry	cp-src/clheir.hpp	15
++WHITE	cp-src/screen.hpp	27
++/wh	ps-src/rfc1245.ps	/^\/wh { $/
++WINDOW_CONFIGURATIONP	c-src/emacs/src/lisp.h	/^WINDOW_CONFIGURATIONP (Lisp_Object a)$/
++WINDOWP	c-src/emacs/src/lisp.h	/^WINDOWP (Lisp_Object a)$/
++WINDOWSNT	c-src/etags.c	101
++WINDOWSNT	c-src/etags.c	102
++windowWillClose	objcpp-src/SimpleCalc.M	/^- windowWillClose:sender$/
++wipe_kboard	c-src/emacs/src/keyboard.c	/^wipe_kboard (KBOARD *kb)$/
++womboid	c-src/h.h	63
++womboid	c-src/h.h	75
++word_size	c-src/emacs/src/lisp.h	1473
++WorkingDays	cp-src/functions.cpp	/^int WorkingDays(Date a, Date b){$/
++WORKING	objc-src/PackInsp.m	368
++/W	ps-src/rfc1245.ps	/^\/W { $/
++write1=	ruby-src/test1.ru	/^    attr_reader :read1 , :read2; attr_writer :writ/
++write2=	ruby-src/test1.ru	/^    attr_reader :read1 , :read2; attr_writer :writ/
++write_abbrev	c-src/abbrev.c	/^write_abbrev (sym, stream)$/
++writebreaklex	prol-src/natded.prolog	/^writebreaklex([]).$/
++writebreak	prol-src/natded.prolog	/^writebreak([]).$/
++writecat	prol-src/natded.prolog	/^writecat(np(ind(sng),nm(_)),np,[],[]):-!.$/
++write_classname	c-src/etags.c	/^write_classname (linebuffer *cn, const char *quali/
++write_lex_cat	prol-src/natded.prolog	/^write_lex_cat(File):-$/
++write_lex	prol-src/natded.prolog	/^write_lex(File):-$/
++writelist	prol-src/natded.prolog	/^writelist([der(Ws)|Ws2]):-$/
++writelistsubs	prol-src/natded.prolog	/^writelistsubs([],X):-$/
++Write_Lock/p	ada-src/2ataspri.adb	/^   procedure Write_Lock (L : in out Lock; Ceiling_/
++Write_Lock/p	ada-src/2ataspri.ads	/^   procedure Write_Lock (L : in out Lock; Ceiling_/
++writenamestring	pas-src/common.pas	/^procedure writenamestring;(*($/
++write	php-src/lce_functions.php	/^      function write()$/
++write	php-src/lce_functions.php	/^      function write($save="yes")$/
++writesubs	prol-src/natded.prolog	/^writesubs([]).$/
++writesups	prol-src/natded.prolog	/^writesups([]).$/
++write_xyc	cp-src/screen.cpp	/^void write_xyc(int x, int y, char c)$/
++written	c-src/etags.c	211
++\w	tex-src/texinfo.tex	/^\\def\\w#1{\\leavevmode\\hbox{#1}}$/
++\w	tex-src/texinfo.tex	/^\\def\\w{\\realbackslash w }%$/
++\w	tex-src/texinfo.tex	/^\\def\\w{\\realbackslash w}$/
++XBOOL_VECTOR	c-src/emacs/src/lisp.h	/^XBOOL_VECTOR (Lisp_Object a)$/
++XBUFFER	c-src/emacs/src/lisp.h	/^XBUFFER (Lisp_Object a)$/
++XBUFFER_OBJFWD	c-src/emacs/src/lisp.h	/^XBUFFER_OBJFWD (union Lisp_Fwd *a)$/
++xcar_addr	c-src/emacs/src/lisp.h	/^xcar_addr (Lisp_Object c)$/
++XCAR	c-src/emacs/src/lisp.h	/^# define XCAR(c) lisp_h_XCAR (c)$/
++x	c.c	153
++x	c.c	179
++x	c.c	188
++x	c.c	189
++xcdr_addr	c-src/emacs/src/lisp.h	/^xcdr_addr (Lisp_Object c)$/
++XCDR	c-src/emacs/src/lisp.h	/^# define XCDR(c) lisp_h_XCDR (c)$/
++XCHAR_TABLE	c-src/emacs/src/lisp.h	/^XCHAR_TABLE (Lisp_Object a)$/
++XCHG_0	c-src/sysdep.h	47
++XCHG_1	c-src/sysdep.h	48
++XCHG_2	c-src/sysdep.h	49
++XCHG_3	c-src/sysdep.h	50
++XCHG_4	c-src/sysdep.h	51
++XCHG_5	c-src/sysdep.h	52
++XCONS	c-src/emacs/src/lisp.h	/^# define XCONS(a) lisp_h_XCONS (a)$/
++x	cp-src/c.C	53
++x	cp-src/c.C	80
++x	cp-src/clheir.hpp	49
++x	cp-src/clheir.hpp	58
++x	cp-src/conway.hpp	7
++x	cp-src/fail.C	10
++x	cp-src/fail.C	44
++X	c-src/h.h	100
++XDEFUN	c.c	/^XDEFUN ("x-get-selection-internal", Fx_get_selecti/
++xdiff	make-src/Makefile	/^xdiff: ETAGS EXTAGS ${infiles}$/
++XFASTINT	c-src/emacs/src/lisp.h	/^#  define XFASTINT(a) lisp_h_XFASTINT (a)$/
++XFASTINT	c-src/emacs/src/lisp.h	/^XFASTINT (Lisp_Object a)$/
++XFINALIZER	c-src/emacs/src/lisp.h	/^XFINALIZER (Lisp_Object a)$/
++XFLOAT	c-src/emacs/src/lisp.h	/^XFLOAT (Lisp_Object a)$/
++XFLOAT_DATA	c-src/emacs/src/lisp.h	/^XFLOAT_DATA (Lisp_Object f)$/
++XFLOATINT	c-src/emacs/src/lisp.h	/^XFLOATINT (Lisp_Object n)$/
++XFWDTYPE	c-src/emacs/src/lisp.h	/^XFWDTYPE (union Lisp_Fwd *a)$/
++x-get-selection-internal	c.c	/^DEFUN ("x-get-selection-internal", Fx_get_selectio/
++x-get-selection-internal	c.c	/^       Fx_get_selection_internal, Sx_get_selection/
++XHASH	c-src/emacs/src/lisp.h	/^# define XHASH(a) lisp_h_XHASH (a)$/
++XHASH_TABLE	c-src/emacs/src/lisp.h	/^XHASH_TABLE (Lisp_Object a)$/
++XIL	c-src/emacs/src/lisp.h	/^# define XIL(i) lisp_h_XIL (i)$/
++XINT	c-src/emacs/src/lisp.h	/^#  define XINT(a) lisp_h_XINT (a)$/
++XINT	c-src/emacs/src/lisp.h	/^XINT (Lisp_Object a)$/
++XINTPTR	c-src/emacs/src/lisp.h	/^XINTPTR (Lisp_Object a)$/
++\xitem	tex-src/texinfo.tex	/^\\def\\xitem{\\errmessage{@xitem while not in a table/
++\xitemx	tex-src/texinfo.tex	/^\\def\\xitemx{\\errmessage{@xitemx while not in a tab/
++\xitemzzz	tex-src/texinfo.tex	/^\\def\\xitemzzz #1{\\dosubind {kw}{\\code{#1}}{for {\\b/
++\xkey	tex-src/texinfo.tex	/^\\def\\xkey{\\key}$/
++XLI_BUILTIN_LISPSYM	c-src/emacs/src/lisp.h	/^#define XLI_BUILTIN_LISPSYM(iname) TAG_SYMOFFSET (/
++XLI	c-src/emacs/src/lisp.h	/^# define XLI(o) lisp_h_XLI (o)$/
++xmalloc	c-src/etags.c	/^xmalloc (size_t size)$/
++XMARKER	c-src/emacs/src/lisp.h	/^XMARKER (Lisp_Object a)$/
++XMISCANY	c-src/emacs/src/lisp.h	/^XMISCANY (Lisp_Object a)$/
++XMISC	c-src/emacs/src/lisp.h	/^XMISC (Lisp_Object a)$/
++XMISCTYPE	c-src/emacs/src/lisp.h	/^XMISCTYPE (Lisp_Object a)$/
++xnew	c-src/etags.c	/^#define xnew(n, Type)      ((Type *) xmalloc ((n) /
++XOVERLAY	c-src/emacs/src/lisp.h	/^XOVERLAY (Lisp_Object a)$/
++XPNTR	c-src/emacs/src/lisp.h	/^# define XPNTR(a) lisp_h_XPNTR (a)$/
++XPROCESS	c-src/emacs/src/lisp.h	/^XPROCESS (Lisp_Object a)$/
++/X	ps-src/rfc1245.ps	/^\/X { $/
++\xrdef	tex-src/texinfo.tex	/^\\def\\xrdef #1#2{$/
++xrealloc	c-src/etags.c	/^xrealloc (void *ptr, size_t size)$/
++xref-etags-location	el-src/emacs/lisp/progmodes/etags.el	/^(defclass xref-etags-location (xref-location)$/
++xref-location-line	el-src/emacs/lisp/progmodes/etags.el	/^(cl-defmethod xref-location-line ((l xref-etags-lo/
++xref-location-marker	el-src/emacs/lisp/progmodes/etags.el	/^(cl-defmethod xref-location-marker ((l xref-etags-/
++xref-make-etags-location	el-src/emacs/lisp/progmodes/etags.el	/^(defun xref-make-etags-location (tag-info file)$/
++\xref	tex-src/texinfo.tex	/^\\def\\xref#1{See \\xrefX[#1,,,,,,,]}$/
++\xrefX[	tex-src/texinfo.tex	/^\\def\\xrefX[#1,#2,#3,#4,#5,#6]{\\begingroup%$/
++xrnew	c-src/etags.c	/^#define xrnew(op, n, Type) ((op) = (Type *) xreall/
++XSAVE_FUNCPOINTER	c-src/emacs/src/lisp.h	/^XSAVE_FUNCPOINTER (Lisp_Object obj, int n)$/
++XSAVE_INTEGER	c-src/emacs/src/lisp.h	/^XSAVE_INTEGER (Lisp_Object obj, int n)$/
++XSAVE_OBJECT	c-src/emacs/src/lisp.h	/^XSAVE_OBJECT (Lisp_Object obj, int n)$/
++XSAVE_POINTER	c-src/emacs/src/lisp.h	/^XSAVE_POINTER (Lisp_Object obj, int n)$/
++XSAVE_VALUE	c-src/emacs/src/lisp.h	/^XSAVE_VALUE (Lisp_Object a)$/
++XSETBOOL_VECTOR	c-src/emacs/src/lisp.h	/^#define XSETBOOL_VECTOR(a, b) (XSETPSEUDOVECTOR (a/
++XSETBUFFER	c-src/emacs/src/lisp.h	/^#define XSETBUFFER(a, b) (XSETPSEUDOVECTOR (a, b, /
++XSETCDR	c-src/emacs/src/lisp.h	/^XSETCDR (Lisp_Object c, Lisp_Object n)$/
++XSETCHAR_TABLE	c-src/emacs/src/lisp.h	/^#define XSETCHAR_TABLE(a, b) (XSETPSEUDOVECTOR (a,/
++XSETCOMPILED	c-src/emacs/src/lisp.h	/^#define XSETCOMPILED(a, b) (XSETPSEUDOVECTOR (a, b/
++XSETCONS	c-src/emacs/src/lisp.h	/^#define XSETCONS(a, b) ((a) = make_lisp_ptr (b, Li/
++XSETFASTINT	c-src/emacs/src/lisp.h	/^#define XSETFASTINT(a, b) ((a) = make_natnum (b))$/
++XSETFLOAT	c-src/emacs/src/lisp.h	/^#define XSETFLOAT(a, b) ((a) = make_lisp_ptr (b, L/
++XSET_HASH_TABLE	c-src/emacs/src/lisp.h	/^#define XSET_HASH_TABLE(VAR, PTR) \\$/
++XSETINT	c-src/emacs/src/lisp.h	/^#define XSETINT(a, b) ((a) = make_number (b))$/
++XSETMISC	c-src/emacs/src/lisp.h	/^#define XSETMISC(a, b) ((a) = make_lisp_ptr (b, Li/
++XSETPROCESS	c-src/emacs/src/lisp.h	/^#define XSETPROCESS(a, b) (XSETPSEUDOVECTOR (a, b,/
++XSETPSEUDOVECTOR	c-src/emacs/src/lisp.h	/^#define XSETPSEUDOVECTOR(a, b, code) \\$/
++XSETPVECTYPE	c-src/emacs/src/lisp.h	/^#define XSETPVECTYPE(v, code)						\\$/
++XSETPVECTYPESIZE	c-src/emacs/src/lisp.h	/^#define XSETPVECTYPESIZE(v, code, lispsize, restsi/
++XSETSTRING	c-src/emacs/src/lisp.h	/^#define XSETSTRING(a, b) ((a) = make_lisp_ptr (b, /
++XSETSUB_CHAR_TABLE	c-src/emacs/src/lisp.h	/^#define XSETSUB_CHAR_TABLE(a, b) (XSETPSEUDOVECTOR/
++XSETSUBR	c-src/emacs/src/lisp.h	/^#define XSETSUBR(a, b) (XSETPSEUDOVECTOR (a, b, PV/
++XSETSYMBOL	c-src/emacs/src/lisp.h	/^#define XSETSYMBOL(a, b) ((a) = make_lisp_symbol (/
++XSETTERMINAL	c-src/emacs/src/lisp.h	/^#define XSETTERMINAL(a, b) (XSETPSEUDOVECTOR (a, b/
++XSETTYPED_PSEUDOVECTOR	c-src/emacs/src/lisp.h	/^#define XSETTYPED_PSEUDOVECTOR(a, b, size, code)		/
++XSETVECTOR	c-src/emacs/src/lisp.h	/^#define XSETVECTOR(a, b) ((a) = make_lisp_ptr (b, /
++XSETWINDOW_CONFIGURATION	c-src/emacs/src/lisp.h	/^#define XSETWINDOW_CONFIGURATION(a, b) \\$/
++XSETWINDOW	c-src/emacs/src/lisp.h	/^#define XSETWINDOW(a, b) (XSETPSEUDOVECTOR (a, b, /
++XSTRING	c-src/emacs/src/lisp.h	/^XSTRING (Lisp_Object a)$/
++XSUB_CHAR_TABLE	c-src/emacs/src/lisp.h	/^XSUB_CHAR_TABLE (Lisp_Object a)$/
++XSUBR	c-src/emacs/src/lisp.h	/^XSUBR (Lisp_Object a)$/
++XSYMBOL	c-src/emacs/src/lisp.h	/^#  define XSYMBOL(a) lisp_h_XSYMBOL (a)$/
++XSYMBOL	c-src/emacs/src/lisp.h	/^XSYMBOL (Lisp_Object a)$/
++XTERMINAL	c-src/emacs/src/lisp.h	/^XTERMINAL (Lisp_Object a)$/
++x	tex-src/texinfo.tex	/^\\refx{#1-snt}{} [\\printednodename], page\\tie\\refx{/
++XTYPE	c-src/emacs/src/lisp.h	/^#  define XTYPE(a) lisp_h_XTYPE (a)$/
++XTYPE	c-src/emacs/src/lisp.h	/^XTYPE (Lisp_Object a)$/
++XUNTAG	c-src/emacs/src/lisp.h	/^#  define XUNTAG(a, type) lisp_h_XUNTAG (a, type)$/
++XUNTAG	c-src/emacs/src/lisp.h	/^XUNTAG (Lisp_Object a, int type)$/
++XWINDOW	c-src/emacs/src/lisp.h	/^XWINDOW (Lisp_Object a)$/
++XX	cp-src/x.cc	1
++xx	make-src/Makefile	/^xx="this line is here because of a fontlock bug$/
++xyz	ruby-src/test1.ru	/^    alias_method :xyz,$/
++Xyzzy	ruby-src/test1.ru	13
++YACC	c-src/etags.c	2199
++Yacc_entries	c-src/etags.c	/^Yacc_entries (FILE *inf)$/
++Yacc_help	c-src/etags.c	693
++Yacc_suffixes	c-src/etags.c	691
++\Yappendixletterandtype	tex-src/texinfo.tex	/^\\def\\Yappendixletterandtype{%$/
++y	cp-src/clheir.hpp	49
++y	cp-src/clheir.hpp	58
++y	cp-src/conway.hpp	7
++Y	c-src/h.h	100
++YELLOW	cp-src/screen.hpp	26
++/yen	ps-src/rfc1245.ps	/^\/yen \/.notdef \/.notdef \/.notdef \/.notdef \/.notdef /
++y-get-selection-internal	c.c	/^      Fy_get_selection_internal, Sy_get_selection_/
++\Ynothing	tex-src/texinfo.tex	/^\\def\\Ynothing{}$/
++\Ypagenumber	tex-src/texinfo.tex	/^\\def\\Ypagenumber{\\folio}$/
++/Y	ps-src/rfc1245.ps	/^\/Y { $/
++\Ysectionnumberandtype	tex-src/texinfo.tex	/^\\def\\Ysectionnumberandtype{%$/
++YSRC	make-src/Makefile	/^YSRC=parse.y parse.c atest.y cccp.c cccp.y$/
++\Ytitle	tex-src/texinfo.tex	/^\\def\\Ytitle{\\thischapter}$/
++YYABORT	/usr/share/bison/bison.simple	153
++YYABORT	/usr/share/bison/bison.simple	154
++YYACCEPT	/usr/share/bison/bison.simple	152
++YYACCEPT	/usr/share/bison/bison.simple	153
++yyalloc	/usr/share/bison/bison.simple	83
++yyalloc	/usr/share/bison/bison.simple	84
++YYBACKUP	/usr/share/bison/bison.simple	/^#define YYBACKUP(Token, Value)					\\$/
++YYBISON	y-src/cccp.c	4
++YYBISON	y-src/parse.c	4
++yyclearin	/usr/share/bison/bison.simple	149
++yyclearin	/usr/share/bison/bison.simple	150
++yydebug	/usr/share/bison/bison.simple	237
++yydebug	/usr/share/bison/bison.simple	238
++YY_DECL_NON_LSP_VARIABLES	/usr/share/bison/bison.simple	374
++YY_DECL_VARIABLES	/usr/share/bison/bison.simple	385
++YY_DECL_VARIABLES	/usr/share/bison/bison.simple	391
++YYDPRINTF	/usr/share/bison/bison.simple	/^# define YYDPRINTF(Args)			\\$/
++YYDPRINTF	/usr/share/bison/bison.simple	/^# define YYDPRINTF(Args)$/
++YYEMPTY	/usr/share/bison/bison.simple	150
++YYEMPTY	/usr/share/bison/bison.simple	151
++YYEOF	/usr/share/bison/bison.simple	151
++YYEOF	/usr/share/bison/bison.simple	152
++YYERRCODE	/usr/share/bison/bison.simple	178
++YYERRCODE	/usr/share/bison/bison.simple	179
++yyerrhandle	/usr/share/bison/bison.simple	848
++yyerrlab1	/usr/share/bison/bison.simple	823
++yyerrok	/usr/share/bison/bison.simple	148
++yyerrok	/usr/share/bison/bison.simple	149
++YYERROR	/usr/share/bison/bison.simple	154
++YYERROR	/usr/share/bison/bison.simple	155
++yyerror	y-src/cccp.y	/^yyerror (s)$/
++yyerrstatus	/usr/share/bison/bison.simple	846
++YYFAIL	/usr/share/bison/bison.simple	158
++YYFAIL	/usr/share/bison/bison.simple	159
++YYFPRINTF	/usr/share/bison/bison.simple	225
++YYFPRINTF	/usr/share/bison/bison.simple	226
++YYINITDEPTH	/usr/share/bison/bison.simple	244
++YYINITDEPTH	/usr/share/bison/bison.simple	245
++YYLEX	/usr/share/bison/bison.simple	200
++YYLEX	/usr/share/bison/bison.simple	201
++YYLEX	/usr/share/bison/bison.simple	202
++YYLEX	/usr/share/bison/bison.simple	203
++YYLEX	/usr/share/bison/bison.simple	206
++YYLEX	/usr/share/bison/bison.simple	207
++YYLEX	/usr/share/bison/bison.simple	208
++YYLEX	/usr/share/bison/bison.simple	209
++YYLEX	/usr/share/bison/bison.simple	212
++YYLEX	/usr/share/bison/bison.simple	213
++yylex	y-src/cccp.y	/^yylex ()$/
++YYLLOC_DEFAULT	/usr/share/bison/bison.simple	/^# define YYLLOC_DEFAULT(Current, Rhs, N)       	\\$/
++yylsp	/usr/share/bison/bison.simple	748
++yylsp	/usr/share/bison/bison.simple	921
++yyls	/usr/share/bison/bison.simple	88
++yyls	/usr/share/bison/bison.simple	89
++YYMAXDEPTH	/usr/share/bison/bison.simple	255
++YYMAXDEPTH	/usr/share/bison/bison.simple	256
++YYMAXDEPTH	/usr/share/bison/bison.simple	259
++YYMAXDEPTH	/usr/share/bison/bison.simple	260
++yymemcpy	/usr/share/bison/bison.simple	264
++yymemcpy	/usr/share/bison/bison.simple	265
++yymemcpy	/usr/share/bison/bison.simple	/^yymemcpy (char *yyto, const char *yyfrom, YYSIZE_T/
++yynewstate	/usr/share/bison/bison.simple	763
++yynewstate	/usr/share/bison/bison.simple	925
++yyn	/usr/share/bison/bison.simple	755
++yyn	/usr/share/bison/bison.simple	861
++yyn	/usr/share/bison/bison.simple	895
++yyn	/usr/share/bison/bison.simple	903
++YYPARSE_PARAM_ARG	/usr/share/bison/bison.simple	351
++YYPARSE_PARAM_ARG	/usr/share/bison/bison.simple	354
++YYPARSE_PARAM_ARG	/usr/share/bison/bison.simple	358
++YYPARSE_PARAM_DECL	/usr/share/bison/bison.simple	352
++YYPARSE_PARAM_DECL	/usr/share/bison/bison.simple	355
++YYPARSE_PARAM_DECL	/usr/share/bison/bison.simple	359
++yyparse	/usr/share/bison/bison.simple	/^yyparse (YYPARSE_PARAM_ARG)$/
++YYPOPSTACK	/usr/share/bison/bison.simple	445
++YYPOPSTACK	/usr/share/bison/bison.simple	447
++YYRECOVERING	/usr/share/bison/bison.simple	/^#define YYRECOVERING()  (!!yyerrstatus)$/
++yyresult	/usr/share/bison/bison.simple	932
++yyresult	/usr/share/bison/bison.simple	939
++yyresult	/usr/share/bison/bison.simple	947
++yyreturn	/usr/share/bison/bison.simple	933
++yyreturn	/usr/share/bison/bison.simple	940
++YYSIZE_T	/usr/share/bison/bison.simple	128
++YYSIZE_T	/usr/share/bison/bison.simple	129
++YYSIZE_T	/usr/share/bison/bison.simple	131
++YYSIZE_T	/usr/share/bison/bison.simple	132
++YYSIZE_T	/usr/share/bison/bison.simple	136
++YYSIZE_T	/usr/share/bison/bison.simple	137
++YYSIZE_T	/usr/share/bison/bison.simple	140
++YYSIZE_T	/usr/share/bison/bison.simple	141
++YYSIZE_T	/usr/share/bison/bison.simple	145
++YYSIZE_T	/usr/share/bison/bison.simple	146
++YYSIZE_T	/usr/share/bison/bison.simple	51
++YYSIZE_T	/usr/share/bison/bison.simple	52
++YYSIZE_T	/usr/share/bison/bison.simple	56
++YYSIZE_T	/usr/share/bison/bison.simple	57
++YYSIZE_T	/usr/share/bison/bison.simple	71
++YYSIZE_T	/usr/share/bison/bison.simple	72
++YYSIZE_T	/usr/share/bison/bison.simple	75
++YYSIZE_T	/usr/share/bison/bison.simple	76
++yyss	/usr/share/bison/bison.simple	85
++yyss	/usr/share/bison/bison.simple	86
++YYSTACK_ALLOC	/usr/share/bison/bison.simple	50
++YYSTACK_ALLOC	/usr/share/bison/bison.simple	51
++YYSTACK_ALLOC	/usr/share/bison/bison.simple	55
++YYSTACK_ALLOC	/usr/share/bison/bison.simple	56
++YYSTACK_ALLOC	/usr/share/bison/bison.simple	59
++YYSTACK_ALLOC	/usr/share/bison/bison.simple	60
++YYSTACK_ALLOC	/usr/share/bison/bison.simple	78
++YYSTACK_ALLOC	/usr/share/bison/bison.simple	79
++YYSTACK_BYTES	/usr/share/bison/bison.simple	/^#  define YYSTACK_BYTES(N) \\$/
++YYSTACK_FREE	/usr/share/bison/bison.simple	79
++YYSTACK_FREE	/usr/share/bison/bison.simple	80
++YYSTACK_FREE	/usr/share/bison/bison.simple	/^#  define YYSTACK_FREE(Ptr) do { \/* empty *\/; } wh/
++YYSTACK_GAP_MAX	/usr/share/bison/bison.simple	93
++YYSTACK_GAP_MAX	/usr/share/bison/bison.simple	94
++YYSTACK_RELOCATE	/usr/share/bison/bison.simple	548
++YYSTACK_RELOCATE	/usr/share/bison/bison.simple	/^# define YYSTACK_RELOCATE(Type, Stack)					\\$/
++yystate	/usr/share/bison/bison.simple	757
++yystate	/usr/share/bison/bison.simple	761
++yystate	/usr/share/bison/bison.simple	875
++yystate	/usr/share/bison/bison.simple	924
++YYSTD	/usr/share/bison/bison.simple	/^# define YYSTD(x) std::x$/
++YYSTD	/usr/share/bison/bison.simple	/^# define YYSTD(x) x$/
++yystpcpy	/usr/share/bison/bison.simple	316
++yystpcpy	/usr/share/bison/bison.simple	317
++yystpcpy	/usr/share/bison/bison.simple	/^yystpcpy (char *yydest, const char *yysrc)$/
++yystrlen	/usr/share/bison/bison.simple	293
++yystrlen	/usr/share/bison/bison.simple	294
++yystrlen	/usr/share/bison/bison.simple	/^yystrlen (const char *yystr)$/
++YYSTYPE	y-src/parse.y	72
++YYSTYPE	y-src/parse.y	73
++YYTERROR	/usr/share/bison/bison.simple	177
++YYTERROR	/usr/share/bison/bison.simple	178
++yyvsp	/usr/share/bison/bison.simple	746
++yyvsp	/usr/share/bison/bison.simple	919
++yyvs	/usr/share/bison/bison.simple	86
++yyvs	/usr/share/bison/bison.simple	87
++z	c.c	144
++z	c.c	164
++z	cp-src/clheir.hpp	49
++z	cp-src/clheir.hpp	58
++Z	c-src/h.h	100
++/Z	ps-src/rfc1245.ps	/^\/Z {$/
+diff --git a/test/manual/etags/CTAGS.good_update b/test/manual/etags/CTAGS.good_update
+new file mode 100644
+index 0000000000..e81bfa5a77
+--- /dev/null
++++ b/test/manual/etags/CTAGS.good_update
+@@ -0,0 +1,4483 @@
++
++($_,$flag,$opt,$f,$r,@temp	perl-src/yagrip.pl	8
++$0x80	c-src/sysdep.h	32
++${CHECKOBJS}	make-src/Makefile	/^${CHECKOBJS}: CFLAGS=-g3 -DNULLFREECHECK=0$/
++$domain	php-src/lce_functions.php	175
++$filename	php-src/lce_functions.php	174
++$ignore_ws	php-src/lce_functions.php	171
++$memassign	php-src/ptest.php	9
++$memassign_space	php-src/ptest.php	10
++$member	php-src/ptest.php	8
++$msgid_lc	php-src/lce_functions.php	113
++$msgid	php-src/lce_functions.php	107
++$msgid	php-src/lce_functions.php	165
++$msgstr_lc	php-src/lce_functions.php	114
++$msgstr	php-src/lce_functions.php	108
++$msgstr	php-src/lce_functions.php	166
++$po_entries	php-src/lce_functions.php	172
++$poe_num	php-src/lce_functions.php	173
++$por_a	php-src/lce_functions.php	500
++$prefix	php-src/lce_functions.php	72
++($prog,$_,@list	perl-src/yagrip.pl	39
++$state	php-src/lce_functions.php	170
++($string,$flag,@string,@temp,@last	perl-src/yagrip.pl	40
++$sys_comment_lc	php-src/lce_functions.php	116
++$sys_comment	php-src/lce_functions.php	110
++$sys_comment	php-src/lce_functions.php	168
++$SYS_##syscall_na	c-src/sysdep.h	31
++$test	php-src/ptest.php	12
++$unk_comment_lc	php-src/lce_functions.php	117
++$unk_comment	php-src/lce_functions.php	111
++$unk_comment	php-src/lce_functions.php	169
++$user_comment_lc	php-src/lce_functions.php	115
++$user_comment	php-src/lce_functions.php	109
++$user_comment	php-src/lce_functions.php	167
++2const	forth-src/test-forth.fth	/^3 4 2constant 2const$/
++2val	forth-src/test-forth.fth	/^2const 2value 2val$/
++2var	forth-src/test-forth.fth	/^2variable 2var$/
++a0	c-src/emacs/src/lisp.h	/^      Lisp_Object (*a0) (void);$/
++a1	c-src/emacs/src/lisp.h	/^      Lisp_Object (*a1) (Lisp_Object);$/
++a2	c-src/emacs/src/lisp.h	/^      Lisp_Object (*a2) (Lisp_Object, Lisp_Object)/
++a3	c-src/emacs/src/lisp.h	/^      Lisp_Object (*a3) (Lisp_Object, Lisp_Object,/
++a4	c-src/emacs/src/lisp.h	/^      Lisp_Object (*a4) (Lisp_Object, Lisp_Object,/
++a5	c-src/emacs/src/lisp.h	/^      Lisp_Object (*a5) (Lisp_Object, Lisp_Object,/
++a6	c-src/emacs/src/lisp.h	/^      Lisp_Object (*a6) (Lisp_Object, Lisp_Object,/
++a7	c-src/emacs/src/lisp.h	/^      Lisp_Object (*a7) (Lisp_Object, Lisp_Object,/
++a8	c-src/emacs/src/lisp.h	/^      Lisp_Object (*a8) (Lisp_Object, Lisp_Object,/
++aaaaaa	c-src/h.h	111
++aaa	c.c	249
++aaa	c.c	269
++aa	c.c	269
++aa	c.c	279
++abbrev_all_caps	c-src/abbrev.c	58
++abbrev-expansion	c-src/abbrev.c	/^DEFUN ("abbrev-expansion", Fabbrev_expansion, Sabb/
++abbrevs_changed	c-src/abbrev.c	56
++abbrev-symbol	c-src/abbrev.c	/^DEFUN ("abbrev-symbol", Fabbrev_symbol, Sabbrev_sy/
++abc	c-src/h.h	33
++abc	c-src/h.h	37
++ABC	ruby-src/test1.ru	11
++Abort_Handler_Pointer/t	ada-src/2ataspri.ads	/^   type Abort_Handler_Pointer is access procedure /
++abort-recursive-edit	c-src/emacs/src/keyboard.c	/^DEFUN ("abort-recursive-edit", Fabort_recursive_ed/
++Abort_Task/p	ada-src/2ataspri.adb	/^   procedure Abort_Task (T : TCB_Ptr) is$/
++Abort_Task/p	ada-src/2ataspri.ads	/^   procedure Abort_Task (T : TCB_Ptr);$/
++Abort_Wrapper/p	ada-src/2ataspri.adb	/^   procedure Abort_Wrapper$/
++\aboveenvbreak	tex-src/texinfo.tex	/^\\def\\aboveenvbreak{{\\advance\\aboveenvskipamount by/
++abs/f	ada-src/etags-test-for.ada	/^   function "abs"   (Right : Complex) return Real'/
++absolute_dirname	c-src/etags.c	/^absolute_dirname (char *file, char *dir)$/
++absolute_filename	c-src/etags.c	/^absolute_filename (char *file, char *dir)$/
++abt	cp-src/c.C	55
++a	c.c	152
++A	c.c	162
++a	c.c	180
++a	c.c	/^a ()$/
++a	c.c	/^a()$/
++accent_key_syms	c-src/emacs/src/keyboard.c	4625
++access_keymap_keyremap	c-src/emacs/src/keyboard.c	/^access_keymap_keyremap (Lisp_Object map, Lisp_Obje/
++acc_pred_info	merc-src/accumulator.m	/^:- pred acc_pred_info(list(mer_type)::in, list(pro/
++acc_proc_info	merc-src/accumulator.m	/^:- pred acc_proc_info(list(prog_var)::in, prog_var/
++accu_assoc	merc-src/accumulator.m	/^:- pred accu_assoc(module_info::in, vartypes::in, /
++accu_assoc	merc-src/accumulator.m	/^:- type accu_assoc$/
++accu_base	merc-src/accumulator.m	/^:- type accu_base$/
++accu_before	merc-src/accumulator.m	/^:- pred accu_before(module_info::in, vartypes::in,/
++accu_case	merc-src/accumulator.m	/^:- type accu_case$/
++accu_construct_assoc	merc-src/accumulator.m	/^:- pred accu_construct_assoc(module_info::in, vart/
++accu_construct	merc-src/accumulator.m	/^:- pred accu_construct(module_info::in, vartypes::/
++accu_create_goal	merc-src/accumulator.m	/^:- pred accu_create_goal(accu_goal_id::in, list(pr/
++accu_divide_base_case	merc-src/accumulator.m	/^:- pred accu_divide_base_case(module_info::in, var/
++accu_goal_id	merc-src/accumulator.m	/^:- type accu_goal_id$/
++accu_goal_list	merc-src/accumulator.m	/^:- func accu_goal_list(list(accu_goal_id), accu_go/
++accu_goal_store	merc-src/accumulator.m	/^:- type accu_goal_store == goal_store(accu_goal_id/
++accu_has_heuristic	merc-src/accumulator.m	/^:- pred accu_has_heuristic(module_name::in, string/
++accu_heuristic	merc-src/accumulator.m	/^:- pred accu_heuristic(module_name::in, string::in/
++accu_is_associative	merc-src/accumulator.m	/^:- pred accu_is_associative(module_info::in, pred_/
++accu_is_update	merc-src/accumulator.m	/^:- pred accu_is_update(module_info::in, pred_id::i/
++acc_unification	merc-src/accumulator.m	/^:- pred acc_unification(pair(prog_var)::in, hlds_g/
++accu_process_assoc_set	merc-src/accumulator.m	/^:- pred accu_process_assoc_set(module_info::in, ac/
++accu_process_update_set	merc-src/accumulator.m	/^:- pred accu_process_update_set(module_info::in, a/
++accu_related	merc-src/accumulator.m	/^:- pred accu_related(module_info::in, vartypes::in/
++accu_rename	merc-src/accumulator.m	/^:- func accu_rename(list(accu_goal_id), accu_subst/
++accu_sets_init	merc-src/accumulator.m	/^:- pred accu_sets_init(accu_sets::out) is det.$/
++accu_sets	merc-src/accumulator.m	/^:- type accu_sets$/
++accu_stage1_2	merc-src/accumulator.m	/^:- pred accu_stage1_2(module_info::in, vartypes::i/
++accu_stage1	merc-src/accumulator.m	/^:- pred accu_stage1(module_info::in, vartypes::in,/
++accu_stage2	merc-src/accumulator.m	/^:- pred accu_stage2(module_info::in, proc_info::in/
++accu_stage3	merc-src/accumulator.m	/^:- pred accu_stage3(accu_goal_id::in, list(prog_va/
++accu_standardize	merc-src/accumulator.m	/^:- pred accu_standardize(hlds_goal::in, hlds_goal:/
++accu_store	merc-src/accumulator.m	/^:- pred accu_store(accu_case::in, hlds_goal::in,$/
++accu_subst	merc-src/accumulator.m	/^:- type accu_subst == map(prog_var, prog_var).$/
++accu_substs_init	merc-src/accumulator.m	/^:- pred accu_substs_init(list(prog_var)::in, prog_/
++accu_substs	merc-src/accumulator.m	/^:- type accu_substs$/
++accu_top_level	merc-src/accumulator.m	/^:- pred accu_top_level(top_level::in, hlds_goal::i/
++accu_transform_proc	merc-src/accumulator.m	/^:- pred accu_transform_proc(pred_proc_id::in, pred/
++accu_update	merc-src/accumulator.m	/^:- pred accu_update(module_info::in, vartypes::in,/
++accu_warning	merc-src/accumulator.m	/^:- type accu_warning$/
++acc_var_subst_init	merc-src/accumulator.m	/^:- pred acc_var_subst_init(list(prog_var)::in,$/
++/Acircumflex	ps-src/rfc1245.ps	/^\/Acircumflex \/Ecircumflex \/Aacute \/Edieresis \/Egra/
++A	cp-src/c.C	117
++a	cp-src/c.C	132
++A	cp-src/c.C	39
++A	cp-src/c.C	56
++A	cp-src/c.C	57
++A	cp-src/c.C	73
++~A	cp-src/c.C	/^A::~A() {}$/
++A	cp-src/c.C	/^void A::A() {}$/
++A	cp-src/fail.C	23
++A	cp-src/fail.C	7
++a	c-src/h.h	103
++a	c-src/h.h	40
++action	prol-src/natded.prolog	/^action(KeyVals):-$/
++\activedoublequote	tex-src/texinfo.tex	/^\\def\\activedoublequote{{\\tt \\char '042}}$/
++active_maps	c-src/emacs/src/keyboard.c	/^active_maps (Lisp_Object first_event)$/
++\activeparens	tex-src/texinfo.tex	/^\\def\\activeparens{%$/
++actout	prol-src/natded.prolog	/^actout('Text',Trees):-$/
++act	prol-src/natded.prolog	/^act(OutForm,OutSyn,Ws):-$/
++Ada_funcs	c-src/etags.c	/^Ada_funcs (FILE *inf)$/
++Ada_getit	c-src/etags.c	/^Ada_getit (FILE *inf, const char *name_qualifier)$/
++Ada_help	c-src/etags.c	475
++ADASRC	make-src/Makefile	/^ADASRC=etags-test-for.ada 2ataspri.adb 2ataspri.ad/
++Ada_suffixes	c-src/etags.c	473
++add_active	prol-src/natded.prolog	/^add_active([],Cat,Goal):-$/
++addArchs	objc-src/PackInsp.m	/^-(void)addArchs:(const char *)string$/
++add_command_key	c-src/emacs/src/keyboard.c	/^add_command_key (Lisp_Object key)$/
++add_edge	prol-src/natded.prolog	/^add_edge(Left,Right,Cat):-$/
++add_node	c-src/etags.c	/^add_node (node *np, node **cur_node_p)$/
++addnoise	html-src/algrthms.html	/^Adding Noise to the$/
++AddNullToNmStr	pas-src/common.pas	/^function AddNullToNmStr; (*($/
++addPOReader	php-src/lce_functions.php	/^      function addPOReader($d_name, &$por)$/
++add_regex	c-src/etags.c	/^add_regex (char *regexp_pattern, language *lang)$/
++ADDRESS	c-src/emacs/src/gmalloc.c	/^#define ADDRESS(B)	((void *) (((B) - 1) * BLOCKSIZ/
++Address_To_Call_State/f	ada-src/2ataspri.adb	/^      function Address_To_Call_State is new$/
++Address_To_TCB_Ptr/f	ada-src/2ataspri.ads	/^   function Address_To_TCB_Ptr is new$/
++address	y-src/cccp.y	113
++add_user_signal	c-src/emacs/src/keyboard.c	/^add_user_signal (int sig, const char *name)$/
++#a-defer-word	forth-src/test-forth.fth	/^defer #a-defer-word$/
++adjust_point_for_property	c-src/emacs/src/keyboard.c	/^adjust_point_for_property (ptrdiff_t last_pt, bool/
++Advanced usage	tex-src/gzip.texi	/^@node Advanced usage, Environment, Invoking gzip, /
++a-forth-constant!	forth-src/test-forth.fth	/^99 constant a-forth-constant!$/
++(a-forth-constant	forth-src/test-forth.fth	/^constant (a-forth-constant$/
++:a-forth-dictionary-entry	forth-src/test-forth.fth	/^create :a-forth-dictionary-entry$/
++a-forth-value?	forth-src/test-forth.fth	/^55 value a-forth-value?$/
++a-forth-word	forth-src/test-forth.fth	/^: a-forth-word ( a b c -- )$/
++a-forth-word	forth-src/test-forth.fth	/^: a-forth-word ( a b c -- a*b+c )  + * ;$/
++\afourpaper	tex-src/texinfo.tex	/^\\def\\afourpaper{$/
++\afterenvbreak	tex-src/texinfo.tex	/^\\def\\afterenvbreak{\\endgraf \\ifdim\\lastskip<\\above/
++agent	cp-src/clheir.hpp	75
++algorithms	html-src/algrthms.html	/^Description$/
++alias	c-src/emacs/src/lisp.h	688
++alignas	c-src/emacs/src/lisp.h	/^# define alignas(alignment) \/* empty *\/$/
++align	c-src/emacs/src/gmalloc.c	/^align (size_t size)$/
++aligned_alloc	c-src/emacs/src/gmalloc.c	1718
++aligned_alloc	c-src/emacs/src/gmalloc.c	71
++aligned_alloc	c-src/emacs/src/gmalloc.c	/^aligned_alloc (size_t alignment, size_t size)$/
++_aligned_blocks	c-src/emacs/src/gmalloc.c	1004
++_aligned_blocks_mutex	c-src/emacs/src/gmalloc.c	518
++Aligned_Cons	c-src/emacs/src/lisp.h	4670
++aligned	c-src/emacs/src/gmalloc.c	199
++Aligned_String	c-src/emacs/src/lisp.h	4676
++alignlist	c-src/emacs/src/gmalloc.c	196
++ALIGNOF_STRUCT_LISP_VECTOR	c-src/emacs/src/lisp.h	1378
++alive	cp-src/conway.hpp	7
++all_kboards	c-src/emacs/src/keyboard.c	86
++ALLOCATED_BEFORE_DUMPING	c-src/emacs/src/gmalloc.c	/^#define ALLOCATED_BEFORE_DUMPING(P) \\$/
++allocated	c-src/emacs/src/regex.h	344
++allocate_kboard	c-src/emacs/src/keyboard.c	/^allocate_kboard (Lisp_Object type)$/
++ALLOCATE_PSEUDOVECTOR	c-src/emacs/src/lisp.h	/^#define ALLOCATE_PSEUDOVECTOR(type, field, tag)			/
++ALLOCATE_ZEROED_PSEUDOVECTOR	c-src/emacs/src/lisp.h	/^#define ALLOCATE_ZEROED_PSEUDOVECTOR(type, field, /
++\alphaenumerate	tex-src/texinfo.tex	/^\\def\\alphaenumerate{\\enumerate{a}}$/
++aMANY	c-src/emacs/src/lisp.h	/^      Lisp_Object (*aMANY) (ptrdiff_t, Lisp_Object/
++analyze_regex	c-src/etags.c	/^analyze_regex (char *regex_arg)$/
++andkeyvalseq	prol-src/natded.prolog	/^andkeyvalseq(KeyVals) --> ['&'], keyvalseq(KeyVals/
++AND	y-src/cccp.c	11
++an_extern_linkage	c-src/h.h	44
++an_extern_linkage	c-src/h.h	56
++an_extern_linkage_ptr	c-src/h.h	43
++animals	cp-src/c.C	126
++animals	cp-src/c.C	130
++animals	c-src/h.h	81
++(another-forth-word)	forth-src/test-forth.fth	/^: (another-forth-word) ( -- )$/
++ANSIC	c-src/h.h	84
++ANSIC	c-src/h.h	85
++any_kboard_state	c-src/emacs/src/keyboard.c	/^any_kboard_state ()$/
++appDidInit	objcpp-src/SimpleCalc.M	/^- appDidInit:sender$/
++\appendixletter	tex-src/texinfo.tex	/^\\def\\appendixletter{\\char\\the\\appendixno}$/
++appendix_name	perl-src/htlmify-cystic	13
++\appendixnoderef	tex-src/texinfo.tex	/^\\def\\appendixnoderef{\\ifx\\lastnode\\relax\\else$/
++appendix	perl-src/htlmify-cystic	24
++\appendixsec	tex-src/texinfo.tex	/^\\outer\\def\\appendixsec{\\parsearg\\appendixsectionzz/
++\appendixsection	tex-src/texinfo.tex	/^\\outer\\def\\appendixsection{\\parsearg\\appendixsecti/
++\appendixsectionzzz	tex-src/texinfo.tex	/^\\def\\appendixsectionzzz #1{\\seccheck{appendixsecti/
++\appendixsetref	tex-src/texinfo.tex	/^\\def\\appendixsetref#1{%$/
++\appendixsubsec	tex-src/texinfo.tex	/^\\outer\\def\\appendixsubsec{\\parsearg\\appendixsubsec/
++\appendixsubseczzz	tex-src/texinfo.tex	/^\\def\\appendixsubseczzz #1{\\seccheck{appendixsubsec/
++\appendixsubsubsec	tex-src/texinfo.tex	/^\\outer\\def\\appendixsubsubsec{\\parsearg\\appendixsub/
++\appendixsubsubseczzz	tex-src/texinfo.tex	/^\\def\\appendixsubsubseczzz #1{\\seccheck{appendixsub/
++\appendix	tex-src/texinfo.tex	/^\\outer\\def\\appendix{\\parsearg\\appendixzzz}$/
++appendix_toc	perl-src/htlmify-cystic	16
++\appendixzzz	tex-src/texinfo.tex	/^\\def\\appendixzzz #1{\\seccheck{appendix}%$/
++append_list	prol-src/natded.prolog	/^append_list([],[]).$/
++append	prol-src/natded.prolog	/^append([],Xs,Xs).$/
++append_string	pas-src/common.pas	/^procedure append_string;(*($/
++AppendTextString	pas-src/common.pas	/^function AppendTextString;(*($/
++appendToDisplay	objcpp-src/SimpleCalc.M	/^- appendToDisplay:(const char *)theDigit$/
++append_tool_bar_item	c-src/emacs/src/keyboard.c	/^append_tool_bar_item (void)$/
++apply_modifiers	c-src/emacs/src/keyboard.c	/^apply_modifiers (int modifiers, Lisp_Object base)$/
++apply_modifiers_uncached	c-src/emacs/src/keyboard.c	/^apply_modifiers_uncached (int modifiers, char *bas/
++/A	ps-src/rfc1245.ps	/^\/A { $/
++aref_addr	c-src/emacs/src/lisp.h	/^aref_addr (Lisp_Object array, ptrdiff_t idx)$/
++AREF	c-src/emacs/src/lisp.h	/^AREF (Lisp_Object array, ptrdiff_t idx)$/
++arg	c-src/emacs/src/lisp.h	2961
++arg	c-src/emacs/src/lisp.h	2966
++arg	c-src/emacs/src/lisp.h	2971
++arg	c-src/h.h	13
++arglist	y-src/cccp.y	41
++argno	y-src/cccp.y	45
++args	c-src/emacs/src/lisp.h	2986
++args	c-src/h.h	30
++argsindent	tex-src/texinfo.tex	/^\\dimen1=\\hsize \\advance \\dimen1 by -\\defargsindent/
++argsindent	tex-src/texinfo.tex	/^\\newskip\\defargsindent \\defargsindent=50pt$/
++argsindent	tex-src/texinfo.tex	/^\\parshape 2 0in \\dimen0 \\defargsindent \\dimen1    /
++ARGS	make-src/Makefile	/^ARGS=- < srclist$/
++arg_type	c-src/etags.c	250
++argument	c-src/etags.c	253
++argvals	prol-src/natded.prolog	/^argvals([]) --> [].$/
++Arith_Comparison	c-src/emacs/src/lisp.h	3497
++ARITH_EQUAL	c-src/emacs/src/lisp.h	3498
++ARITH_GRTR	c-src/emacs/src/lisp.h	3501
++ARITH_GRTR_OR_EQUAL	c-src/emacs/src/lisp.h	3503
++ARITH_LESS	c-src/emacs/src/lisp.h	3500
++ARITH_LESS_OR_EQUAL	c-src/emacs/src/lisp.h	3502
++ARITH_NOTEQUAL	c-src/emacs/src/lisp.h	3499
++array	c.c	190
++ARRAYELTS	c-src/emacs/src/lisp.h	/^#define ARRAYELTS(arr) (sizeof (arr) \/ sizeof (arr/
++ARRAY_MARK_FLAG	c-src/emacs/src/lisp.h	768
++ARRAYP	c-src/emacs/src/lisp.h	/^ARRAYP (Lisp_Object x)$/
++A	ruby-src/test1.ru	/^class A$/
++a	ruby-src/test1.ru	/^ def a()$/
++A	ruby-src/test1.ru	/^module A$/
++ASCII_CHAR_P	c-src/emacs/src/lisp.h	/^#define ASCII_CHAR_P(c) UNSIGNED_CMP (c, <, 0x80)$/
++ascii	c-src/emacs/src/lisp.h	1598
++ASET	c-src/emacs/src/lisp.h	/^ASET (Lisp_Object array, ptrdiff_t idx, Lisp_Objec/
++\asis	tex-src/texinfo.tex	/^\\def\\asis#1{#1}$/
++ASIZE	c-src/emacs/src/lisp.h	/^ASIZE (Lisp_Object array)$/
++Asm_help	c-src/etags.c	504
++Asm_labels	c-src/etags.c	/^Asm_labels (FILE *inf)$/
++Asm_suffixes	c-src/etags.c	493
++asort	cp-src/functions.cpp	/^void asort(int *a, int num){$/
++ASRC	make-src/Makefile	/^ASRC=empty.zz empty.zz.gz$/
++assemby-code-word	forth-src/test-forth.fth	/^code assemby-code-word ( dunno what it does )$/
++assert	c-src/etags.c	135
++assert	c-src/etags.c	/^# define assert(x) ((void) 0)$/
++assign_neighbor	cp-src/clheir.hpp	/^    void assign_neighbor(int direction, location */
++associativity_assertion	merc-src/accumulator.m	/^:- pred associativity_assertion(module_info::in, l/
++assoc_list	merc-src/accumulator.m	/^:- import_module assoc_list.$/
++AST_Array::AST_Array	cp-src/c.C	/^AST_Array::AST_Array(UTL_ScopedName *n, unsigned l/
++AST_ConcreteType::AST_ConcreteType	cp-src/c.C	/^AST_ConcreteType::AST_ConcreteType(AST_Decl::NodeT/
++AST_Root	cp-src/c.C	92
++AT	cp-src/c.C	52
++at_end	c-src/etags.c	249
++at_filename	c-src/etags.c	247
++/atilde	ps-src/rfc1245.ps	/^\/atilde \/aring \/ccedilla \/eacute \/egrave \/ecircumf/
++at_language	c-src/etags.c	245
++at_least_one_member	prol-src/natded.prolog	/^at_least_one_member(X,[X|_]):-!.$/
++atom	prol-src/natded.prolog	/^atom(X) --> [X], {atomic(X)}.$/
++atomval	prol-src/natded.prolog	/^atomval(X) --> atom(X).$/
++at_regexp	c-src/etags.c	246
++at_stdin	c-src/etags.c	248
++AU	cp-src/c.C	53
++aultparindent\hang\textindent	tex-src/texinfo.tex	/^\\footstrut\\parindent=\\defaultparindent\\hang\\textin/
++aultparindent	tex-src/texinfo.tex	/^\\newdimen\\defaultparindent \\defaultparindent = 15p/
++aultparindent	tex-src/texinfo.tex	/^\\parindent = \\defaultparindent$/
++aUNEVALLED	c-src/emacs/src/lisp.h	/^      Lisp_Object (*aUNEVALLED) (Lisp_Object args)/
++\authorfont	tex-src/texinfo.tex	/^   \\def\\authorfont{\\authorrm \\normalbaselineskip =/
++\author	tex-src/texinfo.tex	/^   \\def\\author{\\parsearg\\authorzzz}%$/
++\authorzzz	tex-src/texinfo.tex	/^   \\def\\authorzzz##1{\\ifseenauthor\\else\\vskip 0pt /
++AUTO_CONS	c-src/emacs/src/lisp.h	/^#define AUTO_CONS(name, a, b) Lisp_Object name = A/
++AUTO_CONS_EXPR	c-src/emacs/src/lisp.h	/^#define AUTO_CONS_EXPR(a, b) \\$/
++auto_help	c-src/etags.c	699
++AUTO_LIST1	c-src/emacs/src/lisp.h	/^#define AUTO_LIST1(name, a)						\\$/
++AUTO_LIST2	c-src/emacs/src/lisp.h	/^#define AUTO_LIST2(name, a, b)						\\$/
++AUTO_LIST3	c-src/emacs/src/lisp.h	/^#define AUTO_LIST3(name, a, b, c)					\\$/
++AUTO_LIST4	c-src/emacs/src/lisp.h	/^#define AUTO_LIST4(name, a, b, c, d)					\\$/
++AUTOLOADP	c-src/emacs/src/lisp.h	/^AUTOLOADP (Lisp_Object x)$/
++AUTO_STRING	c-src/emacs/src/lisp.h	/^#define AUTO_STRING(name, str)						\\$/
++AVAIL_ALLOCA	c-src/emacs/src/lisp.h	/^#define AVAIL_ALLOCA(size) (sa_avail -= (size), al/
++backslash=0	tex-src/texinfo.tex	/^\\let\\indexbackslash=0  %overridden during \\printin/
++\balancecolumns	tex-src/texinfo.tex	/^\\def\\balancecolumns{%$/
++bar1	ruby-src/test1.ru	/^    attr_reader(:foo1, :bar1, # comment$/
++bar	c.c	143
++bar	cp-src/x.cc	/^XX::bar()$/
++bar	c-src/c.c	/^void bar() {while(0) {}}$/
++bar	c-src/h.h	19
++Bar	lua-src/test.lua	/^function Square.something:Bar ()$/
++Bar	perl-src/kai-test.pl	/^package Bar;$/
++Barrier_Function_Pointer/t	ada-src/etags-test-for.ada	/^   type Barrier_Function_Pointer is access$/
++bar=	ruby-src/test1.ru	/^    attr_writer :bar,$/
++_bar?	ruby-src/test1.ru	/^    def self._bar?(abc)$/
++base_case_ids	merc-src/accumulator.m	/^:- func base_case_ids(accu_goal_store) = list(accu/
++base_case_ids_set	merc-src/accumulator.m	/^:- func base_case_ids_set(accu_goal_store) = set(a/
++base	cp-src/c.C	/^double base (void) const { return rng_base;  }$/
++base	cp-src/Range.h	/^  double base (void) const { return rng_base;  }$/
++base	c-src/emacs/src/lisp.h	2188
++bas_syn	prol-src/natded.prolog	/^bas_syn(n(_)).$/
++baz=	ruby-src/test1.ru	/^                :baz,$/
++bbbbbb	c-src/h.h	113
++bbb	c.c	251
++bb	c.c	275
++b	c.c	180
++b	c.c	259
++b	c.c	260
++b	c.c	262
++b	c.c	/^b ()$/
++B	cp-src/c.C	122
++b	cp-src/c.C	132
++B	cp-src/c.C	54
++B	cp-src/c.C	56
++B	cp-src/c.C	74
++~B	cp-src/c.C	/^    ~B() {};$/
++B	cp-src/c.C	/^void B::B() {}$/
++B	cp-src/fail.C	24
++B	cp-src/fail.C	8
++b	c-src/h.h	103
++b	c-src/h.h	104
++b	c-src/h.h	41
++been_warned	c-src/etags.c	222
++before_command_echo_length	c-src/emacs/src/keyboard.c	130
++before_command_key_count	c-src/emacs/src/keyboard.c	129
++/BEGINBITMAP2BITc	ps-src/rfc1245.ps	/^\/BEGINBITMAP2BITc { $/
++/BEGINBITMAP2BIT	ps-src/rfc1245.ps	/^\/BEGINBITMAP2BIT { $/
++/BEGINBITMAPBWc	ps-src/rfc1245.ps	/^\/BEGINBITMAPBWc { $/
++/BEGINBITMAPBW	ps-src/rfc1245.ps	/^\/BEGINBITMAPBW { $/
++/BEGINBITMAPGRAYc	ps-src/rfc1245.ps	/^\/BEGINBITMAPGRAYc { $/
++/BEGINBITMAPGRAY	ps-src/rfc1245.ps	/^\/BEGINBITMAPGRAY { $/
++\begindoublecolumns	tex-src/texinfo.tex	/^\\def\\begindoublecolumns{\\begingroup$/
++/BEGINPRINTCODE	ps-src/rfc1245.ps	/^\/BEGINPRINTCODE { $/
++\begin	tex-src/texinfo.tex	/^\\outer\\def\\begin{\\parsearg\\beginxxx}$/
++\beginxxx	tex-src/texinfo.tex	/^\\def\\beginxxx #1{%$/
++begtoken	c-src/etags.c	/^#define	begtoken(c)	(_btk[CHAR (c)]) \/* c can star/
++behaviour_info	erl-src/gs_dialog.erl	/^behaviour_info(callbacks) ->$/
++BE_Node	cp-src/c.C	77
++BE_Node	cp-src/c.C	/^void BE_Node::BE_Node() {}$/
++bf=cmbx10	tex-src/texinfo.tex	/^\\font\\defbf=cmbx10 scaled \\magstep1 %was 1314$/
++/BF	ps-src/rfc1245.ps	/^\/BF { $/
++\bf	tex-src/texinfo.tex	/^\\def\\bf{\\realbackslash bf }%$/
++\bf	tex-src/texinfo.tex	/^\\def\\bf{\\realbackslash bf }$/
++Bidule/b	ada-src/etags-test-for.ada	/^  protected body Bidule is$/
++Bidule/b	ada-src/waroquiers.ada	/^  protected body Bidule is$/
++Bidule/t	ada-src/etags-test-for.ada	/^  protected Bidule is$/
++Bidule/t	ada-src/waroquiers.ada	/^  protected Bidule is$/
++bind_polling_period	c-src/emacs/src/keyboard.c	/^bind_polling_period (int n)$/
++bind	pyt-src/server.py	/^    def bind(self, key, action):$/
++/BITMAPCOLORc	ps-src/rfc1245.ps	/^\/BITMAPCOLORc { $/
++/BITMAPCOLOR	ps-src/rfc1245.ps	/^\/BITMAPCOLOR { $/
++/BITMAPGRAYc	ps-src/rfc1245.ps	/^\/BITMAPGRAYc { $/
++/BITMAPGRAY	ps-src/rfc1245.ps	/^\/BITMAPGRAY { $/
++BITS_PER_BITS_WORD	c-src/emacs/src/lisp.h	125
++BITS_PER_BITS_WORD	c-src/emacs/src/lisp.h	129
++BITS_PER_CHAR	c-src/emacs/src/lisp.h	136
++BITS_PER_EMACS_INT	c-src/emacs/src/lisp.h	139
++BITS_PER_LONG	c-src/emacs/src/lisp.h	138
++BITS_PER_SHORT	c-src/emacs/src/lisp.h	137
++bits_word	c-src/emacs/src/lisp.h	123
++bits_word	c-src/emacs/src/lisp.h	127
++BITS_WORD_MAX	c-src/emacs/src/lisp.h	124
++BITS_WORD_MAX	c-src/emacs/src/lisp.h	128
++bla	c.c	/^int bla ()$/
++BLACK	cp-src/screen.hpp	12
++blah	tex-src/testenv.tex	/^\\section{blah}$/
++bletch	el-src/TAGTEST.EL	/^(foo::defmumble bletch beuarghh)$/
++BLOCK	c-src/emacs/src/gmalloc.c	/^#define BLOCK(A)	(((char *) (A) - _heapbase) \/ BLO/
++BLOCKIFY	c-src/emacs/src/gmalloc.c	/^#define BLOCKIFY(SIZE)	(((SIZE) + BLOCKSIZE - 1) \//
++BLOCKLOG	c-src/emacs/src/gmalloc.c	125
++BLOCKSIZE	c-src/emacs/src/gmalloc.c	126
++/bl	ps-src/rfc1245.ps	/^\/bl { $/
++BLUE	cp-src/screen.hpp	13
++blv	c-src/emacs/src/lisp.h	689
++blv_found	c-src/emacs/src/lisp.h	/^blv_found (struct Lisp_Buffer_Local_Value *blv)$/
++bodyindent	tex-src/texinfo.tex	/^\\advance\\dimen2 by -\\defbodyindent$/
++bodyindent	tex-src/texinfo.tex	/^\\advance\\dimen3 by -\\defbodyindent$/
++bodyindent	tex-src/texinfo.tex	/^\\advance\\leftskip by -\\defbodyindent$/
++bodyindent	tex-src/texinfo.tex	/^\\advance\\leftskip by \\defbodyindent \\advance \\righ/
++bodyindent	tex-src/texinfo.tex	/^\\exdentamount=\\defbodyindent$/
++bodyindent	tex-src/texinfo.tex	/^\\newskip\\defbodyindent \\defbodyindent=.4in$/
++Body_Required/f	ada-src/etags-test-for.ada	/^   function Body_Required$/
++Boo::Boo	cp-src/c.C	/^Boo::Boo(Boo) :$/
++Boo	cp-src/c.C	129
++Boo	cp-src/c.C	/^    Boo(int _i, int _a, int _b) : i(_i), a(_a), b(/
++bool	c.c	222
++bool_header_size	c-src/emacs/src/lisp.h	1472
++bool	merc-src/accumulator.m	/^:- import_module bool.$/
++boolvar	c-src/emacs/src/lisp.h	2287
++bool_vector_bitref	c-src/emacs/src/lisp.h	/^bool_vector_bitref (Lisp_Object a, EMACS_INT i)$/
++BOOL_VECTOR_BITS_PER_CHAR	c-src/emacs/src/lisp.h	114
++BOOL_VECTOR_BITS_PER_CHAR	c-src/emacs/src/lisp.h	115
++bool_vector_bytes	c-src/emacs/src/lisp.h	/^bool_vector_bytes (EMACS_INT size)$/
++bool_vector_data	c-src/emacs/src/lisp.h	/^bool_vector_data (Lisp_Object a)$/
++BOOL_VECTOR_P	c-src/emacs/src/lisp.h	/^BOOL_VECTOR_P (Lisp_Object a)$/
++bool_vector_ref	c-src/emacs/src/lisp.h	/^bool_vector_ref (Lisp_Object a, EMACS_INT i)$/
++bool_vector_set	c-src/emacs/src/lisp.h	/^bool_vector_set (Lisp_Object a, EMACS_INT i, bool /
++bool_vector_size	c-src/emacs/src/lisp.h	/^bool_vector_size (Lisp_Object a)$/
++bool_vector_uchar_data	c-src/emacs/src/lisp.h	/^bool_vector_uchar_data (Lisp_Object a)$/
++bool_vector_words	c-src/emacs/src/lisp.h	/^bool_vector_words (EMACS_INT size)$/
++/B	ps-src/rfc1245.ps	/^\/B { $/
++bracelev	c-src/etags.c	2520
++/braceright	ps-src/rfc1245.ps	/^\/braceright \/asciitilde \/.notdef \/Adieresis \/Aring/
++/bracketright	ps-src/rfc1245.ps	/^\/bracketright \/asciicircum \/underscore \/grave \/a \//
++/breve	ps-src/rfc1245.ps	/^\/breve \/dotaccent \/ring \/cedilla \/hungarumlaut \/og/
++BROWN	cp-src/screen.hpp	18
++B	ruby-src/test1.ru	/^  class B$/
++b	ruby-src/test1.ru	/^ def b()$/
++bsp_DevId	c-src/h.h	25
++bt	c-src/emacs/src/lisp.h	2988
++\b	tex-src/texinfo.tex	/^\\def\\b#1{{\\bf #1}}$/
++\b	tex-src/texinfo.tex	/^\\def\\b##1{\\realbackslash b {##1}}%$/
++\b	tex-src/texinfo.tex	/^\\def\\b##1{\\realbackslash b {##1}}$/
++btowc	c-src/emacs/src/regex.h	/^# define btowc(c) c$/
++buffer	c-src/emacs/src/lisp.h	2000
++buffer	c-src/emacs/src/regex.h	341
++buffer	c-src/etags.c	238
++buffer	c-src/h.h	119
++BUFFER_OBJFWDP	c-src/emacs/src/lisp.h	/^BUFFER_OBJFWDP (union Lisp_Fwd *a)$/
++BUFFERP	c-src/emacs/src/lisp.h	/^BUFFERP (Lisp_Object a)$/
++BUFFERSIZE	objc-src/Subprocess.h	43
++buildact	prol-src/natded.prolog	/^buildact([SynIn],Right,RightPlus1):-$/
++build	prol-src/natded.prolog	/^build([],Left,Left).$/
++build_pure_c_string	c-src/emacs/src/lisp.h	/^build_pure_c_string (const char *str)$/
++build_string	c-src/emacs/src/lisp.h	/^build_string (const char *str)$/
++builtin_lisp_symbol	c-src/emacs/src/lisp.h	/^builtin_lisp_symbol (int index)$/
++\bullet	tex-src/texinfo.tex	/^\\def\\bullet{$\\ptexbullet$}$/
++burst	c-src/h.h	28
++busy	c-src/emacs/src/gmalloc.c	158
++ButtonBar	pyt-src/server.py	/^def ButtonBar(frame, legend, ref, alternatives, co/
++button_down_location	c-src/emacs/src/keyboard.c	5210
++button_down_time	c-src/emacs/src/keyboard.c	5218
++\bye	tex-src/texinfo.tex	/^\\outer\\def\\bye{\\pagealignmacro\\tracingstats=1\\ptex/
++bytecode_dest	c-src/emacs/src/lisp.h	3037
++bytecode_top	c-src/emacs/src/lisp.h	3036
++BYTE_MARK_STACK	c-src/emacs/src/lisp.h	3181
++bytepos	c-src/emacs/src/lisp.h	2016
++bytes_free	c-src/emacs/src/gmalloc.c	314
++_bytes_free	c-src/emacs/src/gmalloc.c	376
++byte_stack	c-src/emacs/src/lisp.h	3049
++bytes_total	c-src/emacs/src/gmalloc.c	310
++bytes_used	c-src/emacs/src/gmalloc.c	312
++_bytes_used	c-src/emacs/src/gmalloc.c	374
++caccacacca	c.c	/^caccacacca (a,b,c,d,e,f,g)$/
++cacheLRUEntry_s	c.c	172
++cacheLRUEntry_t	c.c	177
++calculate_goal_info	merc-src/accumulator.m	/^:- pred calculate_goal_info(hlds_goal_expr::in, hl/
++CALLMANY	c-src/emacs/src/lisp.h	/^#define CALLMANY(f, array) (f) (ARRAYELTS (array),/
++CALLN	c-src/emacs/src/lisp.h	/^#define CALLN(f, ...) CALLMANY (f, ((Lisp_Object [/
++calloc	c-src/emacs/src/gmalloc.c	1717
++calloc	c-src/emacs/src/gmalloc.c	66
++calloc	c-src/emacs/src/gmalloc.c	70
++calloc	c-src/emacs/src/gmalloc.c	/^calloc (size_t nmemb, size_t size)$/
++can_be_null	c-src/emacs/src/regex.h	370
++cancel_echoing	c-src/emacs/src/keyboard.c	/^cancel_echoing (void)$/
++canonicalize_filename	c-src/etags.c	/^canonicalize_filename (register char *fn)$/
++\capsenumerate	tex-src/texinfo.tex	/^\\def\\capsenumerate{\\enumerate{A}}$/
++CAR	c-src/emacs/src/lisp.h	/^CAR (Lisp_Object c)$/
++CAR_SAFE	c-src/emacs/src/lisp.h	/^CAR_SAFE (Lisp_Object c)$/
++\cartbot	tex-src/texinfo.tex	/^\\def\\cartbot{\\hbox to \\cartouter{\\hskip\\lskip$/
++\cartouche	tex-src/texinfo.tex	/^\\long\\def\\cartouche{%$/
++\carttop	tex-src/texinfo.tex	/^\\def\\carttop{\\hbox to \\cartouter{\\hskip\\lskip$/
++case_Lisp_Int	c-src/emacs/src/lisp.h	438
++cat_atoms	prol-src/natded.prolog	/^cat_atoms(A1,A2,A3):-$/
++CATCHER	c-src/emacs/src/lisp.h	3021
++cat	cp-src/c.C	126
++cat	cp-src/c.C	130
++cat	c-src/h.h	81
++cat	prol-src/natded.prolog	/^cat(A, Alpha@Beta, Ass3, Qs3, tree(fe,A:Alpha@Beta/
++C_AUTO	c-src/etags.c	2198
++\cbl	tex-src/texinfo.tex	/^\\def\\cbl{{\\circle\\char'012\\hskip -6pt}}$/
++\cbr	tex-src/texinfo.tex	/^\\def\\cbr{{\\hskip 6pt\\circle\\char'011}}$/
++c	c.c	180
++cccccccccc	c-src/h.h	115
++C	cp-src/fail.C	25
++C	cp-src/fail.C	9
++C	cp-src/fail.C	/^			   C(int i) {x = i;}$/
++c	c-src/h.h	106
++c	c-src/h.h	/^#define c() d$/
++%cdiff	make-src/Makefile	/^%cdiff: CTAGS% CTAGS ${infiles}$/
++cdr	c-src/emacs/src/lisp.h	1159
++CDR	c-src/emacs/src/lisp.h	/^CDR (Lisp_Object c)$/
++CDR_SAFE	c-src/emacs/src/lisp.h	/^CDR_SAFE (Lisp_Object c)$/
++cell	y-src/parse.y	279
++\center	tex-src/texinfo.tex	/^\\def\\center{\\parsearg\\centerzzz}$/
++\centerzzz	tex-src/texinfo.tex	/^\\def\\centerzzz #1{{\\advance\\hsize by -\\leftskip$/
++C_entries	c-src/etags.c	/^C_entries (int c_ext, FILE *inf)$/
++C_EXT	c-src/etags.c	2193
++c_ext	c-src/etags.c	2271
++CFLAGS	make-src/Makefile	/^CFLAGS=${WARNINGS} -ansi -g3 # -pg -O$/
++/cfs	ps-src/rfc1245.ps	/^\/cfs { $/
++cgrep	html-src/software.html	/^cgrep$/
++chain	c-src/emacs/src/lisp.h	1162
++chain	c-src/emacs/src/lisp.h	2206
++chain	c-src/emacs/src/lisp.h	2396
++chain_subst_2	merc-src/accumulator.m	/^:- pred chain_subst_2(list(A)::in, map(A, B)::in, /
++chain_subst	merc-src/accumulator.m	/^:- func chain_subst(accu_subst, accu_subst) = accu/
++ChangeFileType	pas-src/common.pas	/^function ChangeFileType; (*(FileName : NameString;/
++\chapbreak	tex-src/texinfo.tex	/^\\def\\chapbreak{\\dobreak \\chapheadingskip {-4000}}$/
++\chapentryfonts	tex-src/texinfo.tex	/^\\def\\chapentryfonts{\\secfonts \\rm}$/
++\chapentry	tex-src/texinfo.tex	/^\\def\\chapentry#1#2#3{\\dochapentry{#2\\labelspace#1}/
++\chapfonts	tex-src/texinfo.tex	/^\\def\\chapfonts{%$/
++\CHAPFopen	tex-src/texinfo.tex	/^\\def\\CHAPFopen{$/
++\CHAPFplain	tex-src/texinfo.tex	/^\\def\\CHAPFplain{$/
++\chapheading	tex-src/texinfo.tex	/^\\def\\chapheading{\\parsearg\\chapheadingzzz}$/
++\chapheadingzzz	tex-src/texinfo.tex	/^\\def\\chapheadingzzz #1{\\chapbreak %$/
++\chapoddpage	tex-src/texinfo.tex	/^\\def\\chapoddpage{\\chappager \\ifodd\\pageno \\else \\h/
++\chappager	tex-src/texinfo.tex	/^\\def\\chappager{\\par\\vfill\\supereject}$/
++\CHAPPAGodd	tex-src/texinfo.tex	/^\\def\\CHAPPAGodd{$/
++\CHAPPAGoff	tex-src/texinfo.tex	/^\\def\\CHAPPAGoff{$/
++\CHAPPAGon	tex-src/texinfo.tex	/^\\def\\CHAPPAGon{$/
++\chapternofonts	tex-src/texinfo.tex	/^\\def\\chapternofonts{%$/
++\chapter	tex-src/texinfo.tex	/^\\outer\\def\\chapter{\\parsearg\\chapterzzz}$/
++\chapterzzz	tex-src/texinfo.tex	/^\\def\\chapterzzz #1{\\seccheck{chapter}%$/
++CHARACTERBITS	c-src/emacs/src/lisp.h	2457
++CHAR_ALT	c-src/emacs/src/lisp.h	2445
++CHAR_BIT	c-src/emacs/src/lisp.h	2957
++CHAR_BIT	c-src/emacs/src/lisp.h	2959
++CHAR_BIT	c-src/emacs/src/lisp.h	2964
++CHAR_BIT	c-src/emacs/src/lisp.h	2969
++CHAR_BIT	c-src/emacs/src/lisp.h	2974
++CHAR_BIT	c-src/emacs/src/lisp.h	2978
++CHAR_BIT	c-src/emacs/src/lisp.h	2983
++char_bits	c-src/emacs/src/lisp.h	2443
++CHAR_CLASS_MAX_LENGTH	c-src/emacs/src/regex.h	593
++CHAR_CLASS_MAX_LENGTH	c-src/emacs/src/regex.h	597
++CHAR_CLASS_MAX_LENGTH	c-src/emacs/src/regex.h	605
++CHAR	c-src/etags.c	/^#define CHAR(x)		((unsigned int)(x) & (CHARS - 1))/
++CHAR_CTL	c-src/emacs/src/lisp.h	2449
++CHAR_HYPER	c-src/emacs/src/lisp.h	2447
++CHAR_META	c-src/emacs/src/lisp.h	2450
++CHAR_MODIFIER_MASK	c-src/emacs/src/lisp.h	2452
++charpos	c-src/emacs/src/lisp.h	2011
++CHARS	c-src/etags.c	157
++charset_unibyte	c-src/emacs/src/regex.h	410
++CHAR_SHIFT	c-src/emacs/src/lisp.h	2448
++CHAR_SUPER	c-src/emacs/src/lisp.h	2446
++CHAR_TABLE_EXTRA_SLOTS	c-src/emacs/src/lisp.h	/^CHAR_TABLE_EXTRA_SLOTS (struct Lisp_Char_Table *ct/
++CHAR_TABLE_P	c-src/emacs/src/lisp.h	/^CHAR_TABLE_P (Lisp_Object a)$/
++CHAR_TABLE_REF_ASCII	c-src/emacs/src/lisp.h	/^CHAR_TABLE_REF_ASCII (Lisp_Object ct, ptrdiff_t id/
++CHAR_TABLE_REF	c-src/emacs/src/lisp.h	/^CHAR_TABLE_REF (Lisp_Object ct, int idx)$/
++CHAR_TABLE_SET	c-src/emacs/src/lisp.h	/^CHAR_TABLE_SET (Lisp_Object ct, int idx, Lisp_Obje/
++char_table_specials	c-src/emacs/src/lisp.h	1692
++CHAR_TABLE_STANDARD_SLOTS	c-src/emacs/src/lisp.h	1697
++CHARTAB_SIZE_BITS_0	c-src/emacs/src/lisp.h	1567
++CHARTAB_SIZE_BITS_1	c-src/emacs/src/lisp.h	1568
++CHARTAB_SIZE_BITS_2	c-src/emacs/src/lisp.h	1569
++CHARTAB_SIZE_BITS_3	c-src/emacs/src/lisp.h	1570
++CHARTAB_SIZE_BITS	c-src/emacs/src/lisp.h	1565
++\char	tex-src/texinfo.tex	/^\\def\\char{\\realbackslash char}%$/
++\char	tex-src/texinfo.tex	/^\\def\\char{\\realbackslash char}$/
++chartonmstr	pas-src/common.pas	/^function chartonmstr; (*($/
++CHAR_TYPE_SIZE	y-src/cccp.y	87
++CHAR	y-src/cccp.c	7
++CHECK_ARRAY	c-src/emacs/src/lisp.h	/^CHECK_ARRAY (Lisp_Object x, Lisp_Object predicate)/
++CHECK_BOOL_VECTOR	c-src/emacs/src/lisp.h	/^CHECK_BOOL_VECTOR (Lisp_Object x)$/
++CHECK_BUFFER	c-src/emacs/src/lisp.h	/^CHECK_BUFFER (Lisp_Object x)$/
++CHECK_CONS	c-src/emacs/src/lisp.h	/^CHECK_CONS (Lisp_Object x)$/
++check_cons_list	c-src/emacs/src/lisp.h	/^#  define check_cons_list() lisp_h_check_cons_list/
++checker	make-src/Makefile	/^checker:$/
++CHECKFLAGS	make-src/Makefile	/^CHECKFLAGS=-DDEBUG -Wno-unused-function$/
++checkhdr	c-src/emacs/src/gmalloc.c	/^checkhdr (const struct hdr *hdr)$/
++checkiso	html-src/software.html	/^checkiso$/
++CHECK_LISP_OBJECT_TYPE	c-src/emacs/src/lisp.h	571
++CHECK_LISP_OBJECT_TYPE	c-src/emacs/src/lisp.h	572
++CHECK_LISP_OBJECT_TYPE	c-src/emacs/src/lisp.h	579
++CHECK_LIST_CONS	c-src/emacs/src/lisp.h	/^# define CHECK_LIST_CONS(x, y) lisp_h_CHECK_LIST_C/
++CHECK_LIST	c-src/emacs/src/lisp.h	/^CHECK_LIST (Lisp_Object x)$/
++CHECK_NATNUM	c-src/emacs/src/lisp.h	/^CHECK_NATNUM (Lisp_Object x)$/
++CHECK_NUMBER_CAR	c-src/emacs/src/lisp.h	/^CHECK_NUMBER_CAR (Lisp_Object x)$/
++CHECK_NUMBER_CDR	c-src/emacs/src/lisp.h	/^CHECK_NUMBER_CDR (Lisp_Object x)$/
++CHECK_NUMBER_COERCE_MARKER	c-src/emacs/src/lisp.h	/^#define CHECK_NUMBER_COERCE_MARKER(x)					\\$/
++CHECK_NUMBER	c-src/emacs/src/lisp.h	/^# define CHECK_NUMBER(x) lisp_h_CHECK_NUMBER (x)$/
++CHECK_NUMBER_OR_FLOAT_COERCE_MARKER	c-src/emacs/src/lisp.h	/^#define CHECK_NUMBER_OR_FLOAT_COERCE_MARKER(x)				/
++CHECK_NUMBER_OR_FLOAT	c-src/emacs/src/lisp.h	/^CHECK_NUMBER_OR_FLOAT (Lisp_Object x)$/
++CHECKOBJS	make-src/Makefile	/^CHECKOBJS=chkmalloc.o chkxm.o$/
++CHECK_PROCESS	c-src/emacs/src/lisp.h	/^CHECK_PROCESS (Lisp_Object x)$/
++checkQuotation	php-src/lce_functions.php	/^      function checkQuotation($str)$/
++CHECK_RANGED_INTEGER	c-src/emacs/src/lisp.h	/^#define CHECK_RANGED_INTEGER(x, lo, hi)					\\$/
++CHECK_STRING_CAR	c-src/emacs/src/lisp.h	/^CHECK_STRING_CAR (Lisp_Object x)$/
++CHECK_SYMBOL	c-src/emacs/src/lisp.h	/^# define CHECK_SYMBOL(x) lisp_h_CHECK_SYMBOL (x)$/
++CHECK_TYPE	c-src/emacs/src/lisp.h	/^# define CHECK_TYPE(ok, predicate, x) lisp_h_CHECK/
++CHECK_TYPE_RANGED_INTEGER	c-src/emacs/src/lisp.h	/^#define CHECK_TYPE_RANGED_INTEGER(type, x) \\$/
++CHECK_VECTOR	c-src/emacs/src/lisp.h	/^CHECK_VECTOR (Lisp_Object x)$/
++CHECK_VECTOR_OR_STRING	c-src/emacs/src/lisp.h	/^CHECK_VECTOR_OR_STRING (Lisp_Object x)$/
++CHECK_WINDOW	c-src/emacs/src/lisp.h	/^CHECK_WINDOW (Lisp_Object x)$/
++\chfopen	tex-src/texinfo.tex	/^\\def\\chfopen #1#2{\\chapoddpage {\\chapfonts$/
++\chfplain	tex-src/texinfo.tex	/^\\def\\chfplain #1#2{%$/
++childDidExit	objc-src/Subprocess.m	/^- childDidExit$/
++chunks_free	c-src/emacs/src/gmalloc.c	313
++_chunks_free	c-src/emacs/src/gmalloc.c	375
++chunks_used	c-src/emacs/src/gmalloc.c	311
++_chunks_used	c-src/emacs/src/gmalloc.c	373
++\cindexsub	tex-src/texinfo.tex	/^\\def\\cindexsub {\\begingroup\\obeylines\\cindexsub}$/
++\cindex	tex-src/texinfo.tex	/^\\def\\cindex {\\cpindex}$/
++Circle.getPos	lua-src/test.lua	/^function Circle.getPos ()$/
++\cite	tex-src/texinfo.tex	/^\\def\\cite##1{\\realbackslash cite {##1}}%$/
++\cite	tex-src/texinfo.tex	/^\\def\\cite##1{\\realbackslash cite {##1}}$/
++C_JAVA	c-src/etags.c	2197
++cjava	c-src/etags.c	2936
++Cjava_entries	c-src/etags.c	/^Cjava_entries (FILE *inf)$/
++Cjava_help	c-src/etags.c	551
++Cjava_suffixes	c-src/etags.c	549
++CK_ABS_C	y-src/parse.y	/^#define CK_ABS_C(x)	if((x)<MIN_COL || (x)>MAX_COL)/
++CK_ABS_R	y-src/parse.y	/^#define CK_ABS_R(x)	if((x)<MIN_ROW || (x)>MAX_ROW)/
++CK_REL_C	y-src/parse.y	/^#define CK_REL_C(x)	if(   ((x)>0 && MAX_COL-(x)<cu/
++CK_REL_R	y-src/parse.y	/^#define CK_REL_R(x)	if(   ((x)>0 && MAX_ROW-(x)<cu/
++ClassExample	ruby-src/test.rb	/^    class ClassExample$/
++classifyLine	php-src/lce_functions.php	/^      function classifyLine($line)$/
++class_method	ruby-src/test.rb	/^        def ClassExample.class_method$/
++clean	make-src/Makefile	/^clean:$/
++clear-abbrev-table	c-src/abbrev.c	/^DEFUN ("clear-abbrev-table", Fclear_abbrev_table, /
++clearAllKey	objcpp-src/SimpleCalc.M	/^- clearAllKey:sender$/
++clear	cp-src/conway.hpp	/^    void clear(void) { alive = 0; }$/
++clear_event	c-src/emacs/src/keyboard.c	/^clear_event (struct input_event *event)$/
++clear_input_pending	c-src/emacs/src/keyboard.c	/^clear_input_pending (void)$/
++clearKey	objcpp-src/SimpleCalc.M	/^- clearKey:sender$/
++clear_neighbors	cp-src/clheir.cpp	/^void discrete_location::clear_neighbors(void)$/
++Clear/p	ada-src/2ataspri.adb	/^   procedure Clear (Cell : in out TAS_Cell) is$/
++Clear/p	ada-src/2ataspri.ads	/^   procedure Clear        (Cell : in out TAS_Cell)/
++clear_screen	cp-src/screen.cpp	/^void clear_screen(void)$/
++\clear	tex-src/texinfo.tex	/^\\def\\clear{\\parsearg\\clearxxx}$/
++clear-this-command-keys	c-src/emacs/src/keyboard.c	/^DEFUN ("clear-this-command-keys", Fclear_this_comm/
++clear_waiting_for_input	c-src/emacs/src/keyboard.c	/^clear_waiting_for_input (void)$/
++\clearxxx	tex-src/texinfo.tex	/^\\def\\clearxxx #1{$/
++cmd_error	c-src/emacs/src/keyboard.c	/^cmd_error (Lisp_Object data)$/
++cmd_error_internal	c-src/emacs/src/keyboard.c	/^cmd_error_internal (Lisp_Object data, const char */
++cmpfn	c-src/emacs/src/lisp.h	/^  bool (*cmpfn) (struct hash_table_test *t, Lisp_O/
++cmt	prol-src/natded.prolog	/^cmt:-$/
++CMultiChannelCSC19_3D	cp-src/c.C	2
++cname	c-src/etags.c	2519
++CNL	c-src/etags.c	/^#define CNL()								\\$/
++CNL_SAVE_DEFINEDEF	c-src/etags.c	/^#define CNL_SAVE_DEFINEDEF()						\\$/
++cno	c-src/etags.c	224
++COBOLFLAGS	make-src/Makefile	/^COBOLFLAGS=--language=none --regex='\/.......[a-zA-/
++Cobol_help	c-src/etags.c	558
++Cobol_paragraphs	c-src/etags.c	/^Cobol_paragraphs (FILE *inf)$/
++Cobol_suffixes	c-src/etags.c	556
++\code	tex-src/texinfo.tex	/^\\def\\code##1{\\realbackslash code {##1}}%$/
++\code	tex-src/texinfo.tex	/^\\def\\code##1{\\realbackslash code {##1}}$/
++colori	cp-src/c.C	40
++COLORS	cp-src/screen.hpp	11
++__COLORS	cp-src/screen.hpp	9
++/colorsetup	ps-src/rfc1245.ps	/^\/colorsetup {$/
++commaargvals	prol-src/natded.prolog	/^commaargvals(Args) -->$/
++command	c-src/etags.c	187
++command-error-default-function	c-src/emacs/src/keyboard.c	/^DEFUN ("command-error-default-function", Fcommand_/
++command_loop_1	c-src/emacs/src/keyboard.c	/^command_loop_1 (void)$/
++command_loop_2	c-src/emacs/src/keyboard.c	/^command_loop_2 (Lisp_Object ignore)$/
++command_loop	c-src/emacs/src/keyboard.c	/^command_loop (void)$/
++command_loop_level	c-src/emacs/src/keyboard.c	195
++CommentAD	php-src/lce_functions.php	70
++CommentAD	php-src/lce_functions.php	/^      function CommentAD($/
++comment	php-src/lce_functions.php	/^      function comment($line, $class)$/
++\comment	tex-src/texinfo.tex	/^\\def\\comment{\\catcode 64=\\other \\catcode 123=\\othe/
++\commentxxx	tex-src/texinfo.tex	/^\\def\\commentxxx #1{\\catcode 64=0 \\catcode 123=1 \\c/
++/COMMONBITMAPc	ps-src/rfc1245.ps	/^\/COMMONBITMAPc { $/
++/COMMONBITMAP	ps-src/rfc1245.ps	/^\/COMMONBITMAP { $/
++commutativity_assertion	merc-src/accumulator.m	/^:- pred commutativity_assertion(module_info::in,li/
++COMPILED_ARGLIST	c-src/emacs/src/lisp.h	2431
++COMPILED_BYTECODE	c-src/emacs/src/lisp.h	2432
++COMPILED_CONSTANTS	c-src/emacs/src/lisp.h	2433
++COMPILED_DOC_STRING	c-src/emacs/src/lisp.h	2435
++COMPILED_INTERACTIVE	c-src/emacs/src/lisp.h	2436
++COMPILEDP	c-src/emacs/src/lisp.h	/^COMPILEDP (Lisp_Object a)$/
++COMPILED_STACK_DEPTH	c-src/emacs/src/lisp.h	2434
++compile_empty	prol-src/natded.prolog	/^compile_empty:-$/
++compile_lex	prol-src/natded.prolog	/^compile_lex(File):-$/
++complete	prol-src/natded.prolog	/^complete(Cat):-$/
++complete-tag	el-src/emacs/lisp/progmodes/etags.el	/^(defun complete-tag ()$/
++compressor	c-src/etags.c	188
++compressors	c-src/etags.c	457
++compute_next_state	cp-src/clheir.hpp	/^    virtual void compute_next_state(void) { }$/
++compute_next_state	cp-src/conway.hpp	/^    void compute_next_state(void)$/
++conalgorithm	html-src/algrthms.html	/^Convolutionally$/
++concat	c-src/etags.c	/^concat (const char *s1, const char *s2, const char/
++concatenatenamestrings	pas-src/common.pas	/^function concatenatenamestrings; (*($/
++ConcatT	pas-src/common.pas	/^function ConcatT;(*($/
++Concept Index	tex-src/gzip.texi	/^@node Concept Index, , Problems, Top$/
++CONDITION_CASE	c-src/emacs/src/lisp.h	3021
++Condition_Variable/t	ada-src/2ataspri.ads	/^   type Condition_Variable is$/
++Condition_Variable/t	ada-src/2ataspri.ads	/^   type Condition_Variable is private;$/
++Cond_Signal/p	ada-src/2ataspri.adb	/^   procedure Cond_Signal (Cond : in out Condition_/
++Cond_Signal/p	ada-src/2ataspri.ads	/^   procedure Cond_Signal (Cond : in out Condition_/
++Cond_Timed_Wait/p	ada-src/2ataspri.adb	/^   procedure Cond_Timed_Wait$/
++Cond_Timed_Wait/p	ada-src/2ataspri.ads	/^   procedure Cond_Timed_Wait$/
++Cond_Wait/p	ada-src/2ataspri.adb	/^   procedure Cond_Wait (Cond : in out Condition_Va/
++Cond_Wait/p	ada-src/2ataspri.ads	/^   procedure Cond_Wait (Cond : in out Condition_Va/
++Configure	pyt-src/server.py	/^class Configure(Frame, ControlEdit):$/
++ConfirmQuit	pyt-src/server.py	/^def ConfirmQuit(frame, context):$/
++consider_token	c-src/etags.c	/^consider_token (char *str, int len, int c, int *c_/
++CONSP	c-src/emacs/src/lisp.h	/^# define CONSP(x) lisp_h_CONSP (x)$/
++constant_args	c-src/h.h	27
++constant	c-src/emacs/src/lisp.h	668
++constant	c-src/h.h	29
++Constant	ruby-src/test1.ru	42
++constant	y-src/cccp.y	112
++CONS_TO_INTEGER	c-src/emacs/src/lisp.h	/^#define CONS_TO_INTEGER(cons, type, var)				\\$/
++constype	c-src/emacs/src/lisp.h	3739
++CONSTYPE_HEAP	c-src/emacs/src/lisp.h	3739
++CONSTYPE_PURE	c-src/emacs/src/lisp.h	3739
++consult_lex	prol-src/natded.prolog	/^consult_lex:-$/
++contents	c-src/emacs/src/lisp.h	1372
++contents	c-src/emacs/src/lisp.h	1600
++contents	c-src/emacs/src/lisp.h	1624
++\contents	tex-src/texinfo.tex	/^\\outer\\def\\contents{%$/
++ControlEdit	pyt-src/server.py	/^class ControlEdit(Frame):$/
++Controls	pyt-src/server.py	/^class Controls:$/
++CONVERT_CHARSTRING_TO_VALUE	pas-src/common.pas	/^procedure CONVERT_CHARSTRING_TO_VALUE;(*($/
++Copying	tex-src/gzip.texi	/^@node Copying, Overview, , Top$/
++\copyright	tex-src/texinfo.tex	/^\\def\\copyright{\\realbackslash copyright }%$/
++\copyright	tex-src/texinfo.tex	/^\\def\\copyright{\\realbackslash copyright}$/
++CopyTextString	pas-src/common.pas	/^function CopyTextString;(*($/
++count	c-src/emacs/src/lisp.h	1863
++counter	cp-src/c.C	33
++counter	cp-src/c.C	36
++count_layers	lua-src/allegro.lua	/^local function count_layers (layer)$/
++count_words	c-src/tab.c	/^static int		count_words(char *str, char delim)$/
++cow	cp-src/c.C	127
++cow	cp-src/c.C	131
++C_PLAIN	c-src/etags.c	2194
++C_PLPL	c-src/etags.c	2195
++cplpl	c-src/etags.c	2935
++Cplusplus_entries	c-src/etags.c	/^Cplusplus_entries (FILE *inf)$/
++Cplusplus_help	c-src/etags.c	540
++Cplusplus_suffixes	c-src/etags.c	535
++CPPFLAGS	make-src/Makefile	/^CPPFLAGS=${CHECKFLAGS} -DSTDC_HEADERS -DHAVE_GETCW/
++CPSRC	make-src/Makefile	/^CPSRC=c.C abstract.C abstract.H cfront.H burton.cp/
++/C	ps-src/rfc1245.ps	/^\/C { $/
++create_acc_call	merc-src/accumulator.m	/^:- func create_acc_call(hlds_goal::in(goal_plain_c/
++create_acc_goal	merc-src/accumulator.m	/^:- pred create_acc_goal(hlds_goal::in, accu_substs/
++create-bar	forth-src/test-forth.fth	/^: create-bar foo ;$/
++Create_LL_Task/p	ada-src/2ataspri.adb	/^   procedure Create_LL_Task$/
++Create_LL_Task/p	ada-src/2ataspri.ads	/^   procedure Create_LL_Task$/
++create_new_base_goals	merc-src/accumulator.m	/^:- func create_new_base_goals(set(accu_goal_id), a/
++create_new_orig_recursive_goals	merc-src/accumulator.m	/^:- func create_new_orig_recursive_goals(set(accu_g/
++create_new_recursive_goals	merc-src/accumulator.m	/^:- func create_new_recursive_goals(set(accu_goal_i/
++create_new_var	merc-src/accumulator.m	/^:- pred create_new_var(prog_var::in, string::in, p/
++create_orig_goal	merc-src/accumulator.m	/^:- pred create_orig_goal(hlds_goal::in, accu_subst/
++createPOEntries	php-src/lce_functions.php	/^      function createPOEntries()$/
++createWidgets	pyt-src/server.py	/^    def createWidgets(self):$/
++createWidgets	pyt-src/server.py	/^    def createWidgets(self, host):$/
++\cropmarks	tex-src/texinfo.tex	/^\\def\\cropmarks{\\let\\onepageout=\\croppageout }$/
++\croppageout	tex-src/texinfo.tex	/^\\def\\croppageout#1{\\hoffset=0pt % make sure this d/
++cscInitTime	cp-src/c.C	7
++cscSegmentationTime	cp-src/c.C	8
++CSRC	make-src/Makefile	/^CSRC=abbrev.c ..\/etags\/h.h .\/\/c.c torture.c getopt/
++C_stab_entry	c-src/etags.c	2271
++cstack	c-src/etags.c	2523
++C_STAR	c-src/etags.c	2196
++Cstar_entries	c-src/etags.c	/^Cstar_entries (FILE *inf)$/
++Cstar_suffixes	c-src/etags.c	562
++C_symtype	c-src/etags.c	/^C_symtype (char *str, int len, int c_ext)$/
++CTAGS13 CTAGS14 CTAGS15	make-src/Makefile	/^CTAGS13 CTAGS14 CTAGS15: ctags% ${infiles}$/
++CTAGS	c-src/etags.c	146
++CTAGS	c-src/etags.c	147
++CTAGS	c-src/etags.c	149
++CTAGS	make-src/Makefile	/^CTAGS: ctags ${infiles}$/
++CTAGS%	make-src/Makefile	/^CTAGS%: ctags% ${infiles}$/
++ctags	make-src/Makefile	/^ctags: etags.c ${OBJS}$/
++\ctl	tex-src/texinfo.tex	/^\\def\\ctl{{\\circle\\char'013\\hskip -6pt}}% 6pt from /
++\ctrl	tex-src/texinfo.tex	/^\\def\\ctrl #1{{\\tt \\rawbackslash \\hat}#1}$/
++\ctr	tex-src/texinfo.tex	/^\\def\\ctr{{\\hskip 6pt\\circle\\char'010}}$/
++Cube.data.getFoo	lua-src/test.lua	/^function Cube.data.getFoo ()$/
++curlb	c-src/etags.c	2929
++curlinepos	c-src/etags.c	2931
++current-idle-time	c-src/emacs/src/keyboard.c	/^DEFUN ("current-idle-time", Fcurrent_idle_time, Sc/
++current-input-mode	c-src/emacs/src/keyboard.c	/^DEFUN ("current-input-mode", Fcurrent_input_mode, /
++current_kboard	c-src/emacs/src/keyboard.c	85
++current_lb_is_new	c-src/etags.c	2926
++curry-test	scm-src/test.scm	/^(define (((((curry-test a) b) c) d) e)$/
++cursor_position	cp-src/screen.cpp	/^void cursor_position(void)$/
++cursor_x	cp-src/screen.cpp	15
++cursor_y	cp-src/screen.cpp	15
++CYAN	cp-src/screen.hpp	15
++DAEMON_RUNNING	c-src/emacs/src/lisp.h	4258
++DAEMON_RUNNING	c-src/emacs/src/lisp.h	4262
++DARKGRAY	cp-src/screen.hpp	20
++data	c-src/emacs/src/lisp.h	1395
++data	c-src/emacs/src/lisp.h	2129
++data	c-src/emacs/src/lisp.h	2395
++d	c.c	180
++D	cp-src/fail.C	41
++D	cp-src/fail.C	/^		D() : ::A::T2::T(97), x(1066) {}$/
++d	c-src/emacs/src/lisp.h	4673
++d	c-src/emacs/src/lisp.h	4679
++ddefineseen	c-src/etags.c	2462
++DEAFUN	c.c	/^DEAFUN ("expand-file-name", Fexpand_file_name, Sex/
++debian-bug	html-src/software.html	/^debian-bug.el$/
++Debug	cp-src/functions.cpp	/^void Debug ( int lineno, int level, char* func , c/
++DEBUG	c-src/etags.c	84
++DEBUG	c-src/etags.c	85
++DEBUG	c-src/etags.c	87
++DEBUG	objc-src/PackInsp.m	37
++debug_on_exit	c-src/emacs/src/lisp.h	2984
++decimalKey	objcpp-src/SimpleCalc.M	/^- decimalKey:sender$/
++declared_special	c-src/emacs/src/lisp.h	676
++DECLARE_GDB_SYM	c-src/emacs/src/lisp.h	/^#define DECLARE_GDB_SYM(type, id) type const id EX/
++decode_timer	c-src/emacs/src/keyboard.c	/^decode_timer (Lisp_Object timer, struct timespec */
++defalt	c-src/emacs/src/lisp.h	1585
++default_C_entries	c-src/etags.c	/^default_C_entries (FILE *inf)$/
++default_C_help	c-src/etags.c	515
++default_C_help	c-src/etags.c	523
++default_C_suffixes	c-src/etags.c	512
++DEFAULT_HASH_SIZE	c-src/emacs/src/lisp.h	1940
++__default_morecore	c-src/emacs/src/gmalloc.c	/^__default_morecore (ptrdiff_t increment)$/
++DEFAULT_REHASH_SIZE	c-src/emacs/src/lisp.h	1950
++DEFAULT_REHASH_THRESHOLD	c-src/emacs/src/lisp.h	1946
++default-tags-table-function	el-src/emacs/lisp/progmodes/etags.el	/^(defvar default-tags-table-function nil$/
++defcell	c-src/emacs/src/lisp.h	2351
++\defcodeindex	tex-src/texinfo.tex	/^\\def\\defcodeindex{\\parsearg\\newcodeindex}$/
++def	c-src/h.h	35
++def	c-src/h.h	38
++\defcvarheader	tex-src/texinfo.tex	/^\\def\\defcvarheader #1#2#3{%$/
++\defcv	tex-src/texinfo.tex	/^\\def\\defcv #1 {\\def\\defcvtype{#1}%$/
++\defcvx	tex-src/texinfo.tex	/^\\def\\defcvx #1 {\\errmessage{@defcvx in invalid con/
++\deffnheader	tex-src/texinfo.tex	/^\\def\\deffnheader #1#2#3{\\doind {fn}{\\code{#2}}%$/
++\deffn	tex-src/texinfo.tex	/^\\def\\deffn{\\defmethparsebody\\Edeffn\\deffnx\\deffnhe/
++\deffnx	tex-src/texinfo.tex	/^\\def\\deffnx #1 {\\errmessage{@deffnx in invalid con/
++\defindex	tex-src/texinfo.tex	/^\\def\\defindex{\\parsearg\\newindex}$/
++define-abbrev	c-src/abbrev.c	/^DEFUN ("define-abbrev", Fdefine_abbrev, Sdefine_ab/
++define-abbrev-table	c-src/abbrev.c	/^DEFUN ("define-abbrev-table", Fdefine_abbrev_table/
++definedef	c-src/etags.c	2464
++defined_GC_CHECK_STRING_BYTES	c-src/emacs/src/lisp.h	4663
++defined_GC_CHECK_STRING_BYTES	c-src/emacs/src/lisp.h	4665
++DEFINE_GDB_SYMBOL_BEGIN	c-src/emacs/src/lisp.h	/^# define DEFINE_GDB_SYMBOL_BEGIN(type, id) DECLARE/
++DEFINE_GDB_SYMBOL_BEGIN	c-src/emacs/src/lisp.h	/^# define DEFINE_GDB_SYMBOL_BEGIN(type, id) extern /
++DEFINE_GDB_SYMBOL_END	c-src/emacs/src/lisp.h	/^# define DEFINE_GDB_SYMBOL_END(id) = id;$/
++DEFINE_GDB_SYMBOL_END	c-src/emacs/src/lisp.h	/^# define DEFINE_GDB_SYMBOL_END(val) ;$/
++define-global-abbrev	c-src/abbrev.c	/^DEFUN ("define-global-abbrev", Fdefine_global_abbr/
++DEFINE_LISP_SYMBOL	c-src/emacs/src/lisp.h	/^#define DEFINE_LISP_SYMBOL(name) \\$/
++define-mode-abbrev	c-src/abbrev.c	/^DEFUN ("define-mode-abbrev", Fdefine_mode_abbrev, /
++DEFINE_NON_NIL_Q_SYMBOL_MACROS	c-src/emacs/src/lisp.h	755
++\defivarheader	tex-src/texinfo.tex	/^\\def\\defivarheader #1#2#3{%$/
++\defivar	tex-src/texinfo.tex	/^\\def\\defivar{\\defvrparsebody\\Edefivar\\defivarx\\def/
++\defivarx	tex-src/texinfo.tex	/^\\def\\defivarx #1 {\\errmessage{@defivarx in invalid/
++\defmacheader	tex-src/texinfo.tex	/^\\def\\defmacheader #1#2{\\doind {fn}{\\code{#1}}% Mak/
++\defmac	tex-src/texinfo.tex	/^\\def\\defmac{\\defparsebody\\Edefmac\\defmacx\\defmache/
++\defmacx	tex-src/texinfo.tex	/^\\def\\defmacx #1 {\\errmessage{@defmacx in invalid c/
++\defmethodheader	tex-src/texinfo.tex	/^\\def\\defmethodheader #1#2#3{%$/
++\defmethod	tex-src/texinfo.tex	/^\\def\\defmethod{\\defmethparsebody\\Edefmethod\\defmet/
++\defmethodx	tex-src/texinfo.tex	/^\\def\\defmethodx #1 {\\errmessage{@defmethodx in inv/
++\defmethparsebody	tex-src/texinfo.tex	/^\\def\\defmethparsebody #1#2#3#4 {\\begingroup\\inENV /
++\defname	tex-src/texinfo.tex	/^\\def\\defname #1#2{%$/
++\defopheader	tex-src/texinfo.tex	/^\\def\\defopheader #1#2#3{%$/
++\defopparsebody	tex-src/texinfo.tex	/^\\def\\defopparsebody #1#2#3#4#5 {\\begingroup\\inENV /
++\defop	tex-src/texinfo.tex	/^\\def\\defop #1 {\\def\\defoptype{#1}%$/
++\defoptheader	tex-src/texinfo.tex	/^\\def\\defoptheader #1#2{\\doind {vr}{\\code{#1}}% Mak/
++\defopt	tex-src/texinfo.tex	/^\\def\\defopt{\\defvarparsebody\\Edefopt\\defoptx\\defop/
++\defoptx	tex-src/texinfo.tex	/^\\def\\defoptx #1 {\\errmessage{@defoptx in invalid c/
++\defopvarparsebody	tex-src/texinfo.tex	/^\\def\\defopvarparsebody #1#2#3#4#5 {\\begingroup\\inE/
++\defopx	tex-src/texinfo.tex	/^\\def\\defopx #1 {\\errmessage{@defopx in invalid con/
++\defparsebody	tex-src/texinfo.tex	/^\\def\\defparsebody #1#2#3{\\begingroup\\inENV% Enviro/
++Def_	ruby-src/test1.ru	12
++\defspecheader	tex-src/texinfo.tex	/^\\def\\defspecheader #1#2{\\doind {fn}{\\code{#1}}% Ma/
++\defspec	tex-src/texinfo.tex	/^\\def\\defspec{\\defparsebody\\Edefspec\\defspecx\\defsp/
++\defspecx	tex-src/texinfo.tex	/^\\def\\defspecx #1 {\\errmessage{@defspecx in invalid/
++DEFSYM	c-src/emacs/src/lisp.h	/^#define DEFSYM(sym, name) \/* empty *\/$/
++DEFSYM	c-src/emacs/src/lisp.h	/^LISP_MACRO_DEFUN (SYMBOL_CONSTANT_P, int, (Lisp_Ob/
++\deftpargs	tex-src/texinfo.tex	/^\\def\\deftpargs #1{\\bf \\defvarargs{#1}}$/
++\deftpheader	tex-src/texinfo.tex	/^\\def\\deftpheader #1#2#3{\\doind {tp}{\\code{#2}}%$/
++\deftp	tex-src/texinfo.tex	/^\\def\\deftp{\\defvrparsebody\\Edeftp\\deftpx\\deftphead/
++\deftpx	tex-src/texinfo.tex	/^\\def\\deftpx #1 {\\errmessage{@deftpx in invalid con/
++\deftypefnheader	tex-src/texinfo.tex	/^\\def\\deftypefnheader #1#2#3{\\deftypefnheaderx{#1}{/
++\deftypefnheaderx	tex-src/texinfo.tex	/^\\def\\deftypefnheaderx #1#2#3 #4\\relax{%$/
++\deftypefn	tex-src/texinfo.tex	/^\\def\\deftypefn{\\defmethparsebody\\Edeftypefn\\deftyp/
++\deftypefnx	tex-src/texinfo.tex	/^\\def\\deftypefnx #1 {\\errmessage{@deftypefnx in inv/
++\deftypefunargs	tex-src/texinfo.tex	/^\\def\\deftypefunargs #1{%$/
++\deftypefunheader	tex-src/texinfo.tex	/^\\def\\deftypefunheader #1#2{\\deftypefunheaderx{#1}#/
++\deftypefunheaderx	tex-src/texinfo.tex	/^\\def\\deftypefunheaderx #1#2 #3\\relax{%$/
++\deftypefun	tex-src/texinfo.tex	/^\\def\\deftypefun{\\defparsebody\\Edeftypefun\\deftypef/
++\deftypeunx	tex-src/texinfo.tex	/^\\def\\deftypeunx #1 {\\errmessage{@deftypeunx in inv/
++\deftypevarheader	tex-src/texinfo.tex	/^\\def\\deftypevarheader #1#2{%$/
++\deftypevar	tex-src/texinfo.tex	/^\\def\\deftypevar{\\defvarparsebody\\Edeftypevar\\defty/
++\deftypevarx	tex-src/texinfo.tex	/^\\def\\deftypevarx #1 {\\errmessage{@deftypevarx in i/
++\deftypevrheader	tex-src/texinfo.tex	/^\\def\\deftypevrheader #1#2#3{\\doind {vr}{\\code{#3}}/
++\deftypevr	tex-src/texinfo.tex	/^\\def\\deftypevr{\\defvrparsebody\\Edeftypevr\\deftypev/
++\deftypevrx	tex-src/texinfo.tex	/^\\def\\deftypevrx #1 {\\errmessage{@deftypevrx in inv/
++DEFUN_ARGS_0	c-src/emacs/src/lisp.h	714
++DEFUN_ARGS_1	c-src/emacs/src/lisp.h	715
++DEFUN_ARGS_2	c-src/emacs/src/lisp.h	716
++DEFUN_ARGS_3	c-src/emacs/src/lisp.h	717
++DEFUN_ARGS_4	c-src/emacs/src/lisp.h	718
++DEFUN_ARGS_5	c-src/emacs/src/lisp.h	719
++DEFUN_ARGS_6	c-src/emacs/src/lisp.h	721
++DEFUN_ARGS_7	c-src/emacs/src/lisp.h	723
++DEFUN_ARGS_8	c-src/emacs/src/lisp.h	725
++DEFUN_ARGS_MANY	c-src/emacs/src/lisp.h	712
++\defunargs	tex-src/texinfo.tex	/^\\def\\defunargs #1{\\functionparens \\sl$/
++DEFUN_ARGS_UNEVALLED	c-src/emacs/src/lisp.h	713
++DEFUN	c-src/emacs/src/lisp.h	/^#define DEFUN(lname, fnname, sname, minargs, maxar/
++defun_func1	c.c	/^defun_func1()$/
++DEFUN_func2	c.c	/^DEFUN_func2()$/
++\defunheader	tex-src/texinfo.tex	/^\\def\\defunheader #1#2{\\doind {fn}{\\code{#1}}% Make/
++\defun	tex-src/texinfo.tex	/^\\def\\defun{\\defparsebody\\Edefun\\defunx\\defunheader/
++\defunx	tex-src/texinfo.tex	/^\\def\\defunx #1 {\\errmessage{@defunx in invalid con/
++\defvarargs	tex-src/texinfo.tex	/^\\def\\defvarargs #1{\\normalparens #1%$/
++DEFVAR_BOOL	c-src/emacs/src/lisp.h	/^#define DEFVAR_BOOL(lname, vname, doc)		\\$/
++DEFVAR_BUFFER_DEFAULTS	c-src/emacs/src/lisp.h	/^#define DEFVAR_BUFFER_DEFAULTS(lname, vname, doc)	/
++\defvarheader	tex-src/texinfo.tex	/^\\def\\defvarheader #1#2{\\doind {vr}{\\code{#1}}% Mak/
++DEFVAR_INT	c-src/emacs/src/lisp.h	/^#define DEFVAR_INT(lname, vname, doc)		\\$/
++DEFVAR_KBOARD	c-src/emacs/src/lisp.h	/^#define DEFVAR_KBOARD(lname, vname, doc)			\\$/
++DEFVAR_LISP	c-src/emacs/src/lisp.h	/^#define DEFVAR_LISP(lname, vname, doc)		\\$/
++DEFVAR_LISP_NOPRO	c-src/emacs/src/lisp.h	/^#define DEFVAR_LISP_NOPRO(lname, vname, doc)	\\$/
++\defvarparsebody	tex-src/texinfo.tex	/^\\def\\defvarparsebody #1#2#3{\\begingroup\\inENV% Env/
++\defvar	tex-src/texinfo.tex	/^\\def\\defvar{\\defvarparsebody\\Edefvar\\defvarx\\defva/
++\defvarx	tex-src/texinfo.tex	/^\\def\\defvarx #1 {\\errmessage{@defvarx in invalid c/
++\defvrheader	tex-src/texinfo.tex	/^\\def\\defvrheader #1#2#3{\\doind {vr}{\\code{#2}}%$/
++\defvrparsebody	tex-src/texinfo.tex	/^\\def\\defvrparsebody #1#2#3#4 {\\begingroup\\inENV %$/
++\defvr	tex-src/texinfo.tex	/^\\def\\defvr{\\defvrparsebody\\Edefvr\\defvrx\\defvrhead/
++\defvrx	tex-src/texinfo.tex	/^\\def\\defvrx #1 {\\errmessage{@defvrx in invalid con/
++delegate	objc-src/Subprocess.m	/^- delegate$/
++deleteItem	pyt-src/server.py	/^    def deleteItem(self):$/
++delete_kboard	c-src/emacs/src/keyboard.c	/^delete_kboard (KBOARD *kb)$/
++deliver_input_available_signal	c-src/emacs/src/keyboard.c	/^deliver_input_available_signal (int sig)$/
++deliver_interrupt_signal	c-src/emacs/src/keyboard.c	/^deliver_interrupt_signal (int sig)$/
++deliver_user_signal	c-src/emacs/src/keyboard.c	/^deliver_user_signal (int sig)$/
++depth	c-src/emacs/src/lisp.h	1618
++derived_analyses	prol-src/natded.prolog	/^derived_analyses([],[]).$/
++describe_abbrev	c-src/abbrev.c	/^describe_abbrev (sym, stream)$/
++\description	tex-src/texinfo.tex	/^\\def\\description{\\tablez{\\dontindex}{1}{}{}{}{}}$/
++/desperatepapersize	ps-src/rfc1245.ps	/^\/desperatepapersize {$/
++detect_input_pending	c-src/emacs/src/keyboard.c	/^detect_input_pending (void)$/
++detect_input_pending_ignore_squeezables	c-src/emacs/src/keyboard.c	/^detect_input_pending_ignore_squeezables (void)$/
++detect_input_pending_run_timers	c-src/emacs/src/keyboard.c	/^detect_input_pending_run_timers (bool do_display)$/
++DEVICE_LAST	c-src/h.h	24
++DEVICE_SWP	c-src/h.h	23
++\dfn	tex-src/texinfo.tex	/^\\def\\dfn##1{\\realbackslash dfn {##1}}$/
++\df	tex-src/texinfo.tex	/^\\def\\df{\\let\\tentt=\\deftt \\let\\tenbf = \\defbf \\bf}/
++/DiacriticEncoding	ps-src/rfc1245.ps	/^\/DiacriticEncoding [$/
++dialog_loop	erl-src/gs_dialog.erl	/^dialog_loop(Module, Window, Frame, Extra, Args) ->/
++/dieresis	ps-src/rfc1245.ps	/^\/dieresis \/.notdef \/AE \/Oslash \/.notdef \/.notdef \//
++dignorerest	c-src/etags.c	2463
++\direntry	tex-src/texinfo.tex	/^\\def\\direntry{\\begingroup\\direntryxxx}$/
++\direntryxxx	tex-src/texinfo.tex	/^\\long\\def\\direntryxxx #1\\end direntry{\\endgroup\\ig/
++discard-input	c-src/emacs/src/keyboard.c	/^DEFUN ("discard-input", Fdiscard_input, Sdiscard_i/
++discard_mouse_events	c-src/emacs/src/keyboard.c	/^discard_mouse_events (void)$/
++discrete_location	cp-src/clheir.hpp	56
++discrete_location	cp-src/clheir.hpp	/^    discrete_location(int xi, int yi, int zi):$/
++display	cp-src/conway.cpp	/^void display(void)$/
++\display	tex-src/texinfo.tex	/^\\def\\display{\\begingroup\\inENV %This group ends at/
++DisposeANameList	pas-src/common.pas	/^procedure DisposeANameList( $/
++DisposeNameList	pas-src/common.pas	/^procedure DisposeNameList;$/
++disposetextstring	pas-src/common.pas	/^procedure disposetextstring;(*($/
++/dmatrix	ps-src/rfc1245.ps	/^\/dmatrix matrix def$/
++\dmn	tex-src/texinfo.tex	/^\\def\\dmn#1{\\thinspace #1}$/
++dnone	c-src/etags.c	2460
++/dnormalize	ps-src/rfc1245.ps	/^\/dnormalize {$/
++\dobreak	tex-src/texinfo.tex	/^\\def\\dobreak#1#2{\\par\\ifdim\\lastskip<#1\\removelast/
++doc	c-src/emacs/src/lisp.h	1689
++\dochapentry	tex-src/texinfo.tex	/^\\def\\dochapentry#1#2{%$/
++\docodeindex	tex-src/texinfo.tex	/^\\def\\docodeindex#1{\\edef\\indexname{#1}\\parsearg\\si/
++dog	cp-src/c.C	126
++dog	cp-src/c.C	130
++dog	c-src/h.h	81
++\doindex	tex-src/texinfo.tex	/^\\def\\doindex#1{\\edef\\indexname{#1}\\parsearg\\single/
++\doind	tex-src/texinfo.tex	/^\\def\\doind #1#2{%$/
++\donoderef	tex-src/texinfo.tex	/^\\def\\donoderef{\\ifx\\lastnode\\relax\\else$/
++\dontindex	tex-src/texinfo.tex	/^\\def\\dontindex #1{}$/
++\dopageno	tex-src/texinfo.tex	/^\\def\\dopageno#1{{\\rm #1}}$/
++\doprintindex	tex-src/texinfo.tex	/^\\def\\doprintindex#1{%$/
++\dosecentry	tex-src/texinfo.tex	/^\\def\\dosecentry#1#2{%$/
++\dosetq	tex-src/texinfo.tex	/^\\def\\dosetq #1#2{{\\let\\folio=0 \\turnoffactive%$/
++\doshortpageno	tex-src/texinfo.tex	/^\\def\\doshortpageno#1{{\\rm #1}}$/
++DOS_NT	c-src/etags.c	117
++DOS_NT	c-src/etags.c	118
++\dosubind	tex-src/texinfo.tex	/^\\def\\dosubind #1#2#3{%$/
++\dosubsecentry	tex-src/texinfo.tex	/^\\def\\dosubsecentry#1#2{%$/
++\dosubsubsecentry	tex-src/texinfo.tex	/^\\def\\dosubsubsecentry#1#2{%$/
++dotfill	tex-src/texinfo.tex	/^\\noindent\\hskip\\secondaryindent\\hbox{#1}\\indexdotf/
++dotfill	tex-src/texinfo.tex	/^  \\null\\nobreak\\indexdotfill % Have leaders before/
++\dots	tex-src/texinfo.tex	/^\\def\\dots{$\\ldots$}$/
++\dots	tex-src/texinfo.tex	/^\\def\\dots{\\realbackslash dots }%$/
++\dots	tex-src/texinfo.tex	/^\\def\\dots{\\realbackslash dots}$/
++double_click_count	c-src/emacs/src/keyboard.c	5222
++\doublecolumnout	tex-src/texinfo.tex	/^\\def\\doublecolumnout{\\splittopskip=\\topskip \\split/
++/dpi	ps-src/rfc1245.ps	/^\/dpi    72 0 dmatrix defaultmatrix dtransform$/
++/D	ps-src/rfc1245.ps	/^\/D {curveto} bind def$/
++drag_n_drop_syms	c-src/emacs/src/keyboard.c	4629
++dribble	c-src/emacs/src/keyboard.c	236
++dsharpseen	c-src/etags.c	2461
++dummies	tex-src/texinfo.tex	/^{\\indexdummies % Must do this here, since \\bf, etc/
++dummy1	cp-src/burton.cpp	/^::dummy::dummy test::dummy1(void)$/
++dummy2	cp-src/burton.cpp	/^::dummy::dummy test::dummy2(::CORBA::Long dummy)$/
++dummy3	cp-src/burton.cpp	/^::dummy::dummy test::dummy3(char* name, ::CORBA::L/
++dummydots	tex-src/texinfo.tex	/^\\let\\dots=\\indexdummydots$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\b=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\code=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\emph=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\file=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\i=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\kbd=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\key=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\r=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\samp=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\sc=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\strong=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\tclose=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\t=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\var=\\indexdummyfont$/
++dummyfont	tex-src/texinfo.tex	/^\\let\\w=\\indexdummyfont$/
++dummytex	tex-src/texinfo.tex	/^\\let\\TeX=\\indexdummytex$/
++DUMPED	c-src/emacs/src/gmalloc.c	80
++dump	pyt-src/server.py	/^    def dump(self, folded):$/
++eabs	c-src/emacs/src/lisp.h	/^#define eabs(x)         ((x) < 0 ? -(x) : (x))$/
++\Ealphaenumerate	tex-src/texinfo.tex	/^\\def\\Ealphaenumerate{\\Eenumerate}$/
++eassert	c-src/emacs/src/lisp.h	/^# define eassert(cond)						\\$/
++eassert	c-src/emacs/src/lisp.h	/^# define eassert(cond) ((void) (false && (cond))) /
++eassume	c-src/emacs/src/lisp.h	/^# define eassume(cond)						\\$/
++eassume	c-src/emacs/src/lisp.h	/^# define eassume(cond) assume (cond)$/
++eax	c-src/sysdep.h	31
++eax	c-src/sysdep.h	33
++\Ecapsenumerate	tex-src/texinfo.tex	/^\\def\\Ecapsenumerate{\\Eenumerate}$/
++\Ecartouche	tex-src/texinfo.tex	/^\\def\\Ecartouche{%$/
++echo_add_key	c-src/emacs/src/keyboard.c	/^echo_add_key (Lisp_Object c)$/
++echo_char	c-src/emacs/src/keyboard.c	/^echo_char (Lisp_Object c)$/
++echo_dash	c-src/emacs/src/keyboard.c	/^echo_dash (void)$/
++echoing	c-src/emacs/src/keyboard.c	154
++echo_kboard	c-src/emacs/src/keyboard.c	166
++echo_keystrokes_p	c-src/emacs/src/keyboard.c	/^echo_keystrokes_p (void)$/
++echo_length	c-src/emacs/src/keyboard.c	/^echo_length (void)$/
++echo_message_buffer	c-src/emacs/src/keyboard.c	171
++echo_now	c-src/emacs/src/keyboard.c	/^echo_now (void)$/
++echo_truncate	c-src/emacs/src/keyboard.c	/^echo_truncate (ptrdiff_t nchars)$/
++\Edescription	tex-src/texinfo.tex	/^\\def\\Edescription{\\Etable}% Necessary kludge.$/
++%ediff	make-src/Makefile	/^%ediff: ETAGS% ETAGS ${infiles}$/
++\Edisplay	tex-src/texinfo.tex	/^\\def\\Edisplay{\\endgroup\\afterenvbreak}%$/
++editItem	pyt-src/server.py	/^    def editItem(self):$/
++editsite	pyt-src/server.py	/^    def editsite(self, site):$/
++edituser	pyt-src/server.py	/^    def edituser(self, user):$/
++\Eexample	tex-src/texinfo.tex	/^\\def\\Eexample{\\Elisp}$/
++\Eflushleft	tex-src/texinfo.tex	/^\\def\\Eflushleft{\\endgroup\\afterenvbreak}%$/
++\Eflushright	tex-src/texinfo.tex	/^\\def\\Eflushright{\\endgroup\\afterenvbreak}%$/
++\Eformat	tex-src/texinfo.tex	/^\\def\\Eformat{\\endgroup\\afterenvbreak}$/
++\Eftable	tex-src/texinfo.tex	/^\\def\\Eftable{\\endgraf\\endgroup\\afterenvbreak}%$/
++egetenv	c-src/emacs/src/lisp.h	/^egetenv (const char *var)$/
++\Egroup	tex-src/texinfo.tex	/^  \\def\\Egroup{\\egroup\\endgroup}%$/
++\Eifclear	tex-src/texinfo.tex	/^\\def\\Eifclear{}$/
++\Eifset	tex-src/texinfo.tex	/^\\def\\Eifset{}$/
++\Eiftex	tex-src/texinfo.tex	/^\\def\\Eiftex{}$/
++ELEM_I	c-src/h.h	3
++\Elisp	tex-src/texinfo.tex	/^\\def\\Elisp{\\endgroup\\afterenvbreak}%$/
++ELSRC	make-src/Makefile	/^ELSRC=TAGTEST.EL emacs\/lisp\/progmodes\/etags.el$/
++emacs_abort	c-src/emacs/src/lisp.h	/^extern _Noreturn void emacs_abort (void) NO_INLINE/
++EMACS_INT	c-src/emacs/src/lisp.h	103
++EMACS_INT	c-src/emacs/src/lisp.h	91
++EMACS_INT	c-src/emacs/src/lisp.h	96
++EMACS_INT_MAX	c-src/emacs/src/lisp.h	105
++EMACS_INT_MAX	c-src/emacs/src/lisp.h	93
++EMACS_INT_MAX	c-src/emacs/src/lisp.h	98
++EMACS_LISP_H	c-src/emacs/src/lisp.h	22
++EMACS_NAME	c-src/etags.c	786
++EMACS_UINT	c-src/emacs/src/lisp.h	104
++EMACS_UINT	c-src/emacs/src/lisp.h	92
++EMACS_UINT	c-src/emacs/src/lisp.h	97
++\emph	tex-src/texinfo.tex	/^\\def\\emph##1{\\realbackslash emph {##1}}$/
++EmptyNmStr	pas-src/common.pas	/^function EmptyNmStr(* : NameString*);$/
++/ENDBITMAP	ps-src/rfc1245.ps	/^\/ENDBITMAP {$/
++end	c-src/emacs/src/keyboard.c	8753
++end	c-src/emacs/src/lisp.h	2039
++end	c-src/emacs/src/regex.h	432
++\enddoublecolumns	tex-src/texinfo.tex	/^\\def\\enddoublecolumns{\\output={\\balancecolumns}\\ej/
++/ENDPRINTCODE	ps-src/rfc1245.ps	/^\/ENDPRINTCODE {$/
++\end	tex-src/texinfo.tex	/^\\def\\end{\\parsearg\\endxxx}$/
++endtoken	c-src/etags.c	/^#define	endtoken(c)	(_etk[CHAR (c)]) \/* c ends tok/
++\endxxx	tex-src/texinfo.tex	/^\\def\\endxxx #1{%$/
++enter_critical_section	c-src/h.h	116
++ENTRY	c-src/sysdep.h	/^#define	ENTRY(name)							      \\$/
++entry	perl-src/htlmify-cystic	218
++entry	perl-src/htlmify-cystic	234
++entry	perl-src/htlmify-cystic	245
++entry	perl-src/htlmify-cystic	252
++entry	perl-src/htlmify-cystic	268
++entry	perl-src/htlmify-cystic	276
++entry	perl-src/htlmify-cystic	281
++entry	perl-src/htlmify-cystic	296
++\entry	tex-src/texinfo.tex	/^\\def\\entry #1#2{\\begingroup$/
++ENUM_BF	c-src/emacs/src/lisp.h	/^#define ENUM_BF(TYPE) enum TYPE$/
++ENUM_BF	c-src/emacs/src/lisp.h	/^#define ENUM_BF(TYPE) unsigned int$/
++\enumerate	tex-src/texinfo.tex	/^\\def\\enumerate{\\parsearg\\enumeratezzz}$/
++\enumeratey	tex-src/texinfo.tex	/^\\def\\enumeratey #1 #2\\endenumeratey{%$/
++\enumeratezzz	tex-src/texinfo.tex	/^\\def\\enumeratezzz #1{\\enumeratey #1  \\endenumerate/
++\ENVcheck	tex-src/texinfo.tex	/^\\def\\ENVcheck{%$/
++Environment	tex-src/gzip.texi	/^@node Environment, Tapes, Advanced usage, Top$/
++/E	ps-src/rfc1245.ps	/^\/E {lineto} bind def$/
++EQ	c-src/emacs/src/lisp.h	/^# define EQ(x, y) lisp_h_EQ (x, y)$/
++equalsKey	objcpp-src/SimpleCalc.M	/^- equalsKey:sender$/
++EQUAL	y-src/cccp.c	12
++\equiv	tex-src/texinfo.tex	/^\\def\\equiv{\\leavevmode\\lower.1ex\\hbox to 1em{\\hfil/
++\equiv	tex-src/texinfo.tex	/^\\def\\equiv{\\realbackslash equiv}$/
++\Equotation	tex-src/texinfo.tex	/^\\def\\Equotation{\\par\\endgroup\\afterenvbreak}%$/
++erlang_atom	c-src/etags.c	/^erlang_atom (char *s)$/
++erlang_attribute	c-src/etags.c	/^erlang_attribute (char *s)$/
++erlang_func	c-src/etags.c	/^erlang_func (char *s, char *last)$/
++Erlang_functions	c-src/etags.c	/^Erlang_functions (FILE *inf)$/
++Erlang_help	c-src/etags.c	567
++Erlang_suffixes	c-src/etags.c	565
++ERLSRC	make-src/Makefile	/^ERLSRC=gs_dialog.erl lines.erl lists.erl$/
++error	c-src/emacs/src/lisp.h	/^extern _Noreturn void error (const char *, ...) AT/
++error	c-src/etags.c	/^error (const char *format, ...)$/
++error	c-src/etags.c	/^static void error (const char *, ...) ATTRIBUTE_FO/
++\errorE	tex-src/texinfo.tex	/^\\def\\errorE#1{$/
++Error_Information/t	ada-src/2ataspri.ads	/^   type Error_Information is new Interfaces.C.POSI/
++error_signaled	c-src/etags.c	264
++\error	tex-src/texinfo.tex	/^\\def\\error{\\leavevmode\\lower.7ex\\copy\\errorbox}$/
++ERROR	y-src/cccp.c	9
++error	y-src/cccp.y	/^error (msg)$/
++ERROR	y-src/parse.y	304
++ErrStrToNmStr	pas-src/common.pas	/^function ErrStrToNmStr;(*($/
++\Esmallexample	tex-src/texinfo.tex	/^\\def\\Esmallexample{\\Elisp}$/
++\Esmallexample	tex-src/texinfo.tex	/^\\global\\def\\Esmallexample{\\Esmalllisp}$/
++\Esmalllisp	tex-src/texinfo.tex	/^\\def\\Esmalllisp{\\endgroup\\afterenvbreak}%$/
++\Etable	tex-src/texinfo.tex	/^\\def\\Etable{\\endgraf\\endgroup\\afterenvbreak}%$/
++ETAGS12	make-src/Makefile	/^ETAGS12: etags12 ${infiles}$/
++ETAGS13 ETAGS14 ETAGS15	make-src/Makefile	/^ETAGS13 ETAGS14 ETAGS15: etags% ${infiles}$/
++etags.1.man	make-src/Makefile	/^etags.1.man: etags.1$/
++etags	el-src/emacs/lisp/progmodes/etags.el	/^(defgroup etags nil "Tags tables."$/
++etags-file-of-tag	el-src/emacs/lisp/progmodes/etags.el	/^(defun etags-file-of-tag (&optional relative) ; Do/
++etags_getcwd	c-src/etags.c	/^etags_getcwd (void)$/
++etags-goto-tag-location	el-src/emacs/lisp/progmodes/etags.el	/^(defun etags-goto-tag-location (tag-info)$/
++etags	html-src/software.html	/^Etags$/
++etags-list-tags	el-src/emacs/lisp/progmodes/etags.el	/^(defun etags-list-tags (file) ; Doc string?$/
++etags	make-src/Makefile	/^etags: etags.c ${OBJS}$/
++ETAGS	make-src/Makefile	/^ETAGS: FRC etags ${infiles}$/
++ETAGS%	make-src/Makefile	/^ETAGS%: FRC etags% ${infiles}$/
++etags-recognize-tags-table	el-src/emacs/lisp/progmodes/etags.el	/^(defun etags-recognize-tags-table ()$/
++etags-snarf-tag	el-src/emacs/lisp/progmodes/etags.el	/^(defun etags-snarf-tag (&optional use-explicit) ; /
++etags-tags-apropos-additional	el-src/emacs/lisp/progmodes/etags.el	/^(defun etags-tags-apropos-additional (regexp)$/
++etags-tags-apropos	el-src/emacs/lisp/progmodes/etags.el	/^(defun etags-tags-apropos (string) ; Doc string?$/
++etags-tags-completion-table	el-src/emacs/lisp/progmodes/etags.el	/^(defun etags-tags-completion-table () ; Doc string/
++etags-tags-included-tables	el-src/emacs/lisp/progmodes/etags.el	/^(defun etags-tags-included-tables () ; Doc string?/
++etags-tags-table-files	el-src/emacs/lisp/progmodes/etags.el	/^(defun etags-tags-table-files () ; Doc string?$/
++etags-verify-tags-table	el-src/emacs/lisp/progmodes/etags.el	/^(defun etags-verify-tags-table ()$/
++etags--xref-find-definitions	el-src/emacs/lisp/progmodes/etags.el	/^(defun etags--xref-find-definitions (pattern &opti/
++etags-xref-find-definitions-tag-order	el-src/emacs/lisp/progmodes/etags.el	/^(defvar etags-xref-find-definitions-tag-order '(ta/
++etags-xref-find	el-src/emacs/lisp/progmodes/etags.el	/^(defun etags-xref-find (action id)$/
++etags--xref-limit	el-src/emacs/lisp/progmodes/etags.el	/^(defconst etags--xref-limit 1000)$/
++\Etitlepage	tex-src/texinfo.tex	/^\\def\\Etitlepage{%$/
++eval_dyn	c-src/emacs/src/keyboard.c	/^eval_dyn (Lisp_Object form)$/
++\evenfooting	tex-src/texinfo.tex	/^\\def\\evenfooting{\\parsearg\\evenfootingxxx}$/
++\evenheading	tex-src/texinfo.tex	/^\\def\\evenheading{\\parsearg\\evenheadingxxx}$/
++event-convert-list	c-src/emacs/src/keyboard.c	/^DEFUN ("event-convert-list", Fevent_convert_list, /
++event_head	c-src/emacs/src/keyboard.c	11021
++event-symbol-parse-modifiers	c-src/emacs/src/keyboard.c	/^DEFUN ("internal-event-symbol-parse-modifiers", Fe/
++event_to_kboard	c-src/emacs/src/keyboard.c	/^event_to_kboard (struct input_event *event)$/
++\everyfooting	tex-src/texinfo.tex	/^\\def\\everyfooting{\\parsearg\\everyfootingxxx}$/
++\everyheading	tex-src/texinfo.tex	/^\\def\\everyheading{\\parsearg\\everyheadingxxx}$/
++\Evtable	tex-src/texinfo.tex	/^\\def\\Evtable{\\endgraf\\endgroup\\afterenvbreak}%$/
++\ewbot	tex-src/texinfo.tex	/^\\def\\ewbot{\\vrule height0pt depth\\cornerthick widt/
++\ewtop	tex-src/texinfo.tex	/^\\def\\ewtop{\\vrule height\\cornerthick depth0pt widt/
++exact	c-src/emacs/src/gmalloc.c	200
++/exclamdown	ps-src/rfc1245.ps	/^\/exclamdown \/logicalnot \/.notdef \/florin \/.notdef /
++\exdent	tex-src/texinfo.tex	/^\\def\\exdent{\\parsearg\\exdentyyy}$/
++\exdentyyy	tex-src/texinfo.tex	/^\\def\\exdentyyy #1{{\\hfil\\break\\hbox{\\kern -\\exdent/
++execute	cp-src/c.C	/^        void execute(CPluginCSCState& p, int w, in/
++EXFUN	c-src/emacs/src/lisp.h	/^#define EXFUN(fnname, maxargs) \\$/
++exit_critical_to_previous	c-src/h.h	117
++exit	c-src/exit.c	/^DEFUN(exit, (status), int status)$/
++exit	c-src/exit.strange_suffix	/^DEFUN(exit, (status), int status)$/
++Exit_LL_Task/p	ada-src/2ataspri.adb	/^   procedure Exit_LL_Task is$/
++Exit_LL_Task/p	ada-src/2ataspri.ads	/^   procedure Exit_LL_Task;$/
++exit-recursive-edit	c-src/emacs/src/keyboard.c	/^DEFUN ("exit-recursive-edit", Fexit_recursive_edit/
++exp1	y-src/cccp.y	148
++expand-abbrev	c-src/abbrev.c	/^DEFUN ("expand-abbrev", Fexpand_abbrev, Sexpand_ab/
++expandmng	prol-src/natded.prolog	/^expandmng(var(V),var(V)).$/
++expandmng_tree	prol-src/natded.prolog	/^expandmng_tree(tree(Rule,Syn:Sem,Trees),$/
++expandmng_trees	prol-src/natded.prolog	/^expandmng_trees([],[]).$/
++expandsyn	prol-src/natded.prolog	/^expandsyn(Syn,Syn):-$/
++\expansion	tex-src/texinfo.tex	/^\\def\\expansion{\\leavevmode\\raise.1ex\\hbox to 1em{\\/
++\expansion	tex-src/texinfo.tex	/^\\def\\expansion{\\realbackslash expansion}$/
++explicitly-quoted-pending-delete-mode	el-src/TAGTEST.EL	/^(defalias (quote explicitly-quoted-pending-delete-/
++exp_list	y-src/parse.y	263
++expression_value	y-src/cccp.y	68
++exp	y-src/atest.y	2
++exp	y-src/cccp.y	156
++exp	y-src/cccp.y	185
++exp	y-src/parse.y	95
++EXTAGS	make-src/Makefile	/^EXTAGS: extags ${infiles} Makefile$/
++EXTERNALLY_VISIBLE	c-src/emacs/src/keyboard.c	3497
++EXTERNALLY_VISIBLE	c-src/emacs/src/keyboard.c	4372
++ExtractCommentInfo	pas-src/common.pas	/^procedure ExtractCommentInfo; (*($/
++extras	c-src/emacs/src/lisp.h	1603
++extvar	c-src/h.h	109
++f1	c.c	/^     f1 () { \/* Do something. *\/; }$/
++f1	perl-src/kai-test.pl	/^sub f1 {$/
++f2	c.c	/^void f2 () { \/* Do something. *\/; }$/
++f2	perl-src/kai-test.pl	/^sub main::f2 {$/
++f3	perl-src/kai-test.pl	/^sub f3 {$/
++f4	perl-src/kai-test.pl	/^sub Bar::f4 {$/
++f5	perl-src/kai-test.pl	/^sub f5 {$/
++f6	perl-src/kai-test.pl	/^sub f6 {$/
++f7	perl-src/kai-test.pl	/^sub f7 {$/
++Fabbrev_expansion	c-src/abbrev.c	/^DEFUN ("abbrev-expansion", Fabbrev_expansion, Sabb/
++Fabbrev_symbol	c-src/abbrev.c	/^DEFUN ("abbrev-symbol", Fabbrev_symbol, Sabbrev_sy/
++Fabort_recursive_edit	c-src/emacs/src/keyboard.c	/^DEFUN ("abort-recursive-edit", Fabort_recursive_ed/
++=/f	ada-src/etags-test-for.ada	/^   function "=" (L, R : System.Address) return Boo/
++Fails_t	c-src/h.h	5
++/fakecolorsetup	ps-src/rfc1245.ps	/^\/fakecolorsetup {$/
++FASTCFLAGS	make-src/Makefile	/^FASTCFLAGS=-O3 -finline-functions -ffast-math -fun/
++FASTCFLAGSWARN	make-src/Makefile	/^FASTCFLAGSWARN=${WARNINGS} -Werror ${FASTCFLAGS}$/
++fastctags	make-src/Makefile	/^fastctags:$/
++fastetags	make-src/Makefile	/^fastetags:$/
++fastmap_accurate	c-src/emacs/src/regex.h	383
++fastmap	c-src/emacs/src/regex.h	355
++fast_string_match_ignore_case	c-src/emacs/src/lisp.h	/^fast_string_match_ignore_case (Lisp_Object regexp,/
++fatala	c.c	/^void fatala () __attribute__ ((noreturn));$/
++fatal	c-src/etags.c	/^fatal (const char *s1, const char *s2)$/
++f	c.c	145
++f	c.c	156
++f	c.c	168
++f	c.c	/^int f$/
++Fclear_abbrev_table	c-src/abbrev.c	/^DEFUN ("clear-abbrev-table", Fclear_abbrev_table, /
++Fclear_this_command_keys	c-src/emacs/src/keyboard.c	/^DEFUN ("clear-this-command-keys", Fclear_this_comm/
++Fcommand_error_default_function	c-src/emacs/src/keyboard.c	/^DEFUN ("command-error-default-function", Fcommand_/
++fconst	forth-src/test-forth.fth	/^3.1415e fconstant fconst$/
++f	cp-src/c.C	/^A<float,B<int> > A<B<float>,int>::f(A<int>* x) {}$/
++f	cp-src/c.C	/^A<int>* f() {}$/
++f	cp-src/c.C	/^class B<int> { void f() {} };$/
++f	cp-src/c.C	/^int A<int>::f(A<int>* x) {}$/
++f	cp-src/c.C	/^int f(A<int> x) {}$/
++f	cp-src/c.C	/^  int f(){return 0;};		\/\/ first comment$/
++f	cp-src/c.C	/^     void f() {}$/
++f	cp-src/fail.C	/^int A::B::f() { return 2; }$/
++f	cp-src/fail.C	/^		int f() { return 5; }$/
++f	c-src/c.c	/^T f(){if(x){}$/
++f	c-src/h.h	89
++Fcurrent_idle_time	c-src/emacs/src/keyboard.c	/^DEFUN ("current-idle-time", Fcurrent_idle_time, Sc/
++Fcurrent_input_mode	c-src/emacs/src/keyboard.c	/^DEFUN ("current-input-mode", Fcurrent_input_mode, /
++Fdefine_abbrev	c-src/abbrev.c	/^DEFUN ("define-abbrev", Fdefine_abbrev, Sdefine_ab/
++Fdefine_abbrev_table	c-src/abbrev.c	/^DEFUN ("define-abbrev-table", Fdefine_abbrev_table/
++Fdefine_global_abbrev	c-src/abbrev.c	/^DEFUN ("define-global-abbrev", Fdefine_global_abbr/
++Fdefine_mode_abbrev	c-src/abbrev.c	/^DEFUN ("define-mode-abbrev", Fdefine_mode_abbrev, /
++fdefunkey	c-src/etags.c	2409
++fdefunname	c-src/etags.c	2410
++fdesc	c-src/etags.c	201
++fdesc	c-src/etags.c	212
++fdHandler	objc-src/Subprocess.m	/^- fdHandler:(int)theFd$/
++fdHandler	objc-src/Subprocess.m	/^fdHandler (int theFd, id self)$/
++Fdiscard_input	c-src/emacs/src/keyboard.c	/^DEFUN ("discard-input", Fdiscard_input, Sdiscard_i/
++fdp	c-src/etags.c	217
++Fevent_convert_list	c-src/emacs/src/keyboard.c	/^DEFUN ("event-convert-list", Fevent_convert_list, /
++Fevent_symbol_parse_modifiers	c-src/emacs/src/keyboard.c	/^DEFUN ("internal-event-symbol-parse-modifiers", Fe/
++Fexit_recursive_edit	c-src/emacs/src/keyboard.c	/^DEFUN ("exit-recursive-edit", Fexit_recursive_edit/
++Fexpand_abbrev	c-src/abbrev.c	/^DEFUN ("expand-abbrev", Fexpand_abbrev, Sexpand_ab/
++ff	cp-src/c.C	/^  int ff(){return 1;};$/
++F_getit	c-src/etags.c	/^F_getit (FILE *inf)$/
++>field1	forth-src/test-forth.fth	/^   9   field   >field1$/
++>field2	forth-src/test-forth.fth	/^   5   field   >field2$/
++field_of_play	cp-src/conway.cpp	18
++fignore	c-src/etags.c	2416
++file_end	perl-src/htlmify-cystic	/^sub file_end ()$/
++file_index	perl-src/htlmify-cystic	33
++fileJoin	php-src/lce_functions.php	/^  function fileJoin()$/
++filename_is_absolute	c-src/etags.c	/^filename_is_absolute (char *fn)$/
++filenames	c-src/etags.c	196
++file-of-tag	el-src/emacs/lisp/progmodes/etags.el	/^(defun file-of-tag (&optional relative)$/
++file-of-tag-function	el-src/emacs/lisp/progmodes/etags.el	/^(defvar file-of-tag-function nil$/
++\file	tex-src/texinfo.tex	/^\\def\\file##1{\\realbackslash file {##1}}%$/
++\file	tex-src/texinfo.tex	/^\\def\\file##1{\\realbackslash file {##1}}$/
++file_tocs	perl-src/htlmify-cystic	30
++/fillprocs	ps-src/rfc1245.ps	/^\/fillprocs 32 array def$/
++FILTER	make-src/Makefile	/^FILTER=grep -v '\\.[Cchefy][lor]*,[1-9][0-9]*' || t/
++FINAL_FREE_BLOCKS	c-src/emacs/src/gmalloc.c	135
++Finalize_Cond/p	ada-src/2ataspri.adb	/^   procedure Finalize_Cond (Cond : in out Conditio/
++Finalize_Cond/p	ada-src/2ataspri.ads	/^   procedure Finalize_Cond (Cond : in out Conditio/
++Finalize_Lock/p	ada-src/2ataspri.adb	/^   procedure Finalize_Lock (L : in out Lock) is$/
++Finalize_Lock/p	ada-src/2ataspri.ads	/^   procedure Finalize_Lock (L : in out Lock);$/
++FINALIZERP	c-src/emacs/src/lisp.h	/^FINALIZERP (Lisp_Object x)$/
++Finalize_TAS_Cell/p	ada-src/2ataspri.adb	/^   procedure Finalize_TAS_Cell (Cell : in out TAS_/
++Finalize_TAS_Cell/p	ada-src/2ataspri.ads	/^   procedure Finalize_TAS_Cell   (Cell : in out TA/
++\finalout	tex-src/texinfo.tex	/^\\def\\finalout{\\overfullrule=0pt}$/
++findcats	prol-src/natded.prolog	/^findcats([],Left,Left).$/
++find_entries	c-src/etags.c	/^find_entries (FILE *inf)$/
++\findex	tex-src/texinfo.tex	/^\\def\\findex {\\fnindex}$/
++find-tag-default-function	el-src/emacs/lisp/progmodes/etags.el	/^(defcustom find-tag-default-function nil$/
++find-tag	el-src/emacs/lisp/progmodes/etags.el	/^(defun find-tag (tagname &optional next-p regexp-p/
++find-tag-history	el-src/emacs/lisp/progmodes/etags.el	/^(defvar find-tag-history nil) ; Doc string?$/
++find-tag-hook	el-src/emacs/lisp/progmodes/etags.el	/^(defcustom find-tag-hook nil$/
++find-tag-in-order	el-src/emacs/lisp/progmodes/etags.el	/^(defun find-tag-in-order (pattern$/
++find-tag-interactive	el-src/emacs/lisp/progmodes/etags.el	/^(defun find-tag-interactive (prompt &optional no-d/
++find-tag-marker-ring	el-src/emacs/lisp/progmodes/etags.el	/^(defvaralias 'find-tag-marker-ring 'xref--marker-r/
++find-tag-marker-ring-length	el-src/emacs/lisp/progmodes/etags.el	/^(define-obsolete-variable-alias 'find-tag-marker-r/
++find-tag-next-line-after-failure-p	el-src/emacs/lisp/progmodes/etags.el	/^(defvar find-tag-next-line-after-failure-p nil$/
++find-tag-noselect	el-src/emacs/lisp/progmodes/etags.el	/^(defun find-tag-noselect (tagname &optional next-p/
++find-tag-other-frame	el-src/emacs/lisp/progmodes/etags.el	/^(defun find-tag-other-frame (tagname &optional nex/
++find-tag-other-window	el-src/emacs/lisp/progmodes/etags.el	/^(defun find-tag-other-window (tagname &optional ne/
++find-tag-regexp	el-src/emacs/lisp/progmodes/etags.el	/^(defun find-tag-regexp (regexp &optional next-p ot/
++find-tag-regexp-next-line-after-failure-p	el-src/emacs/lisp/progmodes/etags.el	/^(defvar find-tag-regexp-next-line-after-failure-p /
++find-tag-regexp-search-function	el-src/emacs/lisp/progmodes/etags.el	/^(defvar find-tag-regexp-search-function nil$/
++find-tag-regexp-tag-order	el-src/emacs/lisp/progmodes/etags.el	/^(defvar find-tag-regexp-tag-order nil$/
++find-tag-search-function	el-src/emacs/lisp/progmodes/etags.el	/^(defvar find-tag-search-function nil$/
++find-tag-tag	el-src/emacs/lisp/progmodes/etags.el	/^(defun find-tag-tag (string)$/
++find-tag-tag-order	el-src/emacs/lisp/progmodes/etags.el	/^(defvar find-tag-tag-order nil$/
++find_user_signal_name	c-src/emacs/src/keyboard.c	/^find_user_signal_name (int sig)$/
++finish_appendices	perl-src/htlmify-cystic	/^sub finish_appendices ()$/
++finish_sections	perl-src/htlmify-cystic	/^sub finish_sections ()$/
++finish_subsections	perl-src/htlmify-cystic	/^sub finish_subsections ()$/
++finish_subsubsections	perl-src/htlmify-cystic	/^sub finish_subsubsections ()$/
++\finishtitlepage	tex-src/texinfo.tex	/^\\def\\finishtitlepage{%$/
++finlist	c-src/etags.c	2414
++Finput_pending_p	c-src/emacs/src/keyboard.c	/^DEFUN ("input-pending-p", Finput_pending_p, Sinput/
++Finsert_abbrev_table_description	c-src/abbrev.c	/^DEFUN ("insert-abbrev-table-description", Finsert_/
++First100Chars	pas-src/common.pas	/^procedure First100Chars; (*($/
++first	c-src/emacs/src/gmalloc.c	151
++fitchtreelist	prol-src/natded.prolog	/^fitchtreelist([]).$/
++FIXNUM_BITS	c-src/emacs/src/lisp.h	252
++FIXNUM_OVERFLOW_P	c-src/emacs/src/lisp.h	/^#define FIXNUM_OVERFLOW_P(i) \\$/
++FIXNUM_OVERFLOW_P	c-src/emacs/src/lisp.h	/^LISP_MACRO_DEFUN (EQ, bool, (Lisp_Object x, Lisp_O/
++fixup_locale	c-src/emacs/src/lisp.h	/^INLINE void fixup_locale (void) {}$/
++flag2str	pyt-src/server.py	/^def flag2str(value, string):$/
++flag	c-src/getopt.h	83
++flistseen	c-src/etags.c	2415
++FLOATP	c-src/emacs/src/lisp.h	/^# define FLOATP(x) lisp_h_FLOATP (x)$/
++FLOAT_TO_STRING_BUFSIZE	c-src/emacs/src/lisp.h	3927
++/fl	ps-src/rfc1245.ps	/^\/fl { $/
++\flushcr	tex-src/texinfo.tex	/^\\def\\flushcr{\\ifx\\par\\lisppar \\def\\next##1{}\\else /
++\flushleft	tex-src/texinfo.tex	/^\\def\\flushleft{%$/
++\flushright	tex-src/texinfo.tex	/^\\def\\flushright{%$/
++Fmake_abbrev_table	c-src/abbrev.c	/^DEFUN ("make-abbrev-table", Fmake_abbrev_table, Sm/
++/FMBEGINEPSF	ps-src/rfc1245.ps	/^\/FMBEGINEPSF { $/
++/FMBEGINPAGE	ps-src/rfc1245.ps	/^\/FMBEGINPAGE { $/
++/Fmcc	ps-src/rfc1245.ps	/^\/Fmcc {$/
++/FMDEFINEFONT	ps-src/rfc1245.ps	/^\/FMDEFINEFONT { $/
++/FMDOCUMENT	ps-src/rfc1245.ps	/^\/FMDOCUMENT { $/
++/FMENDEPSF	ps-src/rfc1245.ps	/^\/FMENDEPSF {$/
++/FMENDPAGE	ps-src/rfc1245.ps	/^\/FMENDPAGE {$/
++/FMLOCAL	ps-src/rfc1245.ps	/^\/FMLOCAL {$/
++/FMNORMALIZEGRAPHICS	ps-src/rfc1245.ps	/^\/FMNORMALIZEGRAPHICS { $/
++/FMVERSION	ps-src/rfc1245.ps	/^\/FMVERSION {$/
++/FMversion	ps-src/rfc1245.ps	/^\/FMversion (2.0) def $/
++fn	c-src/exit.c	/^    void EXFUN((*fn[1]), (NOARGS));$/
++fn	c-src/exit.strange_suffix	/^    void EXFUN((*fn[1]), (NOARGS));$/
++fnin	y-src/parse.y	68
++\fnitemindex	tex-src/texinfo.tex	/^\\def\\fnitemindex #1{\\doind {fn}{\\code{#1}}}%$/
++focus_set	pyt-src/server.py	/^    def focus_set(self):$/
++follow_key	c-src/emacs/src/keyboard.c	/^follow_key (Lisp_Object keymap, Lisp_Object key)$/
++fonts\rm	tex-src/texinfo.tex	/^  \\indexfonts\\rm \\tolerance=9500 \\advance\\baseline/
++fonts	tex-src/texinfo.tex	/^\\obeyspaces \\obeylines \\ninett \\indexfonts \\rawbac/
++foo1	ruby-src/test1.ru	/^    attr_reader(:foo1, :bar1, # comment$/
++foo2	ruby-src/test1.ru	/^    alias_method ( :foo2, #cmmt$/
++foobar2_	c-src/h.h	16
++foobar2	c-src/h.h	20
++foobar	c.c	/^extern void foobar (void) __attribute__ ((section /
++foobar	c-src/c.c	/^int foobar() {;}$/
++foo==bar	el-src/TAGTEST.EL	/^(defun foo==bar () (message "hi"))  ; Bug#5624$/
++Foo::Bar	perl-src/kai-test.pl	/^package Foo::Bar;$/
++foo	c.c	150
++foo	c.c	166
++foo	c.c	167
++foo	c.c	178
++foo	c.c	189
++foo	cp-src/c.C	68
++foo	cp-src/c.C	79
++foo	cp-src/c.C	/^    foo() {$/
++foo	cp-src/x.cc	/^XX::foo()$/
++foo	c-src/h.h	18
++(foo)	forth-src/test-forth.fth	/^: (foo) 1 ;$/
++foo	forth-src/test-forth.fth	/^: foo (foo) ;$/
++foo	f-src/entry.for	/^       character*(*) function foo()$/
++foo	f-src/entry.strange	/^       character*(*) function foo()$/
++foo	f-src/entry.strange_suffix	/^       character*(*) function foo()$/
++Foo	perl-src/kai-test.pl	/^package Foo;$/
++foo	php-src/ptest.php	/^foo()$/
++foo	ruby-src/test1.ru	/^    attr_reader :foo$/
++foo!	ruby-src/test1.ru	/^    def foo!$/
++Fopen_dribble_file	c-src/emacs/src/keyboard.c	/^DEFUN ("open-dribble-file", Fopen_dribble_file, So/
++foperator	c-src/etags.c	2411
++force_auto_save_soon	c-src/emacs/src/keyboard.c	/^force_auto_save_soon (void)$/
++force_explicit_name	c-src/etags.c	265
++force_quit_count	c-src/emacs/src/keyboard.c	10387
++FOR_EACH_ALIST_VALUE	c-src/emacs/src/lisp.h	/^#define FOR_EACH_ALIST_VALUE(head_var, list_var, v/
++FOR_EACH_TAIL	c-src/emacs/src/lisp.h	/^#define FOR_EACH_TAIL(hare, list, tortoise, n)	\\$/
++foreign_export	merc-src/accumulator.m	/^:- pragma foreign_export("C", unravel_univ(in, out/
++formatSize	objc-src/PackInsp.m	/^-(const char *)formatSize:(const char *)size inBuf/
++\format	tex-src/texinfo.tex	/^\\def\\format{\\begingroup\\inENV %This group ends at /
++Forth_help	c-src/etags.c	573
++FORTHSRC	make-src/Makefile	/^FORTHSRC=test-forth.fth$/
++Forth_suffixes	c-src/etags.c	571
++Forth_words	c-src/etags.c	/^Forth_words (FILE *inf)$/
++Fortran_functions	c-src/etags.c	/^Fortran_functions (FILE *inf)$/
++Fortran_help	c-src/etags.c	579
++Fortran_suffixes	c-src/etags.c	577
++found	c-src/emacs/src/lisp.h	2344
++Fposn_at_point	c-src/emacs/src/keyboard.c	/^DEFUN ("posn-at-point", Fposn_at_point, Sposn_at_p/
++Fposn_at_x_y	c-src/emacs/src/keyboard.c	/^DEFUN ("posn-at-x-y", Fposn_at_x_y, Sposn_at_x_y, /
++/F	ps-src/rfc1245.ps	/^\/F { $/
++fracas	html-src/software.html	/^Fracas$/
++/fraction	ps-src/rfc1245.ps	/^\/fraction \/currency \/guilsinglleft \/guilsinglright/
++frag	c-src/emacs/src/gmalloc.c	152
++_fraghead	c-src/emacs/src/gmalloc.c	370
++/FrameDict	ps-src/rfc1245.ps	/^\/FrameDict 190 dict def $/
++frame_local	c-src/emacs/src/lisp.h	2341
++FRAMEP	c-src/emacs/src/lisp.h	/^FRAMEP (Lisp_Object a)$/
++FRC	make-src/Makefile	/^FRC:;$/
++Fread_key_sequence	c-src/emacs/src/keyboard.c	/^DEFUN ("read-key-sequence", Fread_key_sequence, Sr/
++Fread_key_sequence_vector	c-src/emacs/src/keyboard.c	/^DEFUN ("read-key-sequence-vector", Fread_key_seque/
++Frecent_keys	c-src/emacs/src/keyboard.c	/^DEFUN ("recent-keys", Frecent_keys, Srecent_keys, /
++Frecursion_depth	c-src/emacs/src/keyboard.c	/^DEFUN ("recursion-depth", Frecursion_depth, Srecur/
++Frecursive_edit	c-src/emacs/src/keyboard.c	/^DEFUN ("recursive-edit", Frecursive_edit, Srecursi/
++free	c-src/emacs/src/gmalloc.c	166
++free	c-src/emacs/src/gmalloc.c	1719
++free	c-src/emacs/src/gmalloc.c	67
++free	c-src/emacs/src/gmalloc.c	72
++_free	c-src/emacs/src/gmalloc.c	/^_free (void *ptr)$/
++free	c-src/emacs/src/gmalloc.c	/^free (void *ptr)$/
++free_fdesc	c-src/etags.c	/^free_fdesc (register fdesc *fdp)$/
++FREEFLOOD	c-src/emacs/src/gmalloc.c	1858
++free_for	prol-src/natded.prolog	/^free_for(var(_),_,_).$/
++freehook	c-src/emacs/src/gmalloc.c	/^freehook (void *ptr)$/
++_free_internal	c-src/emacs/src/gmalloc.c	/^_free_internal (void *ptr)$/
++_free_internal_nolock	c-src/emacs/src/gmalloc.c	/^_free_internal_nolock (void *ptr)$/
++free_regexps	c-src/etags.c	/^free_regexps (void)$/
++free_tree	c-src/etags.c	/^free_tree (register node *np)$/
++free_var	prol-src/natded.prolog	/^free_var(var(V),var(V)).$/
++\frenchspacing	tex-src/texinfo.tex	/^\\def\\frenchspacing{\\sfcode46=1000 \\sfcode63=1000 \\/
++/freq	ps-src/rfc1245.ps	/^\/freq dpi 18.75 div 8 div round dup 0 eq {pop 1} i/
++Freset_this_command_lengths	c-src/emacs/src/keyboard.c	/^DEFUN ("reset-this-command-lengths", Freset_this_c/
++fresh_vars	prol-src/natded.prolog	/^fresh_vars(var(V),var(V)).$/
++Fset_input_interrupt_mode	c-src/emacs/src/keyboard.c	/^DEFUN ("set-input-interrupt-mode", Fset_input_inte/
++Fset_input_meta_mode	c-src/emacs/src/keyboard.c	/^DEFUN ("set-input-meta-mode", Fset_input_meta_mode/
++Fset_input_mode	c-src/emacs/src/keyboard.c	/^DEFUN ("set-input-mode", Fset_input_mode, Sset_inp/
++Fset_output_flow_control	c-src/emacs/src/keyboard.c	/^DEFUN ("set-output-flow-control", Fset_output_flow/
++Fset_quit_char	c-src/emacs/src/keyboard.c	/^DEFUN ("set-quit-char", Fset_quit_char, Sset_quit_/
++FSRC	make-src/Makefile	/^FSRC=entry.for entry.strange_suffix entry.strange$/
++fstartlist	c-src/etags.c	2413
++Fsuspend_emacs	c-src/emacs/src/keyboard.c	/^DEFUN ("suspend-emacs", Fsuspend_emacs, Ssuspend_e/
++\ftable	tex-src/texinfo.tex	/^\\def\\ftable{\\begingroup\\inENV\\obeylines\\obeyspaces/
++F_takeprec	c-src/etags.c	/^F_takeprec (void)$/
++Fthis_command_keys	c-src/emacs/src/keyboard.c	/^DEFUN ("this-command-keys", Fthis_command_keys, St/
++Fthis_command_keys_vector	c-src/emacs/src/keyboard.c	/^DEFUN ("this-command-keys-vector", Fthis_command_k/
++Fthis_single_command_keys	c-src/emacs/src/keyboard.c	/^DEFUN ("this-single-command-keys", Fthis_single_co/
++Fthis_single_command_raw_keys	c-src/emacs/src/keyboard.c	/^DEFUN ("this-single-command-raw-keys", Fthis_singl/
++Ftop_level	c-src/emacs/src/keyboard.c	/^DEFUN ("top-level", Ftop_level, Stop_level, 0, 0, /
++Ftrack_mouse	c-src/emacs/src/keyboard.c	/^DEFUN ("internal--track-mouse", Ftrack_mouse, Stra/
++FUN0	y-src/parse.y	/^yylex FUN0()$/
++FUN1	y-src/parse.y	/^str_to_col FUN1(char **,str)$/
++FUN1	y-src/parse.y	/^yyerror FUN1(char *, s)$/
++FUN2	y-src/parse.y	/^make_list FUN2(YYSTYPE, car, YYSTYPE, cdr)$/
++FUN2	y-src/parse.y	/^parse_cell_or_range FUN2(char **,ptr, struct rng */
++func1	c.c	/^int func1$/
++func2	c.c	/^int func2 (a,b$/
++funcboo	c.c	/^bool funcboo ()$/
++func	c-src/emacs/src/lisp.h	/^      void (*func) (int);$/
++func	c-src/emacs/src/lisp.h	/^      void (*func) (Lisp_Object);$/
++func	c-src/emacs/src/lisp.h	/^      void (*func) (void *);$/
++func	c-src/emacs/src/lisp.h	/^      void (*func) (void);$/
++func_key_syms	c-src/emacs/src/keyboard.c	4626
++funcpointer	c-src/emacs/src/lisp.h	2126
++funcptr	c-src/h.h	/^    fu   int (*funcptr) (void *ptr);$/
++function	c-src/emacs/src/lisp.h	1685
++function	c-src/emacs/src/lisp.h	2197
++function	c-src/emacs/src/lisp.h	2985
++function	c-src/emacs/src/lisp.h	694
++function	c-src/etags.c	194
++FUNCTION_KEY_OFFSET	c-src/emacs/src/keyboard.c	4766
++FUNCTION_KEY_OFFSET	c-src/emacs/src/keyboard.c	5061
++FUNCTIONP	c-src/emacs/src/lisp.h	/^FUNCTIONP (Lisp_Object obj)$/
++functionp	c-src/emacs/src/lisp.h	/^functionp (Lisp_Object object)$/
++Funexpand_abbrev	c-src/abbrev.c	/^DEFUN ("unexpand-abbrev", Funexpand_abbrev, Sunexp/
++fval	forth-src/test-forth.fth	/^fconst fvalue fval$/
++fvar	forth-src/test-forth.fth	/^fvariable fvar$/
++fvdef	c-src/etags.c	2418
++fvextern	c-src/etags.c	2420
++fvnameseen	c-src/etags.c	2412
++fvnone	c-src/etags.c	2408
++fwd	c-src/emacs/src/lisp.h	2346
++fwd	c-src/emacs/src/lisp.h	690
++Fx_get_selection_internal	c.c	/^DEFUN ("x-get-selection-internal", Fx_get_selectio/
++Fx_get_selection_internal	c.c	/^       Fx_get_selection_internal, Sx_get_selection/
++Fy_get_selection_internal	c.c	/^      Fy_get_selection_internal, Sy_get_selection_/
++galileo	html-src/software.html	/^GaliLEO$/
++GatherControls	pyt-src/server.py	/^    def GatherControls(self):$/
++gather	pyt-src/server.py	/^    def gather(self):$/
++GCALIGNED	c-src/emacs/src/lisp.h	288
++GCALIGNED	c-src/emacs/src/lisp.h	290
++GCALIGNMENT	c-src/emacs/src/lisp.h	243
++gc_aset	c-src/emacs/src/lisp.h	/^gc_aset (Lisp_Object array, ptrdiff_t idx, Lisp_Ob/
++GC_MAKE_GCPROS_NOOPS	c-src/emacs/src/lisp.h	3172
++gcmarkbit	c-src/emacs/src/lisp.h	1974
++gcmarkbit	c-src/emacs/src/lisp.h	1981
++gcmarkbit	c-src/emacs/src/lisp.h	2035
++gcmarkbit	c-src/emacs/src/lisp.h	2113
++gcmarkbit	c-src/emacs/src/lisp.h	2204
++gcmarkbit	c-src/emacs/src/lisp.h	656
++GC_MARK_STACK_CHECK_GCPROS	c-src/emacs/src/lisp.h	3173
++GC_MARK_STACK	c-src/emacs/src/lisp.h	3177
++GCPRO1	c-src/emacs/src/lisp.h	/^#define GCPRO1(a)							\\$/
++GCPRO1	c-src/emacs/src/lisp.h	/^#define GCPRO1(varname) ((void) gcpro1)$/
++GCPRO2	c-src/emacs/src/lisp.h	/^#define GCPRO2(a, b)							\\$/
++GCPRO2	c-src/emacs/src/lisp.h	/^#define GCPRO2(varname1, varname2) ((void) gcpro2,/
++GCPRO3	c-src/emacs/src/lisp.h	/^#define GCPRO3(a, b, c)							\\$/
++GCPRO3	c-src/emacs/src/lisp.h	/^#define GCPRO3(varname1, varname2, varname3) \\$/
++GCPRO4	c-src/emacs/src/lisp.h	/^#define GCPRO4(a, b, c, d)						\\$/
++GCPRO4	c-src/emacs/src/lisp.h	/^#define GCPRO4(varname1, varname2, varname3, varna/
++GCPRO5	c-src/emacs/src/lisp.h	/^#define GCPRO5(a, b, c, d, e)						\\$/
++GCPRO5	c-src/emacs/src/lisp.h	/^#define GCPRO5(varname1, varname2, varname3, varna/
++GCPRO6	c-src/emacs/src/lisp.h	/^#define GCPRO6(a, b, c, d, e, f)					\\$/
++GCPRO6	c-src/emacs/src/lisp.h	/^#define GCPRO6(varname1, varname2, varname3, varna/
++GCPRO7	c-src/emacs/src/lisp.h	/^#define GCPRO7(a, b, c, d, e, f, g)					\\$/
++GCPRO7	c-src/emacs/src/lisp.h	/^#define GCPRO7(a, b, c, d, e, f, g) (GCPRO6 (a, b,/
++gcpro	c-src/emacs/src/lisp.h	3042
++gcpro	c-src/emacs/src/lisp.h	3132
++g	cp-src/c.C	/^  int g(){return 2;};$/
++GCTYPEBITS	c-src/emacs/src/lisp.h	67
++GCTYPEBITS	c-src/emacs/src/lisp.h	/^DEFINE_GDB_SYMBOL_BEGIN (int, GCTYPEBITS)$/
++GC_USE_GCPROS_AS_BEFORE	c-src/emacs/src/lisp.h	3171
++GC_USE_GCPROS_CHECK_ZOMBIES	c-src/emacs/src/lisp.h	3174
++genalgorithm	html-src/algrthms.html	/^Generating the Data<\/font><\/i><\/b>$/
++generate_warning	merc-src/accumulator.m	/^:- pred generate_warning(module_info::in, prog_var/
++generate_warnings	merc-src/accumulator.m	/^:- pred generate_warnings(module_info::in, prog_va/
++~generic_object	cp-src/clheir.cpp	/^generic_object::~generic_object(void)$/
++generic_object	cp-src/clheir.cpp	/^generic_object::generic_object(void)$/
++generic_object	cp-src/clheir.hpp	13
++GENERIC_PTR	y-src/cccp.y	56
++GENERIC_PTR	y-src/cccp.y	58
++gen_help_event	c-src/emacs/src/keyboard.c	/^gen_help_event (Lisp_Object help, Lisp_Object fram/
++GEQ	y-src/cccp.c	15
++getArchs	objc-src/PackInsp.m	/^-(void)getArchs$/
++getcjmp	c-src/emacs/src/keyboard.c	147
++get_compressor_from_suffix	c-src/etags.c	/^get_compressor_from_suffix (char *file, char **ext/
++get_contiguous_space	c-src/emacs/src/gmalloc.c	/^get_contiguous_space (ptrdiff_t size, void *positi/
++get_current_dir_name	c-src/emacs/src/gmalloc.c	33
++getDomainNames	php-src/lce_functions.php	/^      function getDomainNames()$/
++getFoo	lua-src/test.lua	/^function Cube.data.getFoo ()$/
++get_input_pending	c-src/emacs/src/keyboard.c	/^get_input_pending (int flags)$/
++get_language_from_filename	c-src/etags.c	/^get_language_from_filename (char *file, int case_s/
++get_language_from_interpreter	c-src/etags.c	/^get_language_from_interpreter (char *interpreter)$/
++get_language_from_langname	c-src/etags.c	/^get_language_from_langname (const char *name)$/
++GetLayerByName	lua-src/allegro.lua	/^function GetLayerByName (name)$/
++get_layer_by_name	lua-src/allegro.lua	/^local function get_layer_by_name (sprite, layer, n/
++GetNameList	pas-src/common.pas	/^function GetNameList; (* : BinNodePointer;*)$/
++GetNewNameListNode	pas-src/common.pas	/^function GetNewNameListNode;(*($/
++getopt1.o	make-src/Makefile	/^getopt1.o: emacs\/lib-src\/getopt1.c$/
++_GETOPT_H	c-src/getopt.h	19
++GETOPTOBJS	make-src/Makefile	/^GETOPTOBJS= #getopt.o getopt1.o$/
++getopt.o	make-src/Makefile	/^getopt.o: emacs\/lib-src\/getopt.c$/
++getopt	perl-src/yagrip.pl	/^sub getopt {$/
++Get_Own_Priority/f	ada-src/2ataspri.adb	/^   function Get_Own_Priority return System.Any_Pri/
++Get_Own_Priority/f	ada-src/2ataspri.ads	/^   function Get_Own_Priority return System.Any_Pri/
++getPath	objc-src/PackInsp.m	/^-(const char *)getPath:(char *)buf forType:(const /
++getPOReader	php-src/lce_functions.php	/^      function &getPOReader($domain)$/
++getPos	lua-src/test.lua	/^function Circle.getPos ()$/
++getPos	lua-src/test.lua	/^function Rectangle.getPos ()$/
++Get_Priority/f	ada-src/2ataspri.adb	/^   function Get_Priority (T : TCB_Ptr) return Syst/
++Get_Priority/f	ada-src/2ataspri.ads	/^   function Get_Priority (T : TCB_Ptr) return Syst/
++getptys	objc-src/Subprocess.m	/^getptys (int *master, int *slave)$/
++get_tag	c-src/etags.c	/^get_tag (register char *bp, char **namepp)$/
++getTextDomains	php-src/lce_functions.php	/^  function getTextDomains($lines)$/
++gettext	php-src/lce_functions.php	/^      function gettext($msgid)$/
++GetTextRef	pas-src/common.pas	/^function GetTextRef;(*($/
++GetUniqueLayerName	lua-src/allegro.lua	/^function GetUniqueLayerName ()$/
++get_word	c-src/tab.c	/^static char		*get_word(char **str, char delim)$/
++GE	y-src/parse.c	8
++ggg	c-src/h.h	10
++ghi1	c-src/h.h	36
++ghi2	c-src/h.h	39
++giallo	cp-src/c.C	40
++glider	cp-src/conway.cpp	/^void glider(int x, int y)$/
++\gloggingall	tex-src/texinfo.tex	/^\\def\\gloggingall{\\begingroup \\globaldefs = 1 \\logg/
++/gn	ps-src/rfc1245.ps	/^\/gn { $/
++gnu	html-src/software.html	/^Free software that I wrote for the GNU project or /
++_GNU_SOURCE	c-src/etags.c	94
++gobble_input	c-src/emacs/src/keyboard.c	/^gobble_input (void)$/
++goto-tag-location-function	el-src/emacs/lisp/progmodes/etags.el	/^(defvar goto-tag-location-function nil$/
++goto_xy	cp-src/screen.cpp	/^void goto_xy(unsigned char x, unsigned char y)$/
++/G	ps-src/rfc1245.ps	/^\/G { $/
++/graymode	ps-src/rfc1245.ps	/^\/graymode true def$/
++/grayness	ps-src/rfc1245.ps	/^\/grayness {$/
++GREEN	cp-src/screen.hpp	14
++\group	tex-src/texinfo.tex	/^\\def\\group{\\begingroup$/
++GROW_RAW_KEYBUF	c-src/emacs/src/keyboard.c	119
++\gtr	tex-src/texinfo.tex	/^\\def\\gtr{\\realbackslash gtr}%$/
++\gtr	tex-src/texinfo.tex	/^\\def\\gtr{\\realbackslash gtr}$/
++/guillemotleft	ps-src/rfc1245.ps	/^\/guillemotleft \/guillemotright \/ellipsis \/.notdef /
++handle_async_input	c-src/emacs/src/keyboard.c	/^handle_async_input (void)$/
++handle_input_available_signal	c-src/emacs/src/keyboard.c	/^handle_input_available_signal (int sig)$/
++handle_interrupt	c-src/emacs/src/keyboard.c	/^handle_interrupt (bool in_signal_handler)$/
++handle_interrupt_signal	c-src/emacs/src/keyboard.c	/^handle_interrupt_signal (int sig)$/
++handleList	pyt-src/server.py	/^    def handleList(self, event):$/
++handleNew	pyt-src/server.py	/^    def handleNew(self, event):$/
++handler	c-src/emacs/src/lisp.h	3023
++handlertype	c-src/emacs/src/lisp.h	3021
++handle_user_signal	c-src/emacs/src/keyboard.c	/^handle_user_signal (int sig)$/
++has_arg	c-src/getopt.h	82
++hash	c-src/emacs/src/lisp.h	1843
++hash	c-src/etags.c	/^hash (const char *str, int len)$/
++hashfn	c-src/emacs/src/lisp.h	/^  EMACS_UINT (*hashfn) (struct hash_table_test *t,/
++HASH_HASH	c-src/emacs/src/lisp.h	/^HASH_HASH (struct Lisp_Hash_Table *h, ptrdiff_t id/
++HASH_INDEX	c-src/emacs/src/lisp.h	/^HASH_INDEX (struct Lisp_Hash_Table *h, ptrdiff_t i/
++HASH_KEY	c-src/emacs/src/lisp.h	/^HASH_KEY (struct Lisp_Hash_Table *h, ptrdiff_t idx/
++HASH_NEXT	c-src/emacs/src/lisp.h	/^HASH_NEXT (struct Lisp_Hash_Table *h, ptrdiff_t id/
++HASH_TABLE_P	c-src/emacs/src/lisp.h	/^HASH_TABLE_P (Lisp_Object a)$/
++HASH_TABLE_SIZE	c-src/emacs/src/lisp.h	/^HASH_TABLE_SIZE (struct Lisp_Hash_Table *h)$/
++hash_table_test	c-src/emacs/src/lisp.h	1805
++HASH_VALUE	c-src/emacs/src/lisp.h	/^HASH_VALUE (struct Lisp_Hash_Table *h, ptrdiff_t i/
++\hat	tex-src/texinfo.tex	/^\\def\\hat{\\realbackslash hat}%$/
++\hat	tex-src/texinfo.tex	/^\\def\\hat{\\realbackslash hat}$/
++HAVE_NTGUI	c-src/etags.c	116
++hdr	c-src/emacs/src/gmalloc.c	1860
++header	c-src/emacs/src/lisp.h	1371
++header	c-src/emacs/src/lisp.h	1388
++header	c-src/emacs/src/lisp.h	1581
++header	c-src/emacs/src/lisp.h	1610
++header	c-src/emacs/src/lisp.h	1672
++header	c-src/emacs/src/lisp.h	1826
++header_size	c-src/emacs/src/lisp.h	1471
++\HEADINGSafter	tex-src/texinfo.tex	/^\\def\\HEADINGSafter{\\let\\HEADINGShook=\\HEADINGSdoub/
++\HEADINGSdouble	tex-src/texinfo.tex	/^\\def\\HEADINGSdouble{$/
++\HEADINGSdoublex	tex-src/texinfo.tex	/^\\def\\HEADINGSdoublex{%$/
++\HEADINGSoff	tex-src/texinfo.tex	/^\\def\\HEADINGSoff{$/
++\HEADINGSon	tex-src/texinfo.tex	/^\\def\\HEADINGSon{\\HEADINGSdouble}$/
++\HEADINGSon	tex-src/texinfo.tex	/^\\global\\def\\HEADINGSon{\\HEADINGSdouble}}$/
++\HEADINGSon	tex-src/texinfo.tex	/^\\global\\def\\HEADINGSon{\\HEADINGSsingle}}$/
++\HEADINGSsingleafter	tex-src/texinfo.tex	/^\\def\\HEADINGSsingleafter{\\let\\HEADINGShook=\\HEADIN/
++\HEADINGSsingle	tex-src/texinfo.tex	/^\\def\\HEADINGSsingle{$/
++\HEADINGSsinglex	tex-src/texinfo.tex	/^\\def\\HEADINGSsinglex{%$/
++\headings	tex-src/texinfo.tex	/^\\def\\headings #1 {\\csname HEADINGS#1\\endcsname}$/
++\heading	tex-src/texinfo.tex	/^\\def\\heading{\\parsearg\\secheadingi}$/
++head_table	c-src/emacs/src/keyboard.c	11027
++_heapbase	c-src/emacs/src/gmalloc.c	355
++HEAP	c-src/emacs/src/gmalloc.c	131
++_heapindex	c-src/emacs/src/gmalloc.c	364
++_heapinfo	c-src/emacs/src/gmalloc.c	358
++_heaplimit	c-src/emacs/src/gmalloc.c	367
++heapsize	c-src/emacs/src/gmalloc.c	361
++hello	scm-src/test.scm	/^(define hello "Hello, Emacs!")$/
++hello	scm-src/test.scm	/^(set! hello "Hello, world!")$/
++hello-world	scm-src/test.scm	/^(define (hello-world)$/
++help_char_p	c-src/emacs/src/keyboard.c	/^help_char_p (Lisp_Object c)$/
++help	c-src/etags.c	193
++help_form_saved_window_configs	c-src/emacs/src/keyboard.c	2156
++helpPanel	objcpp-src/SimpleCalc.M	/^- helpPanel:sender$/
++helpwin	pyt-src/server.py	/^def helpwin(helpdict):$/
++hide_cursor	cp-src/screen.cpp	/^void hide_cursor(void)$/
++hlds	merc-src/accumulator.m	/^:- import_module hlds.$/
++/home/www/pub/etags.c.gz	make-src/Makefile	/^\/home\/www\/pub\/etags.c.gz: etags.c$/
++/home/www/pub/software/unix/etags.tar.gz	make-src/Makefile	/^\/home\/www\/pub\/software\/unix\/etags.tar.gz: Makefile/
++/H	ps-src/rfc1245.ps	/^\/H { $/
++HTML_help	c-src/etags.c	584
++HTML_labels	c-src/etags.c	/^HTML_labels (FILE *inf)$/
++HTMLSRC	make-src/Makefile	/^HTMLSRC=softwarelibero.html index.shtml algrthms.h/
++HTML_suffixes	c-src/etags.c	582
++htmltreelist	prol-src/natded.prolog	/^htmltreelist([]).$/
++/hx	ps-src/rfc1245.ps	/^\/hx { $/
++hybrid_aligned_alloc	c-src/emacs/src/gmalloc.c	/^hybrid_aligned_alloc (size_t alignment, size_t siz/
++hybrid_calloc	c-src/emacs/src/gmalloc.c	/^hybrid_calloc (size_t nmemb, size_t size)$/
++hybrid_free	c-src/emacs/src/gmalloc.c	/^hybrid_free (void *ptr)$/
++hybrid_get_current_dir_name	c-src/emacs/src/gmalloc.c	/^hybrid_get_current_dir_name (void)$/
++hybrid_malloc	c-src/emacs/src/gmalloc.c	/^hybrid_malloc (size_t size)$/
++hybrid_realloc	c-src/emacs/src/gmalloc.c	/^hybrid_realloc (void *ptr, size_t size)$/
++hypothetical_mem	prol-src/natded.prolog	/^hypothetical_mem(fi(N),Ass,_):-$/
++/iacute	ps-src/rfc1245.ps	/^\/iacute \/igrave \/icircumflex \/idieresis \/ntilde \/o/
++ialpage	tex-src/texinfo.tex	/^  \\availdimen@=\\pageheight \\advance\\availdimen@ by/
++ialpage	tex-src/texinfo.tex	/^     \\dimen@=\\pageheight \\advance\\dimen@ by-\\ht\\pa/
++ialpage	tex-src/texinfo.tex	/^  \\dimen@=\\pageheight \\advance\\dimen@ by-\\ht\\parti/
++ialpage	tex-src/texinfo.tex	/^\\newbox\\partialpage$/
++ialpage=	tex-src/texinfo.tex	/^  \\output={\\global\\setbox\\partialpage=$/
++i	c.c	169
++/Icircumflex	ps-src/rfc1245.ps	/^\/Icircumflex \/Idieresis \/Igrave \/Oacute \/Ocircumfl/
++i	cp-src/c.C	132
++/ic	ps-src/rfc1245.ps	/^\/ic [ $/
++i	c-src/c.c	2
++i	c-src/emacs/src/lisp.h	4673
++i	c-src/emacs/src/lisp.h	4679
++i	c-src/emacs/src/lisp.h	567
++identify_goal_type	merc-src/accumulator.m	/^:- pred identify_goal_type(pred_id::in, proc_id::i/
++identify_out_and_out_prime	merc-src/accumulator.m	/^:- pred identify_out_and_out_prime(module_info::in/
++identify_recursive_calls	merc-src/accumulator.m	/^:- pred identify_recursive_calls(pred_id::in, proc/
++idx	c-src/emacs/src/lisp.h	3150
++IEEE_FLOATING_POINT	c-src/emacs/src/lisp.h	2415
++\ifclearfail	tex-src/texinfo.tex	/^\\def\\ifclearfail{\\begingroup\\ignoresections\\ifclea/
++\ifclearfailxxx	tex-src/texinfo.tex	/^\\long\\def\\ifclearfailxxx #1\\end ifclear{\\endgroup\\/
++\ifclear	tex-src/texinfo.tex	/^\\def\\ifclear{\\begingroup\\ignoresections\\parsearg\\i/
++\ifclearxxx	tex-src/texinfo.tex	/^\\def\\ifclearxxx #1{\\endgroup$/
++\ifinfo	tex-src/texinfo.tex	/^\\def\\ifinfo{\\begingroup\\ignoresections\\ifinfoxxx}$/
++\ifinfoxxx	tex-src/texinfo.tex	/^\\long\\def\\ifinfoxxx #1\\end ifinfo{\\endgroup\\ignore/
++\ifsetfail	tex-src/texinfo.tex	/^\\def\\ifsetfail{\\begingroup\\ignoresections\\ifsetfai/
++\ifsetfailxxx	tex-src/texinfo.tex	/^\\long\\def\\ifsetfailxxx #1\\end ifset{\\endgroup\\igno/
++\ifset	tex-src/texinfo.tex	/^\\def\\ifset{\\begingroup\\ignoresections\\parsearg\\ifs/
++\ifsetxxx	tex-src/texinfo.tex	/^\\def\\ifsetxxx #1{\\endgroup$/
++\iftex	tex-src/texinfo.tex	/^\\def\\iftex{}$/
++\ifusingtt	tex-src/texinfo.tex	/^\\def\\ifusingtt#1#2{\\ifdim \\fontdimen3\\the\\font=0pt/
++ignore_case	c-src/etags.c	266
++ignore_mouse_drag_p	c-src/emacs/src/keyboard.c	1256
++\ignoresections	tex-src/texinfo.tex	/^\\def\\ignoresections{%$/
++\ignore	tex-src/texinfo.tex	/^\\def\\ignore{\\begingroup\\ignoresections$/
++\ignorexxx	tex-src/texinfo.tex	/^\\long\\def\\ignorexxx #1\\end ignore{\\endgroup\\ignore/
++\ii	tex-src/texinfo.tex	/^\\def\\ii#1{{\\it #1}}		% italic font$/
++ill=\relax	tex-src/texinfo.tex	/^\\let\\refill=\\relax$/
++IMAGEP	c-src/emacs/src/lisp.h	/^IMAGEP (Lisp_Object x)$/
++immediate_quit	c-src/emacs/src/keyboard.c	174
++impatto	html-src/softwarelibero.html	/^Impatto pratico del software libero$/
++implementation	merc-src/accumulator.m	/^:- implementation.$/
++inattribute	c-src/etags.c	2400
++inc	cp-src/Range.h	/^  double inc (void) const { return rng_inc;   }$/
++/inch	ps-src/rfc1245.ps	/^\/inch {72 mul} def$/
++\include	tex-src/texinfo.tex	/^\\def\\include{\\parsearg\\includezzz}$/
++\includezzz	tex-src/texinfo.tex	/^\\def\\includezzz #1{{\\def\\thisfile{#1}\\input #1$/
++\indexbackslash	tex-src/texinfo.tex	/^  \\def\\indexbackslash{\\rawbackslashxx}$/
++index	c-src/emacs/src/lisp.h	1856
++\indexdotfill	tex-src/texinfo.tex	/^\\def\\indexdotfill{\\cleaders$/
++\indexdummies	tex-src/texinfo.tex	/^\\def\\indexdummies{%$/
++\indexdummydots	tex-src/texinfo.tex	/^\\def\\indexdummydots{...}$/
++\indexdummyfont	tex-src/texinfo.tex	/^\\def\\indexdummyfont#1{#1}$/
++=\indexdummyfont	tex-src/texinfo.tex	/^\\let\\cite=\\indexdummyfont$/
++\indexdummytex	tex-src/texinfo.tex	/^\\def\\indexdummytex{TeX}$/
++\indexfonts	tex-src/texinfo.tex	/^\\def\\indexfonts{%$/
++\indexnofonts	tex-src/texinfo.tex	/^\\def\\indexnofonts{%$/
++\inENV	tex-src/texinfo.tex	/^\\newif\\ifENV \\ENVfalse \\def\\inENV{\\ifENV\\relax\\els/
++infabsdir	c-src/etags.c	206
++infabsname	c-src/etags.c	205
++infiles	make-src/Makefile	/^infiles = $(filter-out ${NONSRCS},${SRCS}) srclist/
++infname	c-src/etags.c	204
++\infoappendixsec	tex-src/texinfo.tex	/^\\def\\infoappendixsec{\\parsearg\\appendixseczzz}$/
++\infoappendixsubsec	tex-src/texinfo.tex	/^\\def\\infoappendixsubsec{\\parsearg\\appendixsubseczz/
++\infoappendixsubsubsec	tex-src/texinfo.tex	/^\\def\\infoappendixsubsubsec{\\parsearg\\appendixsubsu/
++\infoappendix	tex-src/texinfo.tex	/^\\def\\infoappendix{\\parsearg\\appendixzzz}$/
++\infochapter	tex-src/texinfo.tex	/^\\def\\infochapter{\\parsearg\\chapterzzz}$/
++info	c-src/emacs/src/gmalloc.c	157
++infoPanel	objcpp-src/SimpleCalc.M	/^- infoPanel:sender$/
++\inforef	tex-src/texinfo.tex	/^\\def\\inforef #1{\\inforefzzz #1,,,,**}$/
++\inforefzzz	tex-src/texinfo.tex	/^\\def\\inforefzzz #1,#2,#3,#4**{See Info file \\file{/
++\infosection	tex-src/texinfo.tex	/^\\def\\infosection{\\parsearg\\sectionzzz}$/
++\infosubsection	tex-src/texinfo.tex	/^\\def\\infosubsection{\\parsearg\\subsectionzzz}$/
++\infosubsubsection	tex-src/texinfo.tex	/^\\def\\infosubsubsection{\\parsearg\\subsubsectionzzz}/
++\infotop	tex-src/texinfo.tex	/^\\def\\infotop{\\parsearg\\unnumberedzzz}$/
++\infounnumberedsec	tex-src/texinfo.tex	/^\\def\\infounnumberedsec{\\parsearg\\unnumberedseczzz}/
++\infounnumberedsubsec	tex-src/texinfo.tex	/^\\def\\infounnumberedsubsec{\\parsearg\\unnumberedsubs/
++\infounnumberedsubsubsec	tex-src/texinfo.tex	/^\\def\\infounnumberedsubsubsec{\\parsearg\\unnumbereds/
++\infounnumbered	tex-src/texinfo.tex	/^\\def\\infounnumbered{\\parsearg\\unnumberedzzz}$/
++inita	c.c	/^static void inita () {}$/
++initb	c.c	/^static void initb () {}$/
++init_control	c.c	239
++init	c-src/etags.c	/^init (void)$/
++Initialize_Cond/p	ada-src/2ataspri.adb	/^   procedure Initialize_Cond (Cond : in out Condit/
++Initialize_Cond/p	ada-src/2ataspri.ads	/^   procedure Initialize_Cond (Cond : in out Condit/
++initialize_goal_store	merc-src/accumulator.m	/^:- func initialize_goal_store(list(hlds_goal), ins/
++Initialize_LL_Tasks/p	ada-src/2ataspri.adb	/^   procedure Initialize_LL_Tasks (T : TCB_Ptr) is$/
++Initialize_LL_Tasks/p	ada-src/2ataspri.ads	/^   procedure Initialize_LL_Tasks (T : TCB_Ptr);$/
++Initialize_Lock/p	ada-src/2ataspri.adb	/^   procedure Initialize_Lock$/
++Initialize_Lock/p	ada-src/2ataspri.ads	/^   procedure Initialize_Lock (Prio : System.Any_Pr/
++initialize-new-tags-table	el-src/emacs/lisp/progmodes/etags.el	/^(defun initialize-new-tags-table ()$/
++initialize_random_junk	y-src/cccp.y	/^initialize_random_junk ()$/
++InitializeStringPackage	pas-src/common.pas	/^procedure InitializeStringPackage;$/
++Initialize_TAS_Cell/p	ada-src/2ataspri.adb	/^   procedure Initialize_TAS_Cell (Cell : out TAS_C/
++Initialize_TAS_Cell/p	ada-src/2ataspri.ads	/^   procedure Initialize_TAS_Cell (Cell :    out TA/
++initial_kboard	c-src/emacs/src/keyboard.c	84
++\initial	tex-src/texinfo.tex	/^\\def\\initial #1{%$/
++init_kboard	c-src/emacs/src/keyboard.c	/^init_kboard (KBOARD *kb, Lisp_Object type)$/
++init_keyboard	c-src/emacs/src/keyboard.c	/^init_keyboard (void)$/
++InitNameList	pas-src/common.pas	/^procedure InitNameList;$/
++InitNameStringPool	pas-src/common.pas	/^procedure InitNameStringPool;$/
++init	objcpp-src/SimpleCalc.M	/^- init$/
++init	objc-src/Subprocess.m	/^    andStdErr:(BOOL)wantsStdErr$/
++init	objc-src/Subprocess.m	/^- init:(const char *)subprocessString$/
++__init__	pyt-src/server.py	/^    def __init__(self):$/
++__init__	pyt-src/server.py	/^    def __init__(self, host, sitelist, master=None/
++__init__	pyt-src/server.py	/^    def __init__(self, master=None):$/
++__init__	pyt-src/server.py	/^    def __init__(self, Master, text, textvar, widt/
++__init__	pyt-src/server.py	/^    def __init__(self, newlegend, list, editor, ma/
++__init__	pyt-src/server.py	/^    def __init__(self, user, userlist, master=None/
++init_registry	cp-src/clheir.cpp	/^void init_registry(void)$/
++init_tool_bar_items	c-src/emacs/src/keyboard.c	/^init_tool_bar_items (Lisp_Object reuse)$/
++Inner1/b	ada-src/etags-test-for.ada	/^  package body Inner1 is$/
++Inner1/b	ada-src/waroquiers.ada	/^  package body Inner1 is$/
++Inner1/s	ada-src/etags-test-for.ada	/^  package Inner1 is$/
++Inner1/s	ada-src/waroquiers.ada	/^  package Inner1 is$/
++Inner2/b	ada-src/etags-test-for.ada	/^  package body Inner2 is$/
++Inner2/b	ada-src/waroquiers.ada	/^  package body Inner2 is$/
++Inner2/s	ada-src/etags-test-for.ada	/^  package Inner2 is$/
++Inner2/s	ada-src/waroquiers.ada	/^  package Inner2 is$/
++input_available_clear_time	c-src/emacs/src/keyboard.c	324
++INPUT_EVENT_POS_MAX	c-src/emacs/src/keyboard.c	3698
++INPUT_EVENT_POS_MIN	c-src/emacs/src/keyboard.c	3701
++input_pending	c-src/emacs/src/keyboard.c	239
++input-pending-p	c-src/emacs/src/keyboard.c	/^DEFUN ("input-pending-p", Finput_pending_p, Sinput/
++input_polling_used	c-src/emacs/src/keyboard.c	/^input_polling_used (void)$/
++input_was_pending	c-src/emacs/src/keyboard.c	287
++insert-abbrev-table-description	c-src/abbrev.c	/^DEFUN ("insert-abbrev-table-description", Finsert_/
++insertion_type	c-src/emacs/src/lisp.h	1989
++insertname	pas-src/common.pas	/^function insertname;(*($/
++INSERT_TREE_NODE	pas-src/common.pas	/^procedure INSERT_TREE_NODE;(*( $/
++Install_Abort_Handler/p	ada-src/2ataspri.adb	/^   procedure Install_Abort_Handler (Handler : Abor/
++Install_Abort_Handler/p	ada-src/2ataspri.ads	/^   procedure Install_Abort_Handler (Handler : Abor/
++Install_Error_Handler/p	ada-src/2ataspri.adb	/^   procedure Install_Error_Handler (Handler : Syst/
++Install_Error_Handler/p	ada-src/2ataspri.ads	/^   procedure Install_Error_Handler (Handler : Syst/
++instance_method_equals=	ruby-src/test.rb	/^        def instance_method_equals=$/
++instance_method_exclamation!	ruby-src/test.rb	/^        def instance_method_exclamation!$/
++instance_method_question?	ruby-src/test.rb	/^        def instance_method_question?$/
++instance_method	ruby-src/test.rb	/^        def instance_method$/
++INSTANTIATE_MDIAGARRAY_FRIENDS	cp-src/MDiagArray2.h	/^#define INSTANTIATE_MDIAGARRAY_FRIENDS(T) \\$/
++instruct	c-src/etags.c	2527
++instr	y-src/parse.y	81
++INT_BIT	c-src/emacs/src/gmalloc.c	124
++INT	c-src/h.h	32
++integer	c-src/emacs/src/lisp.h	2127
++integer_overflow	y-src/cccp.y	/^integer_overflow ()$/
++INTEGERP	c-src/emacs/src/lisp.h	/^# define INTEGERP(x) lisp_h_INTEGERP (x)$/
++INTEGER_TO_CONS	c-src/emacs/src/lisp.h	/^#define INTEGER_TO_CONS(i)					    \\$/
++integertonmstr	pas-src/common.pas	/^function integertonmstr; (* (TheInteger : integer)/
++integer	y-src/cccp.y	112
++intensity1	f-src/entry.for	/^     & intensity1(efv,fv,svin,svquad,sfpv,maxp,val/
++intensity1	f-src/entry.strange	/^     & intensity1(efv,fv,svin,svquad,sfpv,maxp,val/
++intensity1	f-src/entry.strange_suffix	/^     & intensity1(efv,fv,svin,svquad,sfpv,maxp,val/
++interface_locate	c-src/c.c	/^interface_locate(void)$/
++interface	merc-src/accumulator.m	/^:- interface.$/
++\internalBitem	tex-src/texinfo.tex	/^\\def\\internalBitem{\\smallbreak \\parsearg\\itemzzz}$/
++\internalBitemx	tex-src/texinfo.tex	/^\\def\\internalBitemx{\\par \\parsearg\\itemzzz}$/
++\internalBkitem	tex-src/texinfo.tex	/^\\def\\internalBkitem{\\smallbreak \\parsearg\\kitemzzz/
++\internalBkitemx	tex-src/texinfo.tex	/^\\def\\internalBkitemx{\\par \\parsearg\\kitemzzz}$/
++\internalBxitem	tex-src/texinfo.tex	/^\\def\\internalBxitem "#1"{\\def\\xitemsubtopix{#1} \\s/
++\internalBxitemx	tex-src/texinfo.tex	/^\\def\\internalBxitemx "#1"{\\def\\xitemsubtopix{#1} \\/
++internal_last_event_frame	c-src/emacs/src/keyboard.c	228
++\internalsetq	tex-src/texinfo.tex	/^\\def\\internalsetq #1#2{'xrdef {#1}{\\csname #2\\endc/
++intern	c-src/emacs/src/lisp.h	/^intern (const char *str)$/
++intern_c_string	c-src/emacs/src/lisp.h	/^intern_c_string (const char *str)$/
++interned	c-src/emacs/src/lisp.h	672
++interpreters	c-src/etags.c	197
++interrupt_input_blocked	c-src/emacs/src/keyboard.c	76
++interrupt_input_blocked	c-src/emacs/src/lisp.h	3048
++interrupt_input	c-src/emacs/src/keyboard.c	328
++interrupts_deferred	c-src/emacs/src/keyboard.c	331
++INTERVAL	c-src/emacs/src/lisp.h	1149
++INTMASK	c-src/emacs/src/lisp.h	437
++int	merc-src/accumulator.m	/^:- import_module int.$/
++intNumber	go-src/test1.go	13
++intoken	c-src/etags.c	/^#define	intoken(c)	(_itk[CHAR (c)]) \/* c can be in/
++intspec	c-src/emacs/src/lisp.h	1688
++INTTYPEBITS	c-src/emacs/src/lisp.h	249
++INT_TYPE_SIZE	y-src/cccp.y	91
++intvar	c-src/emacs/src/lisp.h	2277
++INT	y-src/cccp.c	6
++invalidate_nodes	c-src/etags.c	/^invalidate_nodes (fdesc *badfdp, node **npp)$/
++Invoking gzip	tex-src/gzip.texi	/^@node Invoking gzip, Advanced usage, Sample, Top$/
++in_word_set	c-src/etags.c	/^in_word_set (register const char *str, register un/
++io	merc-src/accumulator.m	/^:- import_module io.$/
++IpAddrKind	rs-src/test.rs	3
++ipc3dChannelType	cp-src/c.C	1
++ipc3dCSC19	cp-src/c.C	6
++ipc3dIslandHierarchy	cp-src/c.C	1
++ipc3dLinkControl	cp-src/c.C	1
++__ip	c.c	159
++/ip	ps-src/rfc1245.ps	/^\/ip { $/
++/i	ps-src/rfc1245.ps	/^\/i \/j \/k \/l \/m \/n \/o \/p \/q \/r \/s \/t \/u \/v \/w \/x \/y/
++irregular_location	cp-src/clheir.hpp	47
++irregular_location	cp-src/clheir.hpp	/^    irregular_location(double xi, double yi, doubl/
++ISALNUM	c-src/etags.c	/^#define ISALNUM(c)	isalnum (CHAR (c))$/
++ISALPHA	c-src/etags.c	/^#define ISALPHA(c)	isalpha (CHAR (c))$/
++is_associative_construction	merc-src/accumulator.m	/^:- pred is_associative_construction(module_info::i/
++isComment	php-src/lce_functions.php	/^      function isComment($class)$/
++IsControlCharName	pas-src/common.pas	/^function IsControlCharName($/
++IsControlChar	pas-src/common.pas	/^function IsControlChar; (*($/
++is_curly_brace_form	c-src/h.h	54
++IS_DAEMON	c-src/emacs/src/lisp.h	4257
++IS_DAEMON	c-src/emacs/src/lisp.h	4261
++ISDIGIT	c-src/etags.c	/^#define ISDIGIT(c)	isdigit (CHAR (c))$/
++is_explicit	c-src/h.h	49
++is_func	c-src/etags.c	221
++isHoliday	cp-src/functions.cpp	/^bool isHoliday ( Date d ){$/
++is_hor_space	y-src/cccp.y	953
++is_idchar	y-src/cccp.y	948
++is_idstart	y-src/cccp.y	950
++isLeap	cp-src/functions.cpp	/^bool isLeap ( int year ){$/
++ISLOWER	c-src/etags.c	/^#define ISLOWER(c)	islower (CHAR (c))$/
++is_muldiv_operation	cp-src/c.C	/^is_muldiv_operation(pc)$/
++ISO_FUNCTION_KEY_OFFSET	c-src/emacs/src/keyboard.c	5149
++iso_lispy_function_keys	c-src/emacs/src/keyboard.c	5151
++isoperator	prol-src/natded.prolog	/^isoperator(Char):-$/
++isoptab	prol-src/natded.prolog	/^isoptab('%').$/
++is_ordset	prol-src/ordsets.prolog	/^is_ordset(X) :- var(X), !, fail.$/
++is_recursive_case	merc-src/accumulator.m	/^:- pred is_recursive_case(list(hlds_goal)::in, pre/
++Is_Set/f	ada-src/2ataspri.adb	/^   function  Is_Set (Cell : in TAS_Cell) return Bo/
++Is_Set/f	ada-src/2ataspri.ads	/^   function  Is_Set       (Cell : in     TAS_Cell)/
++ISUPPER	c-src/etags.c	/^# define ISUPPER(c)	isupper (CHAR (c))$/
++iswhite	c-src/etags.c	/^#define	iswhite(c)	(_wht[CHAR (c)]) \/* c is white /
++\itemcontents	tex-src/texinfo.tex	/^\\def\\itemcontents{#1}%$/
++\itemfont	tex-src/texinfo.tex	/^\\def\\itemfont{#2}%$/
++\itemizeitem	tex-src/texinfo.tex	/^\\def\\itemizeitem{%$/
++\itemize	tex-src/texinfo.tex	/^\\def\\itemize{\\parsearg\\itemizezzz}$/
++\itemizey	tex-src/texinfo.tex	/^\\def\\itemizey #1#2{%$/
++\itemizezzz	tex-src/texinfo.tex	/^\\def\\itemizezzz #1{%$/
++item_properties	c-src/emacs/src/keyboard.c	7568
++\item	tex-src/texinfo.tex	/^\\def\\item{\\errmessage{@item while not in a table}}/
++\itemx	tex-src/texinfo.tex	/^\\def\\itemx{\\errmessage{@itemx while not in a table/
++\itemzzz	tex-src/texinfo.tex	/^\\def\\itemzzz #1{\\begingroup %$/
++\i	tex-src/texinfo.tex	/^\\def\\i##1{\\realbackslash i {##1}}%$/
++\i	tex-src/texinfo.tex	/^\\def\\i##1{\\realbackslash i {##1}}$/
++JAVASRC	make-src/Makefile	/^JAVASRC=AWTEMul.java KeyEve.java SMan.java SysCol./
++jmp	c-src/emacs/src/lisp.h	3044
++just_read_file	c-src/etags.c	/^just_read_file (FILE *inf)$/
++kbd_buffer	c-src/emacs/src/keyboard.c	291
++kbd_buffer_events_waiting	c-src/emacs/src/keyboard.c	/^kbd_buffer_events_waiting (void)$/
++kbd_buffer_get_event	c-src/emacs/src/keyboard.c	/^kbd_buffer_get_event (KBOARD **kbp,$/
++kbd_buffer_nr_stored	c-src/emacs/src/keyboard.c	/^kbd_buffer_nr_stored (void)$/
++KBD_BUFFER_SIZE	c-src/emacs/src/keyboard.c	82
++kbd_buffer_store_event	c-src/emacs/src/keyboard.c	/^kbd_buffer_store_event (register struct input_even/
++kbd_buffer_store_event_hold	c-src/emacs/src/keyboard.c	/^kbd_buffer_store_event_hold (register struct input/
++kbd_buffer_store_help_event	c-src/emacs/src/keyboard.c	/^kbd_buffer_store_help_event (Lisp_Object frame, Li/
++kbd_buffer_unget_event	c-src/emacs/src/keyboard.c	/^kbd_buffer_unget_event (register struct input_even/
++kbd_fetch_ptr	c-src/emacs/src/keyboard.c	297
++\kbdfoo	tex-src/texinfo.tex	/^\\def\\kbdfoo#1#2#3\\par{\\def\\one{#1}\\def\\three{#3}\\d/
++kbd_store_ptr	c-src/emacs/src/keyboard.c	302
++\kbd	tex-src/texinfo.tex	/^\\def\\kbd#1{\\def\\look{#1}\\expandafter\\kbdfoo\\look??/
++\kbd	tex-src/texinfo.tex	/^\\def\\kbd##1{\\realbackslash kbd {##1}}%$/
++\kbd	tex-src/texinfo.tex	/^\\def\\kbd##1{\\realbackslash kbd {##1}}$/
++kboard	c-src/emacs/src/keyboard.c	860
++kboard_stack	c-src/emacs/src/keyboard.c	858
++kboard_stack	c-src/emacs/src/keyboard.c	864
++KBYTES	objc-src/PackInsp.m	58
++key_and_value	c-src/emacs/src/lisp.h	1868
++keyremap	c-src/emacs/src/keyboard.c	8742
++keyremap	c-src/emacs/src/keyboard.c	8754
++keyremap_step	c-src/emacs/src/keyboard.c	/^keyremap_step (Lisp_Object *keybuf, int bufsize, v/
++keys_of_keyboard	c-src/emacs/src/keyboard.c	/^keys_of_keyboard (void)$/
++\key	tex-src/texinfo.tex	/^\\def\\key##1{\\realbackslash key {##1}}%$/
++\key	tex-src/texinfo.tex	/^\\def\\key##1{\\realbackslash key {##1}}$/
++\key	tex-src/texinfo.tex	/^\\def\\key #1{{\\tt \\exhyphenpenalty=10000\\uppercase{/
++KEY_TO_CHAR	c-src/emacs/src/keyboard.c	/^#define KEY_TO_CHAR(k) (XINT (k) & ((1 << CHARACTE/
++keyvalcgi	prol-src/natded.prolog	/^keyvalcgi(Key,Val):-$/
++keyval	prol-src/natded.prolog	/^keyval(key(Key,Val)) --> [Key,'='], valseq(Val).$/
++keyvalscgi	prol-src/natded.prolog	/^keyvalscgi(KeyVals),$/
++keyvalseq	prol-src/natded.prolog	/^keyvalseq([KeyVal|KeyVals]) --> $/
++keyword_parsing	y-src/cccp.y	73
++keywords	y-src/cccp.y	114
++keywords	y-src/cccp.y	306
++kind	c-src/emacs/src/keyboard.c	11024
++kind	c-src/h.h	46
++\kindex	tex-src/texinfo.tex	/^\\def\\kindex {\\kyindex}$/
++\kitem	tex-src/texinfo.tex	/^\\def\\kitem{\\errmessage{@kitem while not in a table/
++\kitemx	tex-src/texinfo.tex	/^\\def\\kitemx{\\errmessage{@kitemx while not in a tab/
++\kitemzzz	tex-src/texinfo.tex	/^\\def\\kitemzzz #1{\\dosubind {kw}{\\code{#1}}{for {\\b/
++kset_echo_string	c-src/emacs/src/keyboard.c	/^kset_echo_string (struct kboard *kb, Lisp_Object v/
++kset_kbd_queue	c-src/emacs/src/keyboard.c	/^kset_kbd_queue (struct kboard *kb, Lisp_Object val/
++kset_keyboard_translate_table	c-src/emacs/src/keyboard.c	/^kset_keyboard_translate_table (struct kboard *kb, /
++kset_last_prefix_arg	c-src/emacs/src/keyboard.c	/^kset_last_prefix_arg (struct kboard *kb, Lisp_Obje/
++kset_last_repeatable_command	c-src/emacs/src/keyboard.c	/^kset_last_repeatable_command (struct kboard *kb, L/
++kset_local_function_key_map	c-src/emacs/src/keyboard.c	/^kset_local_function_key_map (struct kboard *kb, Li/
++kset_overriding_terminal_local_map	c-src/emacs/src/keyboard.c	/^kset_overriding_terminal_local_map (struct kboard /
++kset_real_last_command	c-src/emacs/src/keyboard.c	/^kset_real_last_command (struct kboard *kb, Lisp_Ob/
++kset_system_key_syms	c-src/emacs/src/keyboard.c	/^kset_system_key_syms (struct kboard *kb, Lisp_Obje/
++LabeledEntry	pyt-src/server.py	/^class LabeledEntry(Frame):$/
++\labelspace	tex-src/texinfo.tex	/^\\def\\labelspace{\\hskip1em \\relax}$/
++lang	c-src/etags.c	208
++lang	c-src/etags.c	251
++lang	c-src/etags.c	259
++Lang_function	c-src/etags.c	182
++Lang_function	c-src/h.h	6
++lang_names	c-src/etags.c	718
++language	c-src/etags.c	199
++last_abbrev_point	c-src/abbrev.c	79
++lasta	c.c	272
++lastargmargin	tex-src/texinfo.tex	/^\\newskip\\deflastargmargin \\deflastargmargin=18pt$/
++lastargmargin	tex-src/texinfo.tex	/^\\setbox0=\\hbox{\\hskip \\deflastargmargin{\\rm #2}\\hs/
++last_auto_save	c-src/emacs/src/keyboard.c	214
++lastb	c.c	278
++last_heapinfo	c-src/emacs/src/gmalloc.c	402
++last_mouse_button	c-src/emacs/src/keyboard.c	5215
++last_mouse_x	c-src/emacs/src/keyboard.c	5216
++last_mouse_y	c-src/emacs/src/keyboard.c	5217
++last_non_minibuf_size	c-src/emacs/src/keyboard.c	207
++last_point_position	c-src/emacs/src/keyboard.c	217
++last_state_size	c-src/emacs/src/gmalloc.c	401
++last-tag	el-src/emacs/lisp/progmodes/etags.el	/^(defvar last-tag nil$/
++last_undo_boundary	c-src/emacs/src/keyboard.c	1287
++LATEST	make-src/Makefile	/^LATEST=17$/
++lb	c-src/etags.c	2923
++\lbrb	tex-src/texinfo.tex	/^\\def\\lbrb{{\\bf\\char`\\[}} \\def\\rbrb{{\\bf\\char`\\]}}$/
++lbs	c-src/etags.c	2924
++lce_bindtextdomain	php-src/lce_functions.php	/^      function lce_bindtextdomain($d_name, $d_path/
++lce_bindtextdomain	php-src/lce_functions.php	/^      function lce_bindtextdomain($domain, $path)$/
++LCE_COMMENT	php-src/lce_functions.php	13
++LCE_COMMENT_TOOL	php-src/lce_functions.php	17
++LCE_COMMENT_USER	php-src/lce_functions.php	15
++lce_dgettext	php-src/lce_functions.php	/^      function lce_dgettext($domain, $msgid)$/
++LCE_FUNCTIONS	php-src/lce_functions.php	4
++lce_geteditcode	php-src/lce_functions.php	/^  function lce_geteditcode($type, $name, $text, $r/
++lce_gettext	php-src/lce_functions.php	/^      function lce_gettext($msgid)$/
++L_CELL	y-src/parse.c	10
++LCE_MSGID	php-src/lce_functions.php	19
++LCE_MSGSTR	php-src/lce_functions.php	21
++lce	php-src/lce_functions.php	/^      function lce()$/
++lce_textdomain	php-src/lce_functions.php	/^      function lce_textdomain($domain)$/
++LCE_TEXT	php-src/lce_functions.php	23
++LCE_UNKNOWN	php-src/lce_functions.php	9
++LCE_WS	php-src/lce_functions.php	11
++L_CONST	y-src/parse.c	13
++LDFLAGS	make-src/Makefile	/^LDFLAGS=#-static -lc_p$/
++leasqr	html-src/software.html	/^Leasqr$/
++left	c-src/etags.c	216
++left_shift	y-src/cccp.y	/^left_shift (a, b)$/
++len	c-src/etags.c	237
++length	c-src/etags.c	2495
++length	y-src/cccp.y	113
++length	y-src/cccp.y	44
++LEQ	y-src/cccp.c	14
++/less	ps-src/rfc1245.ps	/^\/less \/equal \/greater \/question \/at \/A \/B \/C \/D \/E/
++\less	tex-src/texinfo.tex	/^\\def\\less{\\realbackslash less}%$/
++\less	tex-src/texinfo.tex	/^\\def\\less{\\realbackslash less}$/
++let	c-src/emacs/src/lisp.h	2981
++letter	tex-src/texinfo.tex	/^  {#1}{Appendix \\appendixletter}{\\noexpand\\folio}}/
++letter	tex-src/texinfo.tex	/^{#1}{\\appendixletter}{\\the\\secno}{\\noexpand\\folio}/
++letter	tex-src/texinfo.tex	/^{#1}{\\appendixletter}{\\the\\secno}{\\the\\subsecno}{\\/
++letter	tex-src/texinfo.tex	/^  {\\appendixletter}$/
++letter	tex-src/texinfo.tex	/^  {\\appendixletter}{\\the\\secno}{\\the\\subsecno}{\\th/
++letter	tex-src/texinfo.tex	/^\\chapmacro {#1}{Appendix \\appendixletter}%$/
++letter	tex-src/texinfo.tex	/^\\gdef\\thissection{#1}\\secheading {#1}{\\appendixlet/
++letter	tex-src/texinfo.tex	/^\\subsecheading {#1}{\\appendixletter}{\\the\\secno}{\\/
++letter:	tex-src/texinfo.tex	/^\\xdef\\thischapter{Appendix \\appendixletter: \\noexp/
++level	c-src/emacs/src/lisp.h	3153
++lex	prol-src/natded.prolog	/^lex(W,SynOut,Sem):-$/
++lexptr	y-src/cccp.y	332
++LE	y-src/parse.c	7
++L_FN0	y-src/parse.c	14
++L_FN1R	y-src/parse.c	20
++L_FN1	y-src/parse.c	15
++L_FN2R	y-src/parse.c	21
++L_FN2	y-src/parse.c	16
++L_FN3R	y-src/parse.c	22
++L_FN3	y-src/parse.c	17
++L_FN4R	y-src/parse.c	23
++L_FN4	y-src/parse.c	18
++L_FNNR	y-src/parse.c	24
++L_FNN	y-src/parse.c	19
++L_getit	c-src/etags.c	/^L_getit (void)$/
++L_GE	y-src/parse.c	27
++__libc_atexit	c-src/exit.c	30
++__libc_atexit	c-src/exit.strange_suffix	30
++libs	merc-src/accumulator.m	/^:- import_module libs.$/
++licenze	html-src/softwarelibero.html	/^Licenze d'uso di un programma$/
++LIGHTBLUE	cp-src/screen.hpp	21
++LIGHTCYAN	cp-src/screen.hpp	23
++LIGHTGRAY	cp-src/screen.hpp	19
++LIGHTGREEN	cp-src/screen.hpp	22
++LIGHTMAGENTA	cp-src/screen.hpp	25
++LIGHTRED	cp-src/screen.hpp	24
++limit	cp-src/Range.h	/^  double limit (void) const { return rng_limit; }$/
++linebuffer	c-src/etags.c	239
++linebuffer_init	c-src/etags.c	/^linebuffer_init (linebuffer *lbp)$/
++linebuffer_setlen	c-src/etags.c	/^linebuffer_setlen (linebuffer *lbp, int toksize)$/
++lineCount	php-src/lce_functions.php	/^      function lineCount($entry)$/
++line	c-src/etags.c	2493
++lineno	c-src/emacs/src/lisp.h	3147
++lineno	c-src/etags.c	2506
++\linenumber	tex-src/texinfo.tex	/^  \\def\\linenumber{\\the\\inputlineno:\\space}$/
++line	perl-src/htlmify-cystic	37
++linepos	c-src/etags.c	2507
++linepos	c-src/etags.c	2922
++line	y-src/parse.y	87
++links	html-src/software.html	/^Links to interesting software$/
++Lisp_Bits	c-src/emacs/src/lisp.h	239
++Lisp_Boolfwd	c-src/emacs/src/lisp.h	2284
++Lisp_Bool_Vector	c-src/emacs/src/lisp.h	1384
++Lisp_Buffer_Local_Value	c-src/emacs/src/lisp.h	2334
++Lisp_Buffer_Objfwd	c-src/emacs/src/lisp.h	2302
++Lisp_Char_Table	c-src/emacs/src/lisp.h	1575
++Lisp_Compiled	c-src/emacs/src/lisp.h	2429
++Lisp_Cons	c-src/emacs/src/lisp.h	475
++lisp_eval_depth	c-src/emacs/src/lisp.h	3045
++Lisp_Finalizer	c-src/emacs/src/lisp.h	2186
++Lisp_Float	c-src/emacs/src/lisp.h	2391
++Lisp_Float	c-src/emacs/src/lisp.h	477
++Lisp_Free	c-src/emacs/src/lisp.h	2201
++Lisp_functions	c-src/etags.c	/^Lisp_functions (FILE *inf)$/
++Lisp_Fwd_Bool	c-src/emacs/src/lisp.h	505
++Lisp_Fwd_Buffer_Obj	c-src/emacs/src/lisp.h	507
++Lisp_Fwd	c-src/emacs/src/lisp.h	2368
++Lisp_Fwd_Int	c-src/emacs/src/lisp.h	504
++Lisp_Fwd_Kboard_Obj	c-src/emacs/src/lisp.h	508
++Lisp_Fwd_Obj	c-src/emacs/src/lisp.h	506
++Lisp_Fwd_Type	c-src/emacs/src/lisp.h	502
++Lisp_Hash_Table	c-src/emacs/src/lisp.h	1823
++lisp_h_check_cons_list	c-src/emacs/src/lisp.h	/^# define lisp_h_check_cons_list() ((void) 0)$/
++lisp_h_CHECK_LIST_CONS	c-src/emacs/src/lisp.h	/^#define lisp_h_CHECK_LIST_CONS(x, y) CHECK_TYPE (C/
++lisp_h_CHECK_NUMBER	c-src/emacs/src/lisp.h	/^#define lisp_h_CHECK_NUMBER(x) CHECK_TYPE (INTEGER/
++lisp_h_CHECK_SYMBOL	c-src/emacs/src/lisp.h	/^#define lisp_h_CHECK_SYMBOL(x) CHECK_TYPE (SYMBOLP/
++lisp_h_CHECK_TYPE	c-src/emacs/src/lisp.h	/^#define lisp_h_CHECK_TYPE(ok, predicate, x) \\$/
++lisp_h_CONSP	c-src/emacs/src/lisp.h	/^#define lisp_h_CONSP(x) (XTYPE (x) == Lisp_Cons)$/
++Lisp_help	c-src/etags.c	591
++lisp_h_EQ	c-src/emacs/src/lisp.h	/^#define lisp_h_EQ(x, y) (XLI (x) == XLI (y))$/
++lisp_h_FLOATP	c-src/emacs/src/lisp.h	/^#define lisp_h_FLOATP(x) (XTYPE (x) == Lisp_Float)/
++lisp_h_INTEGERP	c-src/emacs/src/lisp.h	/^#define lisp_h_INTEGERP(x) ((XTYPE (x) & (Lisp_Int/
++lisp_h_make_number	c-src/emacs/src/lisp.h	/^# define lisp_h_make_number(n) \\$/
++lisp_h_MARKERP	c-src/emacs/src/lisp.h	/^#define lisp_h_MARKERP(x) (MISCP (x) && XMISCTYPE /
++lisp_h_MISCP	c-src/emacs/src/lisp.h	/^#define lisp_h_MISCP(x) (XTYPE (x) == Lisp_Misc)$/
++lisp_h_NILP	c-src/emacs/src/lisp.h	/^#define lisp_h_NILP(x) EQ (x, Qnil)$/
++lisp_h_SET_SYMBOL_VAL	c-src/emacs/src/lisp.h	/^#define lisp_h_SET_SYMBOL_VAL(sym, v) \\$/
++lisp_h_SYMBOL_CONSTANT_P	c-src/emacs/src/lisp.h	/^#define lisp_h_SYMBOL_CONSTANT_P(sym) (XSYMBOL (sy/
++lisp_h_SYMBOLP	c-src/emacs/src/lisp.h	/^#define lisp_h_SYMBOLP(x) (XTYPE (x) == Lisp_Symbo/
++lisp_h_SYMBOL_VAL	c-src/emacs/src/lisp.h	/^#define lisp_h_SYMBOL_VAL(sym) \\$/
++lisp_h_VECTORLIKEP	c-src/emacs/src/lisp.h	/^#define lisp_h_VECTORLIKEP(x) (XTYPE (x) == Lisp_V/
++lisp_h_XCAR	c-src/emacs/src/lisp.h	/^#define lisp_h_XCAR(c) XCONS (c)->car$/
++lisp_h_XCDR	c-src/emacs/src/lisp.h	/^#define lisp_h_XCDR(c) XCONS (c)->u.cdr$/
++lisp_h_XCONS	c-src/emacs/src/lisp.h	/^#define lisp_h_XCONS(a) \\$/
++lisp_h_XFASTINT	c-src/emacs/src/lisp.h	/^# define lisp_h_XFASTINT(a) XINT (a)$/
++lisp_h_XHASH	c-src/emacs/src/lisp.h	/^#define lisp_h_XHASH(a) XUINT (a)$/
++lisp_h_XIL	c-src/emacs/src/lisp.h	/^# define lisp_h_XIL(i) (i)$/
++lisp_h_XIL	c-src/emacs/src/lisp.h	/^# define lisp_h_XIL(i) ((Lisp_Object) { i })$/
++lisp_h_XINT	c-src/emacs/src/lisp.h	/^# define lisp_h_XINT(a) (XLI (a) >> INTTYPEBITS)$/
++lisp_h_XLI	c-src/emacs/src/lisp.h	/^# define lisp_h_XLI(o) (o)$/
++lisp_h_XLI	c-src/emacs/src/lisp.h	/^# define lisp_h_XLI(o) ((o).i)$/
++lisp_h_XPNTR	c-src/emacs/src/lisp.h	/^#define lisp_h_XPNTR(a) \\$/
++lisp_h_XSYMBOL	c-src/emacs/src/lisp.h	/^# define lisp_h_XSYMBOL(a) \\$/
++lisp_h_XTYPE	c-src/emacs/src/lisp.h	/^# define lisp_h_XTYPE(a) ((enum Lisp_Type) (XLI (a/
++lisp_h_XUNTAG	c-src/emacs/src/lisp.h	/^# define lisp_h_XUNTAG(a, type) ((void *) (intptr_/
++LISP_INITIALLY	c-src/emacs/src/lisp.h	/^#define LISP_INITIALLY(i) (i)$/
++LISP_INITIALLY	c-src/emacs/src/lisp.h	/^#define LISP_INITIALLY(i) {i}$/
++LISP_INITIALLY_ZERO	c-src/emacs/src/lisp.h	582
++Lisp_Int0	c-src/emacs/src/lisp.h	461
++Lisp_Int1	c-src/emacs/src/lisp.h	462
++Lisp_Intfwd	c-src/emacs/src/lisp.h	2274
++Lisp_Kboard_Objfwd	c-src/emacs/src/lisp.h	2362
++LISP_MACRO_DEFUN	c-src/emacs/src/lisp.h	/^#define LISP_MACRO_DEFUN(name, type, argdecls, arg/
++LISP_MACRO_DEFUN	c-src/emacs/src/lisp.h	/^LISP_MACRO_DEFUN (CONSP, bool, (Lisp_Object x), (x/
++LISP_MACRO_DEFUN	c-src/emacs/src/lisp.h	/^LISP_MACRO_DEFUN (NILP, bool, (Lisp_Object x), (x)/
++LISP_MACRO_DEFUN	c-src/emacs/src/lisp.h	/^LISP_MACRO_DEFUN (SYMBOL_VAL, Lisp_Object, (struct/
++LISP_MACRO_DEFUN	c-src/emacs/src/lisp.h	/^LISP_MACRO_DEFUN (XCAR, Lisp_Object, (Lisp_Object /
++LISP_MACRO_DEFUN	c-src/emacs/src/lisp.h	/^LISP_MACRO_DEFUN (XCONS, struct Lisp_Cons *, (Lisp/
++LISP_MACRO_DEFUN	c-src/emacs/src/lisp.h	/^LISP_MACRO_DEFUN (XHASH, EMACS_INT, (Lisp_Object a/
++LISP_MACRO_DEFUN	c-src/emacs/src/lisp.h	/^LISP_MACRO_DEFUN (XLI, EMACS_INT, (Lisp_Object o),/
++LISP_MACRO_DEFUN	c-src/emacs/src/lisp.h	/^LISP_MACRO_DEFUN (XPNTR, void *, (Lisp_Object a), /
++LISP_MACRO_DEFUN_VOID	c-src/emacs/src/lisp.h	/^#define LISP_MACRO_DEFUN_VOID(name, argdecls, args/
++LISP_MACRO_DEFUN_VOID	c-src/emacs/src/lisp.h	/^LISP_MACRO_DEFUN_VOID (CHECK_LIST_CONS, (Lisp_Obje/
++LISP_MACRO_DEFUN_VOID	c-src/emacs/src/lisp.h	/^LISP_MACRO_DEFUN_VOID (CHECK_TYPE,$/
++LISP_MACRO_DEFUN_VOID	c-src/emacs/src/lisp.h	/^LISP_MACRO_DEFUN_VOID (SET_SYMBOL_VAL,$/
++Lisp_Marker	c-src/emacs/src/lisp.h	1978
++Lisp_Misc_Any	c-src/emacs/src/lisp.h	1971
++Lisp_Misc	c-src/emacs/src/lisp.h	2212
++Lisp_Misc	c-src/emacs/src/lisp.h	458
++Lisp_Misc_Finalizer	c-src/emacs/src/lisp.h	491
++Lisp_Misc_Float	c-src/emacs/src/lisp.h	494
++Lisp_Misc_Free	c-src/emacs/src/lisp.h	487
++Lisp_Misc_Limit	c-src/emacs/src/lisp.h	496
++Lisp_Misc_Marker	c-src/emacs/src/lisp.h	488
++Lisp_Misc_Overlay	c-src/emacs/src/lisp.h	489
++Lisp_Misc_Save_Value	c-src/emacs/src/lisp.h	490
++Lisp_Misc_Type	c-src/emacs/src/lisp.h	485
++Lisp_Object	c-src/emacs/src/lisp.h	567
++Lisp_Object	c-src/emacs/src/lisp.h	577
++Lisp_Objfwd	c-src/emacs/src/lisp.h	2294
++Lisp_Overlay	c-src/emacs/src/lisp.h	2021
++Lisp_Save_Type	c-src/emacs/src/lisp.h	2064
++Lisp_Save_Value	c-src/emacs/src/lisp.h	2110
++Lisp_String	c-src/emacs/src/lisp.h	466
++Lisp_Sub_Char_Table	c-src/emacs/src/lisp.h	1606
++Lisp_Subr	c-src/emacs/src/lisp.h	1670
++Lisp_suffixes	c-src/etags.c	589
++Lisp_Symbol	c-src/emacs/src/lisp.h	454
++Lisp_Symbol	c-src/emacs/src/lisp.h	654
++\lisp	tex-src/texinfo.tex	/^\\def\\lisp{\\aboveenvbreak$/
++Lisp_Type	c-src/emacs/src/lisp.h	451
++Lisp_Vector	c-src/emacs/src/lisp.h	1369
++Lisp_Vectorlike	c-src/emacs/src/lisp.h	472
++lispy_accent_codes	c-src/emacs/src/keyboard.c	4634
++lispy_accent_keys	c-src/emacs/src/keyboard.c	4741
++lispy_drag_n_drop_names	c-src/emacs/src/keyboard.c	5181
++lispy_function_keys	c-src/emacs/src/keyboard.c	4768
++lispy_function_keys	c-src/emacs/src/keyboard.c	5065
++lispy_kana_keys	c-src/emacs/src/keyboard.c	5026
++lispy_modifier_list	c-src/emacs/src/keyboard.c	/^lispy_modifier_list (int modifiers)$/
++lispy_multimedia_keys	c-src/emacs/src/keyboard.c	4962
++lispy_wheel_names	c-src/emacs/src/keyboard.c	5174
++list2i	c-src/emacs/src/lisp.h	/^list2i (EMACS_INT x, EMACS_INT y)$/
++list3i	c-src/emacs/src/lisp.h	/^list3i (EMACS_INT x, EMACS_INT y, EMACS_INT w)$/
++list4i	c-src/emacs/src/lisp.h	/^list4i (EMACS_INT x, EMACS_INT y, EMACS_INT w, EMA/
++LISTCONTENTSBUTTON	objc-src/PackInsp.m	48
++LISTCONTENTS	objc-src/PackInsp.m	39
++list	c-src/emacs/src/gmalloc.c	186
++LISTDESCRIPTIONBUTTON	objc-src/PackInsp.m	49
++ListEdit	pyt-src/server.py	/^class ListEdit(Frame):$/
++list	merc-src/accumulator.m	/^:- import_module list.$/
++list-tags	el-src/emacs/lisp/progmodes/etags.el	/^(defun list-tags (file &optional _next-match)$/
++list-tags-function	el-src/emacs/lisp/progmodes/etags.el	/^(defvar list-tags-function nil$/
++list_to_ord_set	prol-src/ordsets.prolog	/^list_to_ord_set(List, Set) :-$/
++LL_Assert/p	ada-src/2ataspri.adb	/^   procedure LL_Assert (B : Boolean; M : String) i/
++LL_Assert/p	ada-src/2ataspri.ads	/^   procedure LL_Assert (B : Boolean; M : String);$/
++L_LE	y-src/parse.c	25
++LL_Task_Procedure_Access/t	ada-src/2ataspri.ads	/^   type LL_Task_Procedure_Access is access procedu/
++LL_Task_Procedure_Access/t	ada-src/etags-test-for.ada	/^   type LL_Task_Procedure_Access is access procedu/
++LL_Wrapper/p	ada-src/2ataspri.adb	/^   procedure LL_Wrapper (T : TCB_Ptr);$/
++LL_Wrapper/p	ada-src/2ataspri.adb	/^   procedure LL_Wrapper (T : TCB_Ptr) is$/
++LL_Wrapper/p	ada-src/etags-test-for.ada	/^   procedure LL_Wrapper (T : TCB_Ptr);$/
++L_NE	y-src/parse.c	26
++lno	c-src/etags.c	223
++/lnormalize	ps-src/rfc1245.ps	/^\/lnormalize { $/
++loadContentsOf	objc-src/PackInsp.m	/^-loadContentsOf:(const char *)type inTable:(HashTa/
++loadImage	objc-src/PackInsp.m	/^-loadImage$/
++loadKeyValuesFrom	objc-src/PackInsp.m	/^-loadKeyValuesFrom:(const char *)type inTable:(Has/
++load	objc-src/PackInsp.m	/^-load$/
++loadPORManager	php-src/lce_functions.php	/^  function &loadPORManager()$/
++local_if_set	c-src/emacs/src/lisp.h	2338
++LOCALIZE_ARCH	objc-src/PackInsp.m	/^#define LOCALIZE_ARCH(s)	NXLoadLocalizedStringFrom/
++LOCALIZE	objc-src/PackInsp.m	/^#define LOCALIZE(s)		NXLoadLocalizedStringFromTabl/
++Locate	pas-src/common.pas	/^function Locate; (*($/
++location	cp-src/clheir.hpp	33
++location	cp-src/clheir.hpp	/^    location() { }$/
++LOCK_ALIGNED_BLOCKS	c-src/emacs/src/gmalloc.c	/^#define LOCK_ALIGNED_BLOCKS()				\\$/
++LOCK_ALIGNED_BLOCKS	c-src/emacs/src/gmalloc.c	/^#define LOCK_ALIGNED_BLOCKS()$/
++LOCK	c-src/emacs/src/gmalloc.c	/^#define LOCK()					\\$/
++LOCK	c-src/emacs/src/gmalloc.c	/^#define LOCK()$/
++Lock/t	ada-src/2ataspri.ads	/^   type Lock is$/
++Lock/t	ada-src/2ataspri.ads	/^   type Lock is private;$/
++\loggingall	tex-src/texinfo.tex	/^\\def\\loggingall{\\tracingcommands2 \\tracingstats2 $/
++LONG_TYPE_SIZE	y-src/cccp.y	95
++LOOKING_AT	c-src/etags.c	/^#define LOOKING_AT(cp, kw)  \/* kw is the keyword, /
++LOOKING_AT_NOCASE	c-src/etags.c	/^#define LOOKING_AT_NOCASE(cp, kw) \/* the keyword i/
++lookup_call	merc-src/accumulator.m	/^:- pred lookup_call(accu_goal_store::in, accu_goal/
++LOOKUP	objc-src/PackInsp.m	176
++LOOKUP	objc-src/PackInsp.m	/^#define LOOKUP(key, notfound)	([table isKey:key] ?/
++lookup	y-src/cccp.y	/^lookup (name, len, hash)$/
++LOOP_ON_INPUT_LINES	c-src/etags.c	/^#define LOOP_ON_INPUT_LINES(file_pointer, line_buf/
++\losespace	tex-src/texinfo.tex	/^\\def\\losespace #1{#1}$/
++lowcase	c-src/etags.c	/^#define lowcase(c)	tolower (CHAR (c))$/
++\lowercaseenumerate	tex-src/texinfo.tex	/^\\def\\lowercaseenumerate{%$/
++LowerCaseNmStr	pas-src/common.pas	/^function LowerCaseNmStr; (*($/
++/L	ps-src/rfc1245.ps	/^\/L { $/
++/L	ps-src/rfc1245.ps	/^\/L \/M \/N \/O \/P \/Q \/R \/S \/T \/U \/V \/W \/X \/Y \/Z \/brac/
++L_RANGE	y-src/parse.c	11
++LSH	y-src/cccp.c	16
++\l	tex-src/texinfo.tex	/^\\def\\l#1{{\\li #1}\\null}		% $/
++LTGT	cp-src/MDiagArray2.h	144
++LTGT	cp-src/MDiagArray2.h	35
++LTGT	cp-src/MDiagArray2.h	39
++LTGT	cp-src/MDiagArray2.h	42
++Lua_functions	c-src/etags.c	/^Lua_functions (FILE *inf)$/
++Lua_help	c-src/etags.c	600
++LUASRC	make-src/Makefile	/^LUASRC=allegro.lua$/
++Lua_suffixes	c-src/etags.c	598
++lucid_event_type_list_p	c-src/emacs/src/keyboard.c	/^lucid_event_type_list_p (Lisp_Object object)$/
++L_VAR	y-src/parse.c	12
++\lvvmode	tex-src/texinfo.tex	/^\\def\\lvvmode{\\vbox to 0pt{}}$/
++mabort	c-src/emacs/src/gmalloc.c	/^mabort (enum mcheck_status status)$/
++mach_host_self	c-src/machsyscalls.h	/^SYSCALL (mach_host_self, -29,$/
++Machine_Exceptions/t	ada-src/2ataspri.ads	/^   type Machine_Exceptions is new Interfaces.C.POS/
++Machin_T/b	ada-src/waroquiers.ada	/^  protected body Machin_T is$/
++Machin_T/t	ada-src/etags-test-for.ada	/^  protected Machin_T is$/
++Machin_T/t	ada-src/etags-test-for.ada	/^  protected type Machin_T is$/
++Machin_T/t	ada-src/waroquiers.ada	/^  protected type Machin_T is$/
++mach_msg_trap	c-src/machsyscalls.h	/^SYSCALL (mach_msg_trap, -25,$/
++mach_reply_port	c-src/machsyscalls.h	/^SYSCALL (mach_reply_port, -26,$/
++mach_task_self	c-src/machsyscalls.h	/^SYSCALL (mach_task_self, -28,$/
++mach_thread_self	c-src/machsyscalls.h	/^SYSCALL (mach_thread_self, -27,$/
++MAGENTA	cp-src/screen.hpp	17
++MAGICBYTE	c-src/emacs/src/gmalloc.c	1856
++magic	c-src/emacs/src/gmalloc.c	1863
++MAGICFREE	c-src/emacs/src/gmalloc.c	1855
++MAGICWORD	c-src/emacs/src/gmalloc.c	1854
++maintaining.info	make-src/Makefile	/^maintaining.info: maintaining.texi$/
++\majorheading	tex-src/texinfo.tex	/^\\def\\majorheading{\\parsearg\\majorheadingzzz}$/
++\majorheadingzzz	tex-src/texinfo.tex	/^\\def\\majorheadingzzz #1{%$/
++make-abbrev-table	c-src/abbrev.c	/^DEFUN ("make-abbrev-table", Fmake_abbrev_table, Sm/
++make_coor	prol-src/natded.prolog	/^make_coor(s(_),Alpha,Sem1,Sem2,Alpha@Sem1@Sem2).$/
++make_C_tag	c-src/etags.c	/^make_C_tag (bool isfun)$/
++make_ctrl_char	c-src/emacs/src/keyboard.c	/^make_ctrl_char (int c)$/
++MakeDispose	pyt-src/server.py	/^    def MakeDispose(self):$/
++Makefile_filenames	c-src/etags.c	603
++Makefile_help	c-src/etags.c	605
++Makefile_targets	c-src/etags.c	/^Makefile_targets (FILE *inf)$/
++make_fixnum_or_float	c-src/emacs/src/lisp.h	/^#define make_fixnum_or_float(val) \\$/
++make_formatted_string	c-src/emacs/src/lisp.h	/^extern Lisp_Object make_formatted_string (char *, /
++make_lisp_ptr	c-src/emacs/src/lisp.h	/^make_lisp_ptr (void *ptr, enum Lisp_Type type)$/
++make_lisp_symbol	c-src/emacs/src/lisp.h	/^make_lisp_symbol (struct Lisp_Symbol *sym)$/
++make_lispy_event	c-src/emacs/src/keyboard.c	/^make_lispy_event (struct input_event *event)$/
++make_lispy_focus_in	c-src/emacs/src/keyboard.c	/^make_lispy_focus_in (Lisp_Object frame)$/
++make_lispy_focus_out	c-src/emacs/src/keyboard.c	/^make_lispy_focus_out (Lisp_Object frame)$/
++make_lispy_movement	c-src/emacs/src/keyboard.c	/^make_lispy_movement (struct frame *frame, Lisp_Obj/
++make_lispy_position	c-src/emacs/src/keyboard.c	/^make_lispy_position (struct frame *f, Lisp_Object /
++make_lispy_switch_frame	c-src/emacs/src/keyboard.c	/^make_lispy_switch_frame (Lisp_Object frame)$/
++MAKE	make-src/Makefile	/^MAKE:=$(MAKE) --no-print-directory$/
++make_number	c-src/emacs/src/lisp.h	/^#  define make_number(n) lisp_h_make_number (n)$/
++make_pointer_integer	c-src/emacs/src/lisp.h	/^make_pointer_integer (void *p)$/
++make_scroll_bar_position	c-src/emacs/src/keyboard.c	/^make_scroll_bar_position (struct input_event *ev, /
++MakeSitelist	pyt-src/server.py	/^    def MakeSitelist(self, master):$/
++MAKESRC	make-src/Makefile	/^MAKESRC=Makefile$/
++make_tag	c-src/etags.c	/^make_tag (const char *name, 	\/* tag name, or NULL /
++make_uninit_sub_char_table	c-src/emacs/src/lisp.h	/^make_uninit_sub_char_table (int depth, int min_cha/
++make_uninit_vector	c-src/emacs/src/lisp.h	/^make_uninit_vector (ptrdiff_t size)$/
++malloc_atfork_handler_child	c-src/emacs/src/gmalloc.c	/^malloc_atfork_handler_child (void)$/
++malloc_atfork_handler_parent	c-src/emacs/src/gmalloc.c	/^malloc_atfork_handler_parent (void)$/
++malloc_atfork_handler_prepare	c-src/emacs/src/gmalloc.c	/^malloc_atfork_handler_prepare (void)$/
++malloc	c-src/emacs/src/gmalloc.c	1715
++malloc	c-src/emacs/src/gmalloc.c	64
++malloc	c-src/emacs/src/gmalloc.c	68
++malloc	c-src/emacs/src/gmalloc.c	/^extern void *malloc (size_t size) ATTRIBUTE_MALLOC/
++_malloc	c-src/emacs/src/gmalloc.c	/^_malloc (size_t size)$/
++malloc	c-src/emacs/src/gmalloc.c	/^malloc (size_t size)$/
++malloc_enable_thread	c-src/emacs/src/gmalloc.c	/^malloc_enable_thread (void)$/
++__malloc_extra_blocks	c-src/emacs/src/gmalloc.c	381
++MALLOCFLOOD	c-src/emacs/src/gmalloc.c	1857
++mallochook	c-src/emacs/src/gmalloc.c	/^mallochook (size_t size)$/
++malloc_info	c-src/emacs/src/gmalloc.c	167
++malloc_initialize_1	c-src/emacs/src/gmalloc.c	/^malloc_initialize_1 (void)$/
++__malloc_initialize	c-src/emacs/src/gmalloc.c	/^__malloc_initialize (void)$/
++__malloc_initialized	c-src/emacs/src/gmalloc.c	379
++_malloc_internal	c-src/emacs/src/gmalloc.c	/^_malloc_internal (size_t size)$/
++_malloc_internal_nolock	c-src/emacs/src/gmalloc.c	/^_malloc_internal_nolock (size_t size)$/
++_malloc_mutex	c-src/emacs/src/gmalloc.c	517
++_malloc_thread_enabled_p	c-src/emacs/src/gmalloc.c	519
++man manpage	make-src/Makefile	/^man manpage: etags.1.man$/
++/manualpapersize	ps-src/rfc1245.ps	/^\/manualpapersize {$/
++MANY	c-src/emacs/src/lisp.h	2833
++mao	c-src/h.h	101
++map	c-src/emacs/src/keyboard.c	8748
++map	merc-src/accumulator.m	/^:- import_module map.$/
++mapping	html-src/algrthms.html	/^Mapping the Channel Symbols$/
++mapsyn	prol-src/natded.prolog	/^mapsyn(A\/B,AM\/BM):-$/
++map_word	prol-src/natded.prolog	/^map_word([[_]|Ws],Exp):-$/
++MARKERP	c-src/emacs/src/lisp.h	/^# define MARKERP(x) lisp_h_MARKERP (x)$/
++mark_kboards	c-src/emacs/src/keyboard.c	/^mark_kboards (void)$/
++\math	tex-src/texinfo.tex	/^\\def\\math#1{\\implicitmath #1\\implicitmath}$/
++MAX_ALLOCA	c-src/emacs/src/lisp.h	4556
++max_args	c-src/emacs/src/lisp.h	1686
++maxargs	c-src/emacs/src/lisp.h	2831
++max	c.c	/^__attribute__ ((always_inline)) max (int a, int b)/
++max	c.c	/^max (int a, int b)$/
++max	cp-src/conway.cpp	/^#define max(x,y)  ((x > y) ? x : y)$/
++max	c-src/emacs/src/lisp.h	58
++max	c-src/emacs/src/lisp.h	/^#define max(a, b) ((a) > (b) ? (a) : (b))$/
++MAX_ENCODED_BYTES	c-src/emacs/src/keyboard.c	2254
++MAX_HASH_VALUE	c-src/etags.c	2329
++max_num_directions	cp-src/clheir.hpp	31
++max_num_generic_objects	cp-src/clheir.cpp	9
++MAXPATHLEN	c-src/etags.c	115
++/max	ps-src/rfc1245.ps	/^\/max {2 copy lt {exch} if pop} bind def$/
++MAX_WORD_LENGTH	c-src/etags.c	2327
++maybe_gc	c-src/emacs/src/lisp.h	/^maybe_gc (void)$/
++maybe	merc-src/accumulator.m	/^:- import_module maybe.$/
++MAYBEREL	y-src/parse.y	/^#define MAYBEREL(p) (*(p)=='[' && (isdigit((p)[1])/
++MBYTES	objc-src/PackInsp.m	59
++Mcccp	y-src/cccp.y	/^main ()$/
++Mc	cp-src/c.C	/^int main (void) { my_function0(0); my_function1(1)/
++mcCSC	cp-src/c.C	6
++mcheck	c-src/emacs/src/gmalloc.c	/^mcheck (void (*func) (enum mcheck_status))$/
++MCHECK_DISABLED	c-src/emacs/src/gmalloc.c	285
++MCHECK_FREE	c-src/emacs/src/gmalloc.c	287
++MCHECK_HEAD	c-src/emacs/src/gmalloc.c	288
++MCHECK_OK	c-src/emacs/src/gmalloc.c	286
++mcheck_status	c-src/emacs/src/gmalloc.c	283
++MCHECK_TAIL	c-src/emacs/src/gmalloc.c	289
++mcheck_used	c-src/emacs/src/gmalloc.c	2012
++Mconway.cpp	cp-src/conway.cpp	/^void main(void)$/
++mdbcomp	merc-src/accumulator.m	/^:- import_module mdbcomp.$/
++MDiagArray2	cp-src/MDiagArray2.h	78
++MDiagArray2	cp-src/MDiagArray2.h	/^  MDiagArray2 (const Array<T>& a) : DiagArray2<T> /
++MDiagArray2	cp-src/MDiagArray2.h	/^  MDiagArray2 (const DiagArray2<T>& a) : DiagArray/
++MDiagArray2	cp-src/MDiagArray2.h	/^  MDiagArray2 (const MDiagArray2<T>& a) : DiagArra/
++MDiagArray2	cp-src/MDiagArray2.h	/^  MDiagArray2 (int r, int c, const T& val) : DiagA/
++MDiagArray2	cp-src/MDiagArray2.h	/^  MDiagArray2 (int r, int c) : DiagArray2<T> (r, c/
++MDiagArray2	cp-src/MDiagArray2.h	/^  MDiagArray2 (T *d, int r, int c) : DiagArray2<T>/
++~MDiagArray2	cp-src/MDiagArray2.h	/^  ~MDiagArray2 (void) { }$/
++MDiagArray2	cp-src/MDiagArray2.h	/^  MDiagArray2 (void) : DiagArray2<T> () { }$/
++me_22a	lua-src/test.lua	/^   function test.me_22a(one, two)$/
++me22b	lua-src/test.lua	/^   local function test.me22b (one)$/
++memalign	c-src/emacs/src/gmalloc.c	/^memalign (size_t alignment, size_t size)$/
++member_lessthan_goalid	merc-src/accumulator.m	/^:- pred member_lessthan_goalid(accu_goal_store::in/
++member	prol-src/natded.prolog	/^member(X,[X|_]).$/
++memclear	c-src/emacs/src/lisp.h	/^memclear (void *p, ptrdiff_t nbytes)$/
++menu_bar_item	c-src/emacs/src/keyboard.c	/^menu_bar_item (Lisp_Object key, Lisp_Object item, /
++menu_bar_items	c-src/emacs/src/keyboard.c	/^menu_bar_items (Lisp_Object old)$/
++menu_bar_items_index	c-src/emacs/src/keyboard.c	7369
++menu_bar_items_vector	c-src/emacs/src/keyboard.c	7368
++menu_bar_one_keymap_changed_items	c-src/emacs/src/keyboard.c	7363
++menu_item_eval_property_1	c-src/emacs/src/keyboard.c	/^menu_item_eval_property_1 (Lisp_Object arg)$/
++menu_item_eval_property	c-src/emacs/src/keyboard.c	/^menu_item_eval_property (Lisp_Object sexpr)$/
++menu_separator_name_p	c-src/emacs/src/keyboard.c	/^menu_separator_name_p (const char *label)$/
++\menu	tex-src/texinfo.tex	/^\\long\\def\\menu #1\\end menu{}$/
++Metags	c-src/etags.c	/^main (int argc, char **argv)$/
++metasource	c-src/etags.c	198
++Mfail	cp-src/fail.C	/^main()$/
++min_args	c-src/emacs/src/lisp.h	1686
++min_char	c-src/emacs/src/lisp.h	1621
++min	cp-src/conway.cpp	/^#define min(x,y)  ((x > y) ? y : x)$/
++min	c-src/emacs/src/gmalloc.c	/^#define min(a, b) ((a) < (b) ? (a) : (b))$/
++min	c-src/emacs/src/lisp.h	57
++min	c-src/emacs/src/lisp.h	/^#define min(a, b) ((a) < (b) ? (a) : (b))$/
++MIN_HASH_VALUE	c-src/etags.c	2328
++/min	ps-src/rfc1245.ps	/^\/min {2 copy gt {exch} if pop} bind def$/
++minus	cp-src/functions.cpp	/^void Date::minus ( int days , int month , int year/
++\minus	tex-src/texinfo.tex	/^\\def\\minus{$-$}$/
++MIN_WORD_LENGTH	c-src/etags.c	2326
++MISCP	c-src/emacs/src/lisp.h	/^# define MISCP(x) lisp_h_MISCP (x)$/
++miti	html-src/softwarelibero.html	/^Sfatiamo alcuni miti$/
++Mkai-test.pl	perl-src/kai-test.pl	/^package main;$/
++modifier_names	c-src/emacs/src/keyboard.c	6319
++modifier_symbols	c-src/emacs/src/keyboard.c	6327
++modify_event_symbol	c-src/emacs/src/keyboard.c	/^modify_event_symbol (ptrdiff_t symbol_num, int mod/
++module_class_method	ruby-src/test.rb	/^    def ModuleExample.module_class_method$/
++ModuleExample	ruby-src/test.rb	/^module ModuleExample$/
++module_instance_method	ruby-src/test.rb	/^    def module_instance_method$/
++more_aligned_int	c.c	165
++morecore_nolock	c-src/emacs/src/gmalloc.c	/^morecore_nolock (size_t size)$/
++morecore_recursing	c-src/emacs/src/gmalloc.c	604
++More_Lisp_Bits	c-src/emacs/src/lisp.h	801
++more=	ruby-src/test1.ru	/^                :more$/
++MOST_NEGATIVE_FIXNUM	c-src/emacs/src/lisp.h	835
++MOST_POSITIVE_FIXNUM	c-src/emacs/src/lisp.h	834
++mouse_syms	c-src/emacs/src/keyboard.c	4627
++move	cp-src/clheir.cpp	/^void agent::move(int direction)$/
++MOVE	c-src/sysdep.h	/^#define MOVE(x,y)	movl x, y$/
++MoveLayerAfter	lua-src/allegro.lua	/^function MoveLayerAfter (this_one)$/
++MoveLayerBefore	lua-src/allegro.lua	/^function MoveLayerBefore (this_one)$/
++MoveLayerBottom	lua-src/allegro.lua	/^function MoveLayerBottom ()$/
++MoveLayerTop	lua-src/allegro.lua	/^function MoveLayerTop ()$/
++mprobe	c-src/emacs/src/gmalloc.c	/^mprobe (void *ptr)$/
++/M	ps-src/rfc1245.ps	/^\/M {newpath moveto} bind def$/
++MSDOS	c-src/etags.c	100
++MSDOS	c-src/etags.c	106
++MSDOS	c-src/etags.c	107
++MSDOS	c-src/etags.c	110
++msgid	php-src/lce_functions.php	/^      function msgid($line, $class)$/
++MSGSEL	f-src/entry.for	/^       ENTRY  MSGSEL ( TYPE )$/
++MSGSEL	f-src/entry.strange	/^       ENTRY  MSGSEL ( TYPE )$/
++MSGSEL	f-src/entry.strange_suffix	/^       ENTRY  MSGSEL ( TYPE )$/
++msgstr	php-src/lce_functions.php	/^      function msgstr($line, $class)$/
++/ms	ps-src/rfc1245.ps	/^\/ms { $/
++mstats	c-src/emacs/src/gmalloc.c	308
++Mtest1.go	go-src/test1.go	1
++Mtest1.go	go-src/test1.go	/^func main() {$/
++Mtest.go	go-src/test.go	1
++Mtest.go	go-src/test.go	/^func main() {$/
++Mtest.rs	rs-src/test.rs	/^fn main() {$/
++mtg	html-src/software.html	/^MTG$/
++mt	prol-src/natded.prolog	/^mt:-$/
++multibyte	c-src/emacs/src/regex.h	403
++MULTI_LETTER_MOD	c-src/emacs/src/keyboard.c	6231
++MULTI_LETTER_MOD	c-src/emacs/src/keyboard.c	6764
++MULTI_LETTER_MOD	c-src/emacs/src/keyboard.c	/^#define MULTI_LETTER_MOD(BIT, NAME, LEN)			\\$/
++MULTI_LETTER_MOD	c-src/emacs/src/keyboard.c	/^#define MULTI_LETTER_MOD(BIT, NAME, LEN)		\\$/
++multi_line	c-src/etags.c	267
++Mx.cc	cp-src/x.cc	/^main(int argc, char *argv[])$/
++\mylbrace	tex-src/texinfo.tex	/^\\def\\mylbrace {{\\tt \\char '173}}$/
++mypi	forth-src/test-forth.fth	/^synonym mypi fconst$/
++my_printf	c.c	/^my_printf (void *my_object, const char *my_format,/
++\myrbrace	tex-src/texinfo.tex	/^\\def\\myrbrace {{\\tt \\char '175}}$/
++my_struct	c.c	226
++my_struct	c-src/h.h	91
++my_typedef	c.c	228
++my_typedef	c-src/h.h	93
++name	c-src/emacs/src/keyboard.c	7241
++name	c-src/emacs/src/lisp.h	1808
++name	c-src/emacs/src/lisp.h	3144
++name	c-src/emacs/src/lisp.h	682
++name	c-src/etags.c	192
++name	c-src/etags.c	218
++name	c-src/etags.c	2271
++name	c-src/etags.c	261
++name	c-src/getopt.h	76
++name	c-src/getopt.h	78
++named	c-src/etags.c	2505
++NameHasChar	pas-src/common.pas	/^function NameHasChar; (* (TheName : NameString; Th/
++name	perl-src/htlmify-cystic	357
++namestringequal	pas-src/common.pas	/^function namestringequal;(*(var Name1,Name2 : Name/
++NameStringLess	pas-src/common.pas	/^function NameStringLess;(*(var Name1,Name2 : NameS/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {#1}{Function}%$/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {#1}{Macro}%$/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {#1}{Special Form}%$/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {#1}{User Option}%$/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {#1}{Variable}%$/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {#2}{#1}\\deftpargs{#3}\\endgrou/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {#2}{#1}\\defunargs{#3}\\endgrou/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {#2}{#1}\\defvarargs{#3}\\endgro/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {#2}{\\defcvtype{} of #1}%$/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {#2}{\\defoptype{} on #1}%$/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {#2}{Instance Variable of #1}%/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {#2}{Method on #1}%$/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {\\code{#1} #2}{Function}%$/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {\\code{#1} #2}{Variable}%$/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {\\code{#2} #3}{#1}%$/
++name	tex-src/texinfo.tex	/^\\begingroup\\defname {\\code{#2} #3}{#1}$/
++NAME	y-src/cccp.c	8
++name	y-src/cccp.y	113
++name	y-src/cccp.y	43
++nargs	c-src/emacs/src/lisp.h	2987
++NATNUMP	c-src/emacs/src/lisp.h	/^NATNUMP (Lisp_Object x)$/
++/nbluet	ps-src/rfc1245.ps	/^\/nbluet 256 array def$/
++n	c-src/exit.c	28
++n	c-src/exit.strange_suffix	28
++NDEBUG	c-src/etags.c	88
++need_adjustment	c-src/emacs/src/lisp.h	1986
++\need	tex-src/texinfo.tex	/^\\def\\need{\\parsearg\\needx}$/
++\needx	tex-src/texinfo.tex	/^\\def\\needx#1{%$/
++NEG	y-src/parse.c	9
++neighbors	cp-src/clheir.hpp	59
++nelem	cp-src/Range.h	/^  int nelem (void) const { return rng_nelem; }$/
++nestlev	c-src/etags.c	2525
++\newcodeindex	tex-src/texinfo.tex	/^\\def\\newcodeindex #1{$/
++\newindex	tex-src/texinfo.tex	/^\\def\\newindex #1{$/
++NewLayer	lua-src/allegro.lua	/^function NewLayer (name, x, y, w, h)$/
++NewLayerSet	lua-src/allegro.lua	/^function NewLayerSet (name)$/
++newlb	c-src/etags.c	2930
++newlinepos	c-src/etags.c	2932
++NewNameString	pas-src/common.pas	/^procedure NewNameString; (* (var NSP: NameStringPo/
++new	objc-src/PackInsp.m	/^+new$/
++new	perl-src/htlmify-cystic	163
++new_tag	perl-src/htlmify-cystic	18
++newtextstring	pas-src/common.pas	/^function newtextstring; (*: TextString;*)$/
++next_alive	cp-src/conway.hpp	7
++next_almost_prime	c-src/emacs/src/lisp.h	/^extern EMACS_INT next_almost_prime (EMACS_INT) ATT/
++NEXT_ALMOST_PRIME_LIMIT	c-src/emacs/src/lisp.h	3573
++next	c.c	174
++next	c-src/emacs/src/gmalloc.c	164
++next	c-src/emacs/src/gmalloc.c	188
++next	c-src/emacs/src/gmalloc.c	198
++next	c-src/emacs/src/keyboard.c	7246
++next	c-src/emacs/src/keyboard.c	861
++next	c-src/emacs/src/lisp.h	1848
++next	c-src/emacs/src/lisp.h	2009
++next	c-src/emacs/src/lisp.h	2037
++next	c-src/emacs/src/lisp.h	2192
++next	c-src/emacs/src/lisp.h	3028
++next	c-src/emacs/src/lisp.h	3134
++next	c-src/emacs/src/lisp.h	700
++next	c-src/etags.c	203
++next-file	el-src/emacs/lisp/progmodes/etags.el	/^(defun next-file (&optional initialize novisit)$/
++next-file-list	el-src/emacs/lisp/progmodes/etags.el	/^(defvar next-file-list nil$/
++next_free	c-src/emacs/src/lisp.h	1851
++nextfree	c-src/emacs/src/lisp.h	3029
++\next	tex-src/texinfo.tex	/^\\def\\next##1{}\\next}$/
++next_weak	c-src/emacs/src/lisp.h	1875
++next	y-src/cccp.y	42
++NE	y-src/parse.c	6
++nfree	c-src/emacs/src/gmalloc.c	150
++/ngrayt	ps-src/rfc1245.ps	/^\/ngrayt 256 array def$/
++/ngreent	ps-src/rfc1245.ps	/^\/ngreent 256 array def$/
++NIL_IS_ZERO	c-src/emacs/src/lisp.h	1515
++NILP	c-src/emacs/src/lisp.h	/^# define NILP(x) lisp_h_NILP (x)$/
++nl	c-src/etags.c	2521
++NmStrToErrStr	pas-src/common.pas	/^function NmStrToErrStr;(*($/
++NmStrToInteger	pas-src/common.pas	/^function NmStrToInteger; (* (Str : NameString) : i/
++\nm	tex-src/testenv.tex	/^\\newcommand{\\nm}[2]{\\nomenclature{#1}{#2}}$/
++no_argument	c-src/getopt.h	89
++nocase_tail	c-src/etags.c	/^nocase_tail (const char *cp)$/
++node	c-src/etags.c	225
++noderef	tex-src/texinfo.tex	/^\\appendixnoderef %$/
++node_st	c-src/etags.c	214
++\node	tex-src/texinfo.tex	/^\\def\\node{\\ENVcheck\\parsearg\\nodezzz}$/
++\nodexxx[	tex-src/texinfo.tex	/^\\def\\nodexxx[#1,#2]{\\gdef\\lastnode{#1}}$/
++\nodezzz	tex-src/texinfo.tex	/^\\def\\nodezzz#1{\\nodexxx [#1,]}$/
++\nofillexdent	tex-src/texinfo.tex	/^\\def\\nofillexdent{\\parsearg\\nofillexdentyyy}$/
++\nofillexdentyyy	tex-src/texinfo.tex	/^\\def\\nofillexdentyyy #1{{\\advance \\leftskip by -\\e/
++nofonts%	tex-src/texinfo.tex	/^{\\chapternofonts%$/
++nofonts	tex-src/texinfo.tex	/^{\\indexnofonts$/
++no_lang_help	c-src/etags.c	707
++none_help	c-src/etags.c	703
++NONPOINTER_BITS	c-src/emacs/src/lisp.h	78
++NONPOINTER_BITS	c-src/emacs/src/lisp.h	80
++NONSRCS	make-src/Makefile	/^NONSRCS=entry.strange lists.erl clheir.hpp.gz$/
++\normalbackslash	tex-src/texinfo.tex	/^\\def\\normalbackslash{{\\tt\\rawbackslashxx}}$/
++\normalcaret	tex-src/texinfo.tex	/^\\def\\normalcaret{^}$/
++\normaldoublequote	tex-src/texinfo.tex	/^\\def\\normaldoublequote{"}$/
++\normalgreater	tex-src/texinfo.tex	/^\\def\\normalgreater{>}$/
++normalize_fresh	prol-src/natded.prolog	/^normalize_fresh(M,N):-$/
++normalize	prol-src/natded.prolog	/^normalize(M,MNorm):-$/
++/normalize	ps-src/rfc1245.ps	/^\/normalize {$/
++normalize_tree	prol-src/natded.prolog	/^normalize_tree(tree(Rule,Syn:Sem,Trees),$/
++normalize_trees	prol-src/natded.prolog	/^normalize_trees([],[]).$/
++\normalless	tex-src/texinfo.tex	/^\\def\\normalless{<}$/
++\normalplus	tex-src/texinfo.tex	/^\\def\\normalplus{+}$/
++\normaltilde	tex-src/texinfo.tex	/^\\def\\normaltilde{~}$/
++\normalunderscore	tex-src/texinfo.tex	/^\\def\\normalunderscore{_}$/
++\normalverticalbar	tex-src/texinfo.tex	/^\\def\\normalverticalbar{|}$/
++nosave	pyt-src/server.py	/^    def nosave(self):$/
++no_sub	c-src/emacs/src/regex.h	387
++notag2	c-src/dostorture.c	26
++notag2	c-src/torture.c	26
++notag4	c-src/dostorture.c	45
++notag4	c-src/torture.c	45
++not_bol	c-src/emacs/src/regex.h	391
++/.notdef	ps-src/rfc1245.ps	/^\/.notdef \/.notdef \/.notdef \/.notdef \/.notdef \/.not/
++/.notdef	ps-src/rfc1245.ps	/^\/.notdef \/.notdef \/.notdef \/.notdef \/space \/exclam/
++not_eol	c-src/emacs/src/regex.h	394
++NOTEQUAL	y-src/cccp.c	13
++no	tex-src/texinfo.tex	/^\\global\\advance \\appendixno by 1 \\message{Appendix/
++no	tex-src/texinfo.tex	/^\\ifnum\\secno=0 Appendix\\xreftie'char\\the\\appendixn/
++no	tex-src/texinfo.tex	/^\\newcount \\appendixno  \\appendixno = `\\@$/
++no.\the\secno	tex-src/texinfo.tex	/^\\else \\ifnum \\subsecno=0 Section\\xreftie'char\\the\\/
++no.\the\secno.\the\subsecno	tex-src/texinfo.tex	/^Section\\xreftie'char\\the\\appendixno.\\the\\secno.\\th/
++no.\the\secno.\the\subsecno.\the\subsubsecno	tex-src/texinfo.tex	/^Section\\xreftie'char\\the\\appendixno.\\the\\secno.\\th/
++notinname	c-src/etags.c	/^#define notinname(c)	(_nin[CHAR (c)]) \/* c is not /
++not_single_kboard_state	c-src/emacs/src/keyboard.c	/^not_single_kboard_state (KBOARD *kboard)$/
++npending	c-src/emacs/src/keyboard.c	7244
++/N	ps-src/rfc1245.ps	/^\/N { $/
++/nredt	ps-src/rfc1245.ps	/^\/nredt 256 array def$/
++\nsbot	tex-src/texinfo.tex	/^\\def\\nsbot{\\vbox$/
++\nstop	tex-src/texinfo.tex	/^\\def\\nstop{\\vbox$/
++/Ntilde	ps-src/rfc1245.ps	/^\/Ntilde \/Odieresis \/Udieresis \/aacute \/agrave \/aci/
++ntool_bar_items	c-src/emacs/src/keyboard.c	7974
++NULL_PTR	y-src/cccp.y	63
++NULL	y-src/cccp.y	51
++\numberedsec	tex-src/texinfo.tex	/^\\outer\\def\\numberedsec{\\parsearg\\seczzz}$/
++\numberedsubsec	tex-src/texinfo.tex	/^\\outer\\def\\numberedsubsec{\\parsearg\\numberedsubsec/
++\numberedsubseczzz	tex-src/texinfo.tex	/^\\def\\numberedsubseczzz #1{\\seccheck{subsection}%$/
++\numberedsubsubsec	tex-src/texinfo.tex	/^\\outer\\def\\numberedsubsubsec{\\parsearg\\numberedsub/
++\numberedsubsubseczzz	tex-src/texinfo.tex	/^\\def\\numberedsubsubseczzz #1{\\seccheck{subsubsecti/
++numberKeys	objcpp-src/SimpleCalc.M	/^- numberKeys:sender$/
++number_len	c-src/etags.c	/^static int number_len (long) ATTRIBUTE_CONST;$/
++/numbersign	ps-src/rfc1245.ps	/^\/numbersign \/dollar \/percent \/ampersand \/quotesing/
++numbervars	prol-src/natded.prolog	/^numbervars(X):-$/
++num_columns	cp-src/conway.cpp	16
++\numericenumerate	tex-src/texinfo.tex	/^\\def\\numericenumerate{%$/
++num_input_events	c-src/emacs/src/keyboard.c	210
++NUM_MOD_NAMES	c-src/emacs/src/keyboard.c	6325
++numOfChannels	cp-src/c.C	1
++NUM_RECENT_KEYS	c-src/emacs/src/keyboard.c	91
++num_regs	c-src/emacs/src/regex.h	430
++num_rows	cp-src/conway.cpp	15
++NUMSTATS	objc-src/PackInsp.h	36
++nvars	c-src/emacs/src/lisp.h	3140
++Objc_help	c-src/etags.c	613
++OBJCPPSRC	make-src/Makefile	/^OBJCPPSRC=SimpleCalc.H SimpleCalc.M$/
++OBJCSRC	make-src/Makefile	/^OBJCSRC=Subprocess.h Subprocess.m PackInsp.h PackI/
++Objc_suffixes	c-src/etags.c	609
++objdef	c-src/etags.c	2484
++object	c-src/emacs/src/lisp.h	2128
++object_registry	cp-src/clheir.cpp	10
++OBJS	make-src/Makefile	/^OBJS=${GETOPTOBJS} ${REGEXOBJS} ${CHECKOBJS}$/
++objtag	c-src/etags.c	2453
++objvar	c-src/emacs/src/lisp.h	2297
++obstack_chunk_alloc	y-src/parse.y	47
++obstack_chunk_free	y-src/parse.y	48
++ocatseen	c-src/etags.c	2477
++/ocircumflex	ps-src/rfc1245.ps	/^\/ocircumflex \/odieresis \/otilde \/uacute \/ugrave \/u/
++octave_MDiagArray2_h	cp-src/MDiagArray2.h	29
++octave_Range_h	cp-src/Range.h	24
++\oddfooting	tex-src/texinfo.tex	/^\\def\\oddfooting{\\parsearg\\oddfootingxxx}$/
++\oddheading	tex-src/texinfo.tex	/^\\def\\oddheading{\\parsearg\\oddheadingxxx}$/
++oediff	make-src/Makefile	/^oediff: OTAGS ETAGS ${infiles}$/
++offset	c-src/emacs/src/lisp.h	2305
++offset	c-src/emacs/src/lisp.h	2365
++offset	c-src/etags.c	2494
++oignore	c-src/etags.c	2483
++oimplementation	c-src/etags.c	2474
++oinbody	c-src/etags.c	2478
++ok	objc-src/PackInsp.m	/^-ok:sender$/
++ok_to_echo_at_next_pause	c-src/emacs/src/keyboard.c	159
++old_value	c-src/emacs/src/lisp.h	2980
++omethodcolon	c-src/etags.c	2481
++omethodparm	c-src/etags.c	2482
++omethodsign	c-src/etags.c	2479
++omethodtag	c-src/etags.c	2480
++\onepageout	tex-src/texinfo.tex	/^\\def\\onepageout#1{\\hoffset=\\normaloffset$/
++onone	c-src/etags.c	2472
++oparenseen	c-src/etags.c	2476
++OPENBUTTON	objc-src/PackInsp.m	47
++\opencontents	tex-src/texinfo.tex	/^\\def\\opencontents{\\openout \\contentsfile = \\jobnam/
++open-dribble-file	c-src/emacs/src/keyboard.c	/^DEFUN ("open-dribble-file", Fopen_dribble_file, So/
++\openindices	tex-src/texinfo.tex	/^\\def\\openindices{%$/
++openInWorkspace	objc-src/PackInsp.m	/^static void openInWorkspace(const char *filename)$/
++open	objc-src/PackInsp.m	/^-open:sender$/
++operationKeys	objcpp-src/SimpleCalc.M	/^- operationKeys:sender$/
++operator+	cp-src/c.C	/^  A operator+(A& a) {};$/
++operator+	cp-src/c.C	/^const A& A::operator+(const A&) { }$/
++operator -	cp-src/c.C	/^void operator -(int, int) {}$/
++operator+	cp-src/c.C	/^void operator+(int, int) {}$/
++operator =	cp-src/functions.cpp	/^Date & Date::operator = ( Date d ){$/
++operator +=	cp-src/functions.cpp	/^Date & Date::operator += ( int days ){$/
++operator -=	cp-src/functions.cpp	/^Date & Date::operator -= ( int days ){$/
++operator ++	cp-src/functions.cpp	/^Date & Date::operator ++ ( void ){$/
++operator --	cp-src/functions.cpp	/^Date & Date::operator -- ( void ){$/
++operator -	cp-src/functions.cpp	/^int Date::operator - ( Date d ){$/
++operator <	cp-src/functions.cpp	/^int Date::operator < ( Date d ) {$/
++operator ==	cp-src/functions.cpp	/^int Date::operator == ( Date d ) {$/
++operator >	cp-src/functions.cpp	/^int Date::operator > ( Date d ) {$/
++operator >>	cp-src/functions.cpp	/^istream& operator >> ( istream &i, Date & dd ){$/
++operator <<	cp-src/functions.cpp	/^ostream& operator <<  ( ostream &c, Date d ) {$/
++operator =	cp-src/MDiagArray2.h	/^  MDiagArray2<T>& operator = (const MDiagArray2<T>/
++OperatorFun	c-src/h.h	88
++operator int	cp-src/c.C	/^void operator int(int, int) {}$/
++operator int	cp-src/fail.C	/^			   operator int() const {return x;}$/
++operator MArray2<T>	cp-src/MDiagArray2.h	/^  operator MArray2<T> () const$/
++operator	y-src/cccp.y	438
++\opnr	tex-src/texinfo.tex	/^\\def\\opnr{{\\sf\\char`\\(}} \\def\\clnr{{\\sf\\char`\\)}} /
++opparsebody\Edefop\defopx\defopheader\defoptype	tex-src/texinfo.tex	/^\\defopparsebody\\Edefop\\defopx\\defopheader\\defoptyp/
++oprotocol	c-src/etags.c	2473
++/O	ps-src/rfc1245.ps	/^\/O {closepath} bind def$/
++optional_argument	c-src/getopt.h	91
++option	c-src/getopt.h	73
++OPTIONS	make-src/Makefile	/^OPTIONS=--members --declarations --regex=@regexfil/
++opvarparsebody\Edefcv\defcvx\defcvarheader\defcvtype	tex-src/texinfo.tex	/^\\defopvarparsebody\\Edefcv\\defcvx\\defcvarheader\\def/
++ord_add_element	prol-src/ordsets.prolog	/^ord_add_element([], Element, [Element]).$/
++ord_del_element	prol-src/ordsets.prolog	/^ord_del_element([], _, []).$/
++ord_disjoint	prol-src/ordsets.prolog	/^ord_disjoint(Set1, Set2) :-$/
++/ordfeminine	ps-src/rfc1245.ps	/^\/ordfeminine \/ordmasculine \/.notdef \/ae \/oslash \/q/
++ord_intersection2	prol-src/ordsets.prolog	/^ord_intersection2(1, [Set|Sets], Set0, Sets0) :- !/
++ord_intersection3	prol-src/ordsets.prolog	/^ord_intersection3(<, _, Set1, Head2, Tail2, Inters/
++ord_intersection4	prol-src/ordsets.prolog	/^ord_intersection4(<, _, Set1, Head2, Tail2, Inters/
++ord_intersection	prol-src/ordsets.prolog	/^ord_intersection([], _, []).$/
++ord_intersection	prol-src/ordsets.prolog	/^ord_intersection([], Set2, [], Set2).$/
++ord_intersection	prol-src/ordsets.prolog	/^ord_intersection(Sets, Intersection) :- $/
++ord_intersect	prol-src/ordsets.prolog	/^ord_intersect([Head1|Tail1], [Head2|Tail2]) :-$/
++ord_member	prol-src/ordsets.prolog	/^ord_member(X, [E|Es]) :-$/
++ord_seteq	prol-src/ordsets.prolog	/^ord_seteq(Set1, Set2) :-$/
++ord_setproduct	prol-src/ordsets.prolog	/^ord_setproduct([], _, []).$/
++ord_subset	prol-src/ordsets.prolog	/^ord_subset([], _).$/
++ord_subtract	prol-src/ordsets.prolog	/^ord_subtract(Set1, Set2, Union) :-$/
++ord_symdiff	prol-src/ordsets.prolog	/^ord_symdiff([], Set2, Set2).$/
++ord_union4	prol-src/ordsets.prolog	/^ord_union4(<, Head, Set1, Head2, Tail2, [Head|Unio/
++ord_union_all	prol-src/ordsets.prolog	/^ord_union_all(1, [Set|Sets], Set, Sets) :- !.$/
++ord_union	prol-src/ordsets.prolog	/^ord_union(Set1, Set2, Union) :-$/
++ord_union	prol-src/ordsets.prolog	/^ord_union([], Union) :- !, Union = [].$/
++OR	y-src/cccp.c	10
++oss	html-src/softwarelibero.html	/^Il movimento open source$/
++otagseen	c-src/etags.c	2475
++OTAGS	make-src/Makefile	/^OTAGS: oetags ${SRCS} srclist$/
++/Otilde	ps-src/rfc1245.ps	/^\/Otilde \/OE \/oe \/endash \/emdash \/quotedblleft \/quo/
++output_file	perl-src/htlmify-cystic	35
++output_files	perl-src/htlmify-cystic	32
++outputtable	html-src/algrthms.html	/^Output$/
++outputTime	cp-src/c.C	9
++outsyn	prol-src/natded.prolog	/^outsyn(['Any'],_).$/
++OVERLAYP	c-src/emacs/src/lisp.h	/^OVERLAYP (Lisp_Object x)$/
++Overview	tex-src/gzip.texi	/^@node Overview, Sample, Copying, Top$/
++PackageInspector	objc-src/PackInsp.h	/^@interface PackageInspector:WMInspector$/
++\pagebody	tex-src/texinfo.tex	/^\\def\\pagebody#1{\\vbox to\\pageheight{\\boxmaxdepth=\\/
++/pagedimen	ps-src/rfc1245.ps	/^\/pagedimen { $/
++pagesize	c-src/emacs/src/gmalloc.c	1703
++\pagesofar	tex-src/texinfo.tex	/^\\def\\pagesofar{\\unvbox\\partialpage %$/
++\page	tex-src/texinfo.tex	/^   \\def\\page{%$/
++\page	tex-src/texinfo.tex	/^\\def\\page{\\par\\vfill\\supereject}$/
++pair	merc-src/accumulator.m	/^:- import_module pair.$/
++/papersize	ps-src/rfc1245.ps	/^\/papersize {$/
++/paragraph	ps-src/rfc1245.ps	/^\/paragraph \/germandbls \/registered \/copyright \/tra/
++/parenright	ps-src/rfc1245.ps	/^\/parenright \/asterisk \/plus \/comma \/hyphen \/period/
++parent	c-src/emacs/src/keyboard.c	8745
++parent	c-src/emacs/src/lisp.h	1590
++\parseargline	tex-src/texinfo.tex	/^\\def\\parseargline{\\begingroup \\obeylines \\parsearg/
++\parsearg	tex-src/texinfo.tex	/^\\def\\parsearg #1{\\let\\next=#1\\begingroup\\obeylines/
++\parseargx	tex-src/texinfo.tex	/^\\def\\parseargx{%$/
++parse_c_expression	y-src/cccp.y	/^parse_c_expression (string)$/
++parse_cgi	prol-src/natded.prolog	/^parse_cgi(TokenList,KeyVals):-$/
++parse_error	y-src/parse.y	82
++parse_escape	y-src/cccp.y	/^parse_escape (string_ptr)$/
++parseFromVars	php-src/lce_functions.php	/^      function parseFromVars($prefix)$/
++parse_hash	y-src/parse.y	64
++parse_menu_item	c-src/emacs/src/keyboard.c	/^parse_menu_item (Lisp_Object item, int inmenubar)$/
++parse_modifiers	c-src/emacs/src/keyboard.c	/^parse_modifiers (Lisp_Object symbol)$/
++parse_modifiers_uncached	c-src/emacs/src/keyboard.c	/^parse_modifiers_uncached (Lisp_Object symbol, ptrd/
++parse_number	y-src/cccp.y	/^parse_number (olen)$/
++parse	prol-src/natded.prolog	/^parse(Ws,Cat):-$/
++parse_return_error	y-src/cccp.y	70
++parse_return	y-src/parse.y	74
++parse_solitary_modifier	c-src/emacs/src/keyboard.c	/^parse_solitary_modifier (Lisp_Object symbol)$/
++parse_tool_bar_item	c-src/emacs/src/keyboard.c	/^parse_tool_bar_item (Lisp_Object key, Lisp_Object /
++parse_tree	merc-src/accumulator.m	/^:- import_module parse_tree.$/
++Pascal_functions	c-src/etags.c	/^Pascal_functions (FILE *inf)$/
++Pascal_help	c-src/etags.c	621
++Pascal_suffixes	c-src/etags.c	619
++PASSRC	make-src/Makefile	/^PASSRC=common.pas$/
++pat	c-src/etags.c	262
++pattern	c-src/etags.c	260
++p	c-src/emacs/src/lisp.h	4673
++p	c-src/emacs/src/lisp.h	4679
++pD	c-src/emacs/src/lisp.h	165
++pD	c-src/emacs/src/lisp.h	167
++pD	c-src/emacs/src/lisp.h	169
++pD	c-src/emacs/src/lisp.h	171
++pdlcount	c-src/emacs/src/lisp.h	3046
++PDT	c-src/h.h	/^  Date 04 May 87 235311 PDT (Mon)$/
++pending-delete-mode	el-src/TAGTEST.EL	/^(defalias 'pending-delete-mode 'delete-selection-m/
++pending_funcalls	c-src/emacs/src/keyboard.c	4377
++pending_signals	c-src/emacs/src/keyboard.c	80
++/periodcentered	ps-src/rfc1245.ps	/^\/periodcentered \/quotesinglbase \/quotedblbase \/per/
++Perl_functions	c-src/etags.c	/^Perl_functions (FILE *inf)$/
++Perl_help	c-src/etags.c	630
++Perl_interpreters	c-src/etags.c	628
++PERLSRC	make-src/Makefile	/^PERLSRC=htlmify-cystic yagrip.pl kai-test.pl mirro/
++Perl_suffixes	c-src/etags.c	626
++p/f	ada-src/etags-test-for.ada	/^function p ("p");$/
++p/f	ada-src/etags-test-for.ada	/^   function p pragma Import (C,$/
++pfatal	c-src/etags.c	/^pfatal (const char *s1)$/
++pfdset	c-src/h.h	57
++pfnote	c-src/etags.c	/^pfnote (char *name, bool is_func, char *linestart,/
++/PF	ps-src/rfc1245.ps	/^\/PF { $/
++PHP_functions	c-src/etags.c	/^PHP_functions (FILE *inf)$/
++PHP_help	c-src/etags.c	639
++PHPSRC	make-src/Makefile	/^PHPSRC=lce_functions.php ptest.php sendmail.php$/
++PHP_suffixes	c-src/etags.c	637
++pI	c-src/emacs/src/lisp.h	106
++pI	c-src/emacs/src/lisp.h	94
++pI	c-src/emacs/src/lisp.h	99
++\pindex	tex-src/texinfo.tex	/^\\def\\pindex {\\pgindex}$/
++pinned	c-src/emacs/src/lisp.h	679
++Pkg1/b	ada-src/etags-test-for.ada	/^package body Pkg1 is$/
++Pkg1/b	ada-src/waroquiers.ada	/^package body Pkg1 is$/
++Pkg1_Func1/f	ada-src/etags-test-for.ada	/^  function Pkg1_Func1 return Boolean;$/
++Pkg1_Func1/f	ada-src/etags-test-for.ada	/^function  Pkg1_Func1 return Boolean is$/
++Pkg1_Func1/f	ada-src/etags-test-for.ada	/^  function Pkg1_Func1 return Boolean is separate;$/
++Pkg1_Func1/f	ada-src/waroquiers.ada	/^  function Pkg1_Func1 return Boolean;$/
++Pkg1_Func1/f	ada-src/waroquiers.ada	/^function  Pkg1_Func1 return Boolean is$/
++Pkg1_Func1/f	ada-src/waroquiers.ada	/^  function Pkg1_Func1 return Boolean is separate;$/
++Pkg1_Func2/f	ada-src/etags-test-for.ada	/^  function Pkg1_Func2 (Ijk : Integer; Z : Integer)/
++Pkg1_Func2/f	ada-src/waroquiers.ada	/^  function Pkg1_Func2 (Ijk : Integer; Z : Integer)/
++Pkg1_Pkg1/b	ada-src/etags-test-for.ada	/^package body Pkg1_Pkg1 is$/
++Pkg1_Pkg1/b	ada-src/etags-test-for.ada	/^  package body Pkg1_Pkg1 is separate;$/
++Pkg1_Pkg1/b	ada-src/waroquiers.ada	/^package body Pkg1_Pkg1 is$/
++Pkg1_Pkg1/b	ada-src/waroquiers.ada	/^  package body Pkg1_Pkg1 is separate;$/
++Pkg1_Pkg1_Proc1/p	ada-src/etags-test-for.ada	/^    procedure Pkg1_Pkg1_Proc1;$/
++Pkg1_Pkg1_Proc1/p	ada-src/etags-test-for.ada	/^  procedure Pkg1_Pkg1_Proc1 is$/
++Pkg1_Pkg1_Proc1/p	ada-src/waroquiers.ada	/^    procedure Pkg1_Pkg1_Proc1;$/
++Pkg1_Pkg1_Proc1/p	ada-src/waroquiers.ada	/^  procedure Pkg1_Pkg1_Proc1 is$/
++Pkg1_Pkg1/s	ada-src/etags-test-for.ada	/^  package Pkg1_Pkg1 is$/
++Pkg1_Pkg1/s	ada-src/waroquiers.ada	/^  package Pkg1_Pkg1 is$/
++Pkg1_Proc1/p	ada-src/etags-test-for.ada	/^  procedure Pkg1_Proc1;$/
++Pkg1_Proc1/p	ada-src/etags-test-for.ada	/^  procedure Pkg1_Proc1 is$/
++Pkg1_Proc1/p	ada-src/waroquiers.ada	/^  procedure Pkg1_Proc1;$/
++Pkg1_Proc1/p	ada-src/waroquiers.ada	/^  procedure Pkg1_Proc1 is$/
++Pkg1_Proc2/p	ada-src/etags-test-for.ada	/^  procedure Pkg1_Proc2 (I : Integer);$/
++Pkg1_Proc2/p	ada-src/etags-test-for.ada	/^  procedure Pkg1_Proc2 (I : Integer) is$/
++Pkg1_Proc2/p	ada-src/waroquiers.ada	/^  procedure Pkg1_Proc2 (I : Integer);$/
++Pkg1_Proc2/p	ada-src/waroquiers.ada	/^  procedure Pkg1_Proc2 (I : Integer) is$/
++Pkg1/s	ada-src/etags-test-for.ada	/^package Pkg1 is$/
++Pkg1/s	ada-src/waroquiers.ada	/^package Pkg1 is$/
++plainc	c-src/etags.c	2934
++plain_C_entries	c-src/etags.c	/^plain_C_entries (FILE *inf)$/
++plain_C_suffixes	c-src/etags.c	643
++\plainsecheading	tex-src/texinfo.tex	/^\\def\\plainsecheading #1{\\secheadingi {#1}}$/
++plist	c-src/emacs/src/lisp.h	2040
++plist	c-src/emacs/src/lisp.h	697
++plus	cp-src/functions.cpp	/^void Date::plus ( int days , int month , int year /
++plus	go-src/test1.go	5
++plusvalseq	prol-src/natded.prolog	/^plusvalseq([]) --> [].$/
++pMd	c-src/emacs/src/lisp.h	150
++pMd	c-src/emacs/src/lisp.h	155
++pMu	c-src/emacs/src/lisp.h	151
++pMu	c-src/emacs/src/lisp.h	156
++p_next	c-src/etags.c	258
++POEntryAD	php-src/lce_functions.php	29
++POEntry	php-src/lce_functions.php	105
++POEntry	php-src/lce_functions.php	/^      function POEntry()$/
++pointer	c-src/emacs/src/lisp.h	2125
++point	forth-src/test-forth.fth	/^BEGIN-STRUCTURE point \\ create the named structure/
++\point	tex-src/texinfo.tex	/^\\def\\point{$\\star$}$/
++poll_for_input_1	c-src/emacs/src/keyboard.c	/^poll_for_input_1 (void)$/
++poll_for_input	c-src/emacs/src/keyboard.c	/^poll_for_input (struct atimer *timer)$/
++poll_suppress_count	c-src/emacs/src/keyboard.c	1908
++poll_suppress_count	c-src/emacs/src/lisp.h	3047
++poll_timer	c-src/emacs/src/keyboard.c	1915
++popclass_above	c-src/etags.c	/^popclass_above (int bracelev)$/
++pop_kboard	c-src/emacs/src/keyboard.c	/^pop_kboard (void)$/
++pop-tag-mark	el-src/emacs/lisp/progmodes/etags.el	/^(defalias 'pop-tag-mark 'xref-pop-marker-stack)$/
++POReader	php-src/lce_functions.php	163
++POReader	php-src/lce_functions.php	/^      function POReader($domain, $filename)$/
++PORManager	php-src/lce_functions.php	498
++PORManager	php-src/lce_functions.php	/^      function PORManager()$/
++position_to_Time	c-src/emacs/src/keyboard.c	/^position_to_Time (ptrdiff_t pos)$/
++posix_memalign	c-src/emacs/src/gmalloc.c	/^posix_memalign (void **memptr, size_t alignment, s/
++posn-at-point	c-src/emacs/src/keyboard.c	/^DEFUN ("posn-at-point", Fposn_at_point, Sposn_at_p/
++posn-at-x-y	c-src/emacs/src/keyboard.c	/^DEFUN ("posn-at-x-y", Fposn_at_x_y, Sposn_at_x_y, /
++possible_sum_sign	y-src/cccp.y	/^#define possible_sum_sign(a, b, sum) ((((a) ^ (b))/
++PostControls	pyt-src/server.py	/^    def PostControls(self):$/
++post	pyt-src/server.py	/^    def post(self):$/
++POSTSCRIPTFLAGS	make-src/Makefile	/^POSTSCRIPTFLAGS=--language=none --regex='#\/[^ \\t{]/
++pot_etags_version	c-src/etags.c	81
++pp1	c-src/dostorture.c	/^int pp1($/
++pp1	c-src/torture.c	/^int pp1($/
++pp2	c-src/dostorture.c	/^pp2$/
++pp2	c-src/torture.c	/^pp2$/
++pp3	c-src/dostorture.c	/^pp3(int bar)$/
++pp3	c-src/torture.c	/^pp3(int bar)$/
++pp_bas_cat	prol-src/natded.prolog	/^pp_bas_cat(Cat):-$/
++pp_cat	prol-src/natded.prolog	/^pp_cat(Syn:Sem):-$/
++pp_exp	prol-src/natded.prolog	/^pp_exp('NIL'):-$/
++pp_exps	prol-src/natded.prolog	/^pp_exps([]).$/
++pp_html_fitch_tree	prol-src/natded.prolog	/^pp_html_fitch_tree(tree(der,Root,[ders(Words)]),M,/
++pp_html_table_fitch_tree	prol-src/natded.prolog	/^pp_html_table_fitch_tree(T):-$/
++pp_html_table_tree	prol-src/natded.prolog	/^pp_html_table_tree(T):-$/
++pp_html_tree	prol-src/natded.prolog	/^pp_html_tree(ass(Syn,V,'$VAR'(N))):-$/
++pp_html_trees	prol-src/natded.prolog	/^pp_html_trees([T|Ts],N,M):-$/
++pp_lam_bracket	prol-src/natded.prolog	/^pp_lam_bracket(A^B):-$/
++pp_lam_paren	prol-src/natded.prolog	/^pp_lam_paren(Var^Alpha):-$/
++pp_lam	prol-src/natded.prolog	/^pp_lam(Var^Alpha):-$/
++pp_paren	prol-src/natded.prolog	/^pp_paren(C):-$/
++pp_rule	prol-src/natded.prolog	/^pp_rule(fe):-write('\/E').$/
++/P	ps-src/rfc1245.ps	/^\/P { $/
++pp_syn_back	prol-src/natded.prolog	/^pp_syn_back(A\/B):-$/
++pp_syn_paren	prol-src/natded.prolog	/^pp_syn_paren(A\/B):-$/
++pp_syn	prol-src/natded.prolog	/^pp_syn(A\/B):-$/
++pp_tree	prol-src/natded.prolog	/^pp_tree(T):-$/
++pp_trees	prol-src/natded.prolog	/^pp_trees([T|Ts],Column):-$/
++pp_word_list	prol-src/natded.prolog	/^pp_word_list([]).$/
++pp_word_list_rest	prol-src/natded.prolog	/^pp_word_list_rest([]).$/
++pp_word	prol-src/natded.prolog	/^pp_word(W):-$/
++Pre_Call_State/t	ada-src/2ataspri.ads	/^   type Pre_Call_State is new System.Address;$/
++.PRECIOUS	make-src/Makefile	/^.PRECIOUS: ETAGS CTAGS ETAGS16 CTAGS16 ETAGS17 CTA/
++predicate	c-src/emacs/src/lisp.h	2307
++prev	c.c	175
++prev	c-src/emacs/src/gmalloc.c	165
++prev	c-src/emacs/src/gmalloc.c	189
++prev	c-src/emacs/src/lisp.h	2191
++\primary	tex-src/texinfo.tex	/^\\def\\primary #1{\\line{#1\\hfil}}$/
++PrintAdd	go-src/test1.go	/^func (n intNumber) PrintAdd() {$/
++PrintAdd	go-src/test1.go	/^func (s str) PrintAdd() {$/
++printClassification	php-src/lce_functions.php	/^      function printClassification()$/
++\printedmanual	tex-src/texinfo.tex	/^\\def\\printedmanual{\\ignorespaces #5}%$/
++\printedmanual	tex-src/texinfo.tex	/^section ``\\printednodename'' in \\cite{\\printedmanu/
++\printednodename	tex-src/texinfo.tex	/^\\def\\printednodename{\\ignorespaces #1}%$/
++\printednodename	tex-src/texinfo.tex	/^\\def\\printednodename{\\ignorespaces #3}%$/
++print_help	c-src/etags.c	/^print_help (argument *argbuffer)$/
++\printindex	tex-src/texinfo.tex	/^\\def\\printindex{\\parsearg\\doprintindex}$/
++print_language_names	c-src/etags.c	/^print_language_names (void)$/
++printmax_t	c-src/emacs/src/lisp.h	148
++printmax_t	c-src/emacs/src/lisp.h	153
++\print	tex-src/texinfo.tex	/^\\def\\print{\\leavevmode\\lower.1ex\\hbox to 1em{\\hfil/
++\print	tex-src/texinfo.tex	/^\\def\\print{\\realbackslash print}$/
++PRINT_UNDOCUMENTED_OPTIONS_HELP	c-src/etags.c	804
++print_version	c-src/etags.c	/^print_version (void)$/
++Private	objc-src/Subprocess.m	/^@interface Subprocess(Private)$/
++Private_T/b	ada-src/etags-test-for.ada	/^    task body Private_T is$/
++Private_T/b	ada-src/waroquiers.ada	/^    task body Private_T is$/
++Private_T/k	ada-src/etags-test-for.ada	/^    task Private_T;$/
++Private_T/k	ada-src/waroquiers.ada	/^    task Private_T;$/
++Private_T/p	ada-src/etags-test-for.ada	/^    procedure Private_T;$/
++Private_T/p	ada-src/etags-test-for.ada	/^    procedure Private_T is$/
++Private_T/p	ada-src/waroquiers.ada	/^    procedure Private_T;$/
++Private_T/p	ada-src/waroquiers.ada	/^    procedure Private_T is$/
++Private_T/t	ada-src/etags-test-for.ada	/^  type Private_T is$/
++Private_T/t	ada-src/etags-test-for.ada	/^  type Private_T is private;$/
++Private_T/t	ada-src/waroquiers.ada	/^  type Private_T is$/
++Private_T/t	ada-src/waroquiers.ada	/^  type Private_T is private;$/
++Problems	tex-src/gzip.texi	/^@node Problems, Concept Index, Tapes, Top$/
++proc	c-src/h.h	87
++process_file	c-src/etags.c	/^process_file (FILE *fh, char *fn, language *lang)$/
++process_file_name	c-src/etags.c	/^process_file_name (char *file, language *lang)$/
++PROCESSP	c-src/emacs/src/lisp.h	/^PROCESSP (Lisp_Object a)$/
++process_pending_signals	c-src/emacs/src/keyboard.c	/^process_pending_signals (void)$/
++process_special_events	c-src/emacs/src/keyboard.c	/^process_special_events (void)$/
++process_tool_bar_item	c-src/emacs/src/keyboard.c	/^process_tool_bar_item (Lisp_Object key, Lisp_Objec/
++Proc/t	ada-src/2ataspri.ads	/^   type Proc is access procedure (Addr : System.Ad/
++prof	make-src/Makefile	/^prof: ETAGS$/
++prolog_atom	c-src/etags.c	/^prolog_atom (char *s, size_t pos)$/
++Prolog_functions	c-src/etags.c	/^Prolog_functions (FILE *inf)$/
++Prolog_help	c-src/etags.c	654
++prolog_pr	c-src/etags.c	/^prolog_pr (char *s, char *last)$/
++prolog_skip_comment	c-src/etags.c	/^prolog_skip_comment (linebuffer *plb, FILE *inf)$/
++Prolog_suffixes	c-src/etags.c	652
++PROLSRC	make-src/Makefile	/^PROLSRC=ordsets.prolog natded.prolog$/
++PROP	c-src/emacs/src/keyboard.c	8379
++PROP	c-src/emacs/src/keyboard.c	/^#define PROP(IDX) AREF (tool_bar_item_properties, /
++prop	c-src/etags.c	209
++PROTECT_MALLOC_STATE	c-src/emacs/src/gmalloc.c	/^#define PROTECT_MALLOC_STATE(PROT)	\/* empty *\/$/
++PROTECT_MALLOC_STATE	c-src/emacs/src/gmalloc.c	/^#define PROTECT_MALLOC_STATE(PROT) protect_malloc_/
++protect_malloc_state	c-src/emacs/src/gmalloc.c	/^protect_malloc_state (int protect_p)$/
++PRTPKG	f-src/entry.for	/^      LOGICAL FUNCTION PRTPKG ( SHORT, LONG, EXPL,/
++PRTPKG	f-src/entry.strange	/^      LOGICAL FUNCTION PRTPKG ( SHORT, LONG, EXPL,/
++PRTPKG	f-src/entry.strange_suffix	/^      LOGICAL FUNCTION PRTPKG ( SHORT, LONG, EXPL,/
++PSEUDO	c-src/sysdep.h	/^#define	PSEUDO(name, syscall_name, args)				      /
++PSEUDOVECSIZE	c-src/emacs/src/lisp.h	/^#define PSEUDOVECSIZE(type, nonlispfield)			\\$/
++PSEUDOVECTOR_AREA_BITS	c-src/emacs/src/lisp.h	818
++PSEUDOVECTOR_FLAG	c-src/emacs/src/lisp.h	774
++PSEUDOVECTORP	c-src/emacs/src/lisp.h	/^PSEUDOVECTORP (Lisp_Object a, int code)$/
++PSEUDOVECTOR_REST_BITS	c-src/emacs/src/lisp.h	813
++PSEUDOVECTOR_REST_MASK	c-src/emacs/src/lisp.h	814
++PSEUDOVECTOR_SIZE_BITS	c-src/emacs/src/lisp.h	808
++PSEUDOVECTOR_SIZE_MASK	c-src/emacs/src/lisp.h	809
++PSEUDOVECTOR_TYPEP	c-src/emacs/src/lisp.h	/^PSEUDOVECTOR_TYPEP (struct vectorlike_header *a, i/
++PS_functions	c-src/etags.c	/^PS_functions (FILE *inf)$/
++PS_help	c-src/etags.c	649
++PSSRC	make-src/Makefile	/^PSSRC=rfc1245.ps$/
++PS_suffixes	c-src/etags.c	647
++pthread_mutexattr_setprio_ceiling/f	ada-src/2ataspri.adb	/^   function pthread_mutexattr_setprio_ceiling$/
++pthread_mutexattr_setprotocol/f	ada-src/2ataspri.adb	/^   function pthread_mutexattr_setprotocol$/
++PTY_LENGTH	objc-src/Subprocess.m	21
++PTY_TEMPLATE	objc-src/Subprocess.m	20
++Public_T/t	ada-src/etags-test-for.ada	/^  type Public_T is$/
++Public_T/t	ada-src/waroquiers.ada	/^  type Public_T is$/
++purpose	c-src/emacs/src/lisp.h	1594
++pushclass_above	c-src/etags.c	/^pushclass_above (int bracelev, char *str, int len)/
++PUSH_C_STR	c-src/emacs/src/keyboard.c	/^#define PUSH_C_STR(str, listvar) \\$/
++PUSH_HANDLER	c-src/emacs/src/lisp.h	/^#define PUSH_HANDLER(c, tag_ch_val, handlertype)	\\/
++push_kboard	c-src/emacs/src/keyboard.c	/^push_kboard (struct kboard *k)$/
++put_entries	c-src/etags.c	/^put_entries (register node *np)$/
++PVEC_BOOL_VECTOR	c-src/emacs/src/lisp.h	787
++PVEC_BUFFER	c-src/emacs/src/lisp.h	788
++PVEC_CHAR_TABLE	c-src/emacs/src/lisp.h	796
++PVEC_COMPILED	c-src/emacs/src/lisp.h	795
++PVEC_FONT	c-src/emacs/src/lisp.h	798
++PVEC_FRAME	c-src/emacs/src/lisp.h	785
++PVEC_FREE	c-src/emacs/src/lisp.h	783
++PVEC_HASH_TABLE	c-src/emacs/src/lisp.h	789
++PVEC_NORMAL_VECTOR	c-src/emacs/src/lisp.h	782
++PVEC_OTHER	c-src/emacs/src/lisp.h	793
++PVEC_PROCESS	c-src/emacs/src/lisp.h	784
++PVEC_SUB_CHAR_TABLE	c-src/emacs/src/lisp.h	797
++PVEC_SUBR	c-src/emacs/src/lisp.h	792
++PVEC_TERMINAL	c-src/emacs/src/lisp.h	790
++pvec_type	c-src/emacs/src/lisp.h	780
++PVEC_TYPE_MASK	c-src/emacs/src/lisp.h	819
++PVEC_WINDOW_CONFIGURATION	c-src/emacs/src/lisp.h	791
++PVEC_WINDOW	c-src/emacs/src/lisp.h	786
++p.x	forth-src/test-forth.fth	/^  1 CELLS +FIELD p.x    \\ A single cell filed name/
++\pxref	tex-src/texinfo.tex	/^\\def\\pxref#1{see \\xrefX[#1,,,,,,,]}$/
++p.y	forth-src/test-forth.fth	/^  1 CELLS +FIELD p.y    \\ A single cell field name/
++Python_functions	c-src/etags.c	/^Python_functions (FILE *inf)$/
++Python_help	c-src/etags.c	660
++Python_suffixes	c-src/etags.c	658
++PYTSRC	make-src/Makefile	/^PYTSRC=server.py$/
++quantizing	html-src/algrthms.html	/^Quantizing the Received$/
++questo	../c/c.web	34
++quiettest	make-src/Makefile	/^quiettest:$/
++quit_char	c-src/emacs/src/keyboard.c	192
++QUIT	c-src/emacs/src/lisp.h	3101
++QUITP	c-src/emacs/src/lisp.h	3112
++quit_throw_to_read_char	c-src/emacs/src/keyboard.c	/^quit_throw_to_read_char (bool from_signal)$/
++\quotation	tex-src/texinfo.tex	/^\\def\\quotation{%$/
++/quoteleft	ps-src/rfc1245.ps	/^\/quoteleft \/quoteright \/.notdef \/.notdef \/ydieresi/
++qux1	ruby-src/test1.ru	/^                :qux1)$/
++qux	ruby-src/test1.ru	/^    alias_method :qux, :tee, attr_accessor(:bogus)/
++qux=	ruby-src/test1.ru	/^      def qux=(tee)$/
++r0	c-src/sysdep.h	54
++r1	c-src/sysdep.h	55
++r_alloc	c-src/emacs/src/lisp.h	/^extern void *r_alloc (void **, size_t) ATTRIBUTE_A/
++Range	cp-src/Range.h	35
++Range	cp-src/Range.h	/^  Range (const Range& r)$/
++Range	cp-src/Range.h	/^  Range (double b, double l)$/
++Range	cp-src/Range.h	/^  Range (double b, double l, double i)$/
++Range	cp-src/Range.h	/^  Range (void)$/
++RANGED_INTEGERP	c-src/emacs/src/lisp.h	/^RANGED_INTEGERP (intmax_t lo, Lisp_Object x, intma/
++range_exp_list	y-src/parse.y	273
++range_exp	y-src/parse.y	269
++\rawbackslashxx	tex-src/texinfo.tex	/^\\def\\rawbackslashxx{\\indexbackslash}%$/
++\rawbackslashxx	tex-src/texinfo.tex	/^\\def\\rawbackslashxx{\\indexbackslash}% \\indexbacksl/
++raw_keybuf_count	c-src/emacs/src/keyboard.c	117
++raw_keybuf	c-src/emacs/src/keyboard.c	116
++rbtp	c.c	240
++RCSid	objc-src/PackInsp.m	30
++read1	ruby-src/test1.ru	/^    attr_reader :read1 , :read2; attr_writer :writ/
++read2	ruby-src/test1.ru	/^    attr_reader :read1 , :read2; attr_writer :writ/
++readable_events	c-src/emacs/src/keyboard.c	/^readable_events (int flags)$/
++READABLE_EVENTS_DO_TIMERS_NOW	c-src/emacs/src/keyboard.c	346
++READABLE_EVENTS_FILTER_EVENTS	c-src/emacs/src/keyboard.c	347
++READABLE_EVENTS_IGNORE_SQUEEZABLES	c-src/emacs/src/keyboard.c	348
++\readauxfile	tex-src/texinfo.tex	/^\\def\\readauxfile{%$/
++read_char	c-src/emacs/src/keyboard.c	/^read_char (int commandflag, Lisp_Object map,$/
++read_char_help_form_unwind	c-src/emacs/src/keyboard.c	/^read_char_help_form_unwind (void)$/
++read_char_minibuf_menu_prompt	c-src/emacs/src/keyboard.c	/^read_char_minibuf_menu_prompt (int commandflag,$/
++read_char_x_menu_prompt	c-src/emacs/src/keyboard.c	/^read_char_x_menu_prompt (Lisp_Object map,$/
++read	cp-src/conway.hpp	/^    char read() { return alive; }$/
++read_decoded_event_from_main_queue	c-src/emacs/src/keyboard.c	/^read_decoded_event_from_main_queue (struct timespe/
++read_event_from_main_queue	c-src/emacs/src/keyboard.c	/^read_event_from_main_queue (struct timespec *end_t/
++read_key_sequence_cmd	c-src/emacs/src/keyboard.c	232
++read-key-sequence	c-src/emacs/src/keyboard.c	/^DEFUN ("read-key-sequence", Fread_key_sequence, Sr/
++read_key_sequence	c-src/emacs/src/keyboard.c	/^read_key_sequence (Lisp_Object *keybuf, int bufsiz/
++read_key_sequence_remapped	c-src/emacs/src/keyboard.c	233
++read-key-sequence-vector	c-src/emacs/src/keyboard.c	/^DEFUN ("read-key-sequence-vector", Fread_key_seque/
++read_key_sequence_vs	c-src/emacs/src/keyboard.c	/^read_key_sequence_vs (Lisp_Object prompt, Lisp_Obj/
++readline	c-src/etags.c	/^readline (linebuffer *lbp, FILE *stream)$/
++readline_internal	c-src/etags.c	/^readline_internal (linebuffer *lbp, register FILE /
++Read_Lock/p	ada-src/2ataspri.adb	/^   procedure Read_Lock (L : in out Lock; Ceiling_V/
++Read_Lock/p	ada-src/2ataspri.ads	/^   procedure Read_Lock (L : in out Lock; Ceiling_V/
++read_menu_command	c-src/emacs/src/keyboard.c	/^read_menu_command (void)$/
++read	php-src/lce_functions.php	/^      function read()$/
++read_toc	perl-src/htlmify-cystic	/^sub read_toc ()$/
++ReadVacation	cp-src/functions.cpp	/^void ReadVacation ( char *filename ) {$/
++realloc	c-src/emacs/src/gmalloc.c	1716
++realloc	c-src/emacs/src/gmalloc.c	65
++realloc	c-src/emacs/src/gmalloc.c	69
++_realloc	c-src/emacs/src/gmalloc.c	/^_realloc (void *ptr, size_t size)$/
++realloc	c-src/emacs/src/gmalloc.c	/^realloc (void *ptr, size_t size)$/
++reallochook	c-src/emacs/src/gmalloc.c	/^reallochook (void *ptr, size_t size)$/
++_realloc_internal	c-src/emacs/src/gmalloc.c	/^_realloc_internal (void *ptr, size_t size)$/
++_realloc_internal_nolock	c-src/emacs/src/gmalloc.c	/^_realloc_internal_nolock (void *ptr, size_t size)$/
++RE_BACKSLASH_ESCAPE_IN_LISTS	c-src/emacs/src/regex.h	47
++RE_BK_PLUS_QM	c-src/emacs/src/regex.h	52
++RECC_ALNUM	c-src/emacs/src/regex.h	610
++RECC_ALPHA	c-src/emacs/src/regex.h	610
++RECC_ASCII	c-src/emacs/src/regex.h	617
++RECC_BLANK	c-src/emacs/src/regex.h	615
++RECC_CNTRL	c-src/emacs/src/regex.h	613
++RECC_DIGIT	c-src/emacs/src/regex.h	614
++RECC_ERROR	c-src/emacs/src/regex.h	609
++RECC_GRAPH	c-src/emacs/src/regex.h	611
++RECC_LOWER	c-src/emacs/src/regex.h	612
++RECC_MULTIBYTE	c-src/emacs/src/regex.h	616
++RECC_NONASCII	c-src/emacs/src/regex.h	616
++RECC_PRINT	c-src/emacs/src/regex.h	611
++RECC_PUNCT	c-src/emacs/src/regex.h	613
++RECC_SPACE	c-src/emacs/src/regex.h	615
++RECC_UNIBYTE	c-src/emacs/src/regex.h	617
++RECC_UPPER	c-src/emacs/src/regex.h	612
++RECC_WORD	c-src/emacs/src/regex.h	610
++RECC_XDIGIT	c-src/emacs/src/regex.h	614
++recent_keys	c-src/emacs/src/keyboard.c	100
++recent-keys	c-src/emacs/src/keyboard.c	/^DEFUN ("recent-keys", Frecent_keys, Srecent_keys, /
++recent_keys_index	c-src/emacs/src/keyboard.c	94
++RE_CHAR_CLASSES	c-src/emacs/src/regex.h	58
++RE_CONTEXT_INDEP_ANCHORS	c-src/emacs/src/regex.h	72
++RE_CONTEXT_INDEP_OPS	c-src/emacs/src/regex.h	80
++RE_CONTEXT_INVALID_OPS	c-src/emacs/src/regex.h	84
++record_asynch_buffer_change	c-src/emacs/src/keyboard.c	/^record_asynch_buffer_change (void)$/
++record_auto_save	c-src/emacs/src/keyboard.c	/^record_auto_save (void)$/
++record_char	c-src/emacs/src/keyboard.c	/^record_char (Lisp_Object c)$/
++record_menu_key	c-src/emacs/src/keyboard.c	/^record_menu_key (Lisp_Object c)$/
++record_single_kboard_state	c-src/emacs/src/keyboard.c	/^record_single_kboard_state ()$/
++record_xmalloc	c-src/emacs/src/lisp.h	/^extern void *record_xmalloc (size_t) ATTRIBUTE_ALL/
++recover_top_level_message	c-src/emacs/src/keyboard.c	138
++Rectangle.getPos	lua-src/test.lua	/^function Rectangle.getPos ()$/
++recursion-depth	c-src/emacs/src/keyboard.c	/^DEFUN ("recursion-depth", Frecursion_depth, Srecur/
++recursive_edit_1	c-src/emacs/src/keyboard.c	/^recursive_edit_1 (void)$/
++recursive-edit	c-src/emacs/src/keyboard.c	/^DEFUN ("recursive-edit", Frecursive_edit, Srecursi/
++recursive_edit_unwind	c-src/emacs/src/keyboard.c	/^recursive_edit_unwind (Lisp_Object buffer)$/
++RED	cp-src/screen.hpp	16
++RE_DEBUG	c-src/emacs/src/regex.h	161
++redirect	c-src/emacs/src/lisp.h	663
++RE_DOT_NEWLINE	c-src/emacs/src/regex.h	88
++RE_DOT_NOT_NULL	c-src/emacs/src/regex.h	92
++reduce	prol-src/natded.prolog	/^reduce((X^M)@N,L):-     % beta reduction$/
++reduce_subterm	prol-src/natded.prolog	/^reduce_subterm(M,M2):-$/
++RE_DUP_MAX	c-src/emacs/src/regex.h	253
++RE_DUP_MAX	c-src/emacs/src/regex.h	256
++/ReEncode	ps-src/rfc1245.ps	/^\/ReEncode { $/
++refreshPort	pyt-src/server.py	/^    def refreshPort(self):$/
++RE_FRUGAL	c-src/emacs/src/regex.h	147
++\ref	tex-src/texinfo.tex	/^\\def\\ref#1{\\xrefX[#1,,,,,,,]}$/
++\refx	tex-src/texinfo.tex	/^\\def\\refx#1#2{%$/
++REG_BADBR	c-src/emacs/src/regex.h	313
++REG_BADPAT	c-src/emacs/src/regex.h	305
++REG_BADRPT	c-src/emacs/src/regex.h	316
++REG_EBRACE	c-src/emacs/src/regex.h	312
++REG_EBRACK	c-src/emacs/src/regex.h	310
++REG_ECOLLATE	c-src/emacs/src/regex.h	306
++REG_ECTYPE	c-src/emacs/src/regex.h	307
++REG_EEND	c-src/emacs/src/regex.h	319
++REG_EESCAPE	c-src/emacs/src/regex.h	308
++REG_ENOSYS	c.c	279
++REG_ENOSYS	c-src/emacs/src/regex.h	297
++REG_EPAREN	c-src/emacs/src/regex.h	311
++REG_ERANGE	c-src/emacs/src/regex.h	314
++REG_ERANGEX	c-src/emacs/src/regex.h	322
++REG_ERPAREN	c-src/emacs/src/regex.h	321
++reg_errcode_t	c.c	279
++reg_errcode_t	c-src/emacs/src/regex.h	323
++REG_ESIZE	c-src/emacs/src/regex.h	320
++REG_ESPACE	c-src/emacs/src/regex.h	315
++REG_ESUBREG	c-src/emacs/src/regex.h	309
++regex	c-src/etags.c	219
++regexfile	make-src/Makefile	/^regexfile: Makefile$/
++_REGEX_H	c-src/emacs/src/regex.h	21
++REGEX	make-src/Makefile	/^REGEX=\/[ \\t]*DEFVAR_[A-Z_ \\t\\n(]+"\\([^"]+\\)"\/$/
++REGEXOBJS	make-src/Makefile	/^REGEXOBJS=regex.o$/
++regex.o	make-src/Makefile	/^regex.o: emacs\/src\/regex.c$/
++regexp	c-src/etags.c	256
++regexp	c-src/etags.c	268
++regex_tag_multiline	c-src/etags.c	/^regex_tag_multiline (void)$/
++regex_t	c-src/emacs/src/regex.h	416
++REG_EXTENDED	c-src/emacs/src/regex.h	263
++REG_ICASE	c-src/emacs/src/regex.h	267
++registerAction	objcpp-src/SimpleCalc.M	/^- registerAction:(SEL)action$/
++register_heapinfo	c-src/emacs/src/gmalloc.c	/^register_heapinfo (void)$/
++regmatch_t	c-src/emacs/src/regex.h	451
++REG_NEWLINE	c-src/emacs/src/regex.h	272
++REG_NOERROR	c-src/emacs/src/regex.h	300
++REG_NOMATCH	c-src/emacs/src/regex.h	301
++REG_NOSUB	c-src/emacs/src/regex.h	276
++REG_NOTBOL	c-src/emacs/src/regex.h	286
++REG_NOTEOL	c-src/emacs/src/regex.h	289
++regoff_t	c-src/emacs/src/regex.h	423
++regs_allocated	c-src/emacs/src/regex.h	379
++regs	cp-src/screen.cpp	16
++regs	c-src/etags.c	263
++regset	c-src/h.h	31
++REGS_FIXED	c-src/emacs/src/regex.h	378
++REGS_REALLOCATE	c-src/emacs/src/regex.h	377
++REGS_UNALLOCATED	c-src/emacs/src/regex.h	376
++reg_syntax_t	c-src/emacs/src/regex.h	43
++regular_top_level_message	c-src/emacs/src/keyboard.c	143
++rehash_size	c-src/emacs/src/lisp.h	1835
++rehash_threshold	c-src/emacs/src/lisp.h	1839
++RE_HAT_LISTS_NOT_NEWLINE	c-src/emacs/src/regex.h	96
++RE_INTERVALS	c-src/emacs/src/regex.h	101
++re_iswctype	c-src/emacs/src/regex.h	602
++relative_filename	c-src/etags.c	/^relative_filename (char *file, char *dir)$/
++=\relax	tex-src/texinfo.tex	/^\\let\\appendix=\\relax$/
++=\relax	tex-src/texinfo.tex	/^\\let\\chapter=\\relax$/
++=\relax	tex-src/texinfo.tex	/^\\let\\section=\\relax$/
++=\relax	tex-src/texinfo.tex	/^\\let\\subsection=\\relax$/
++=\relax	tex-src/texinfo.tex	/^\\let\\subsubsection=\\relax$/
++release distrib	make-src/Makefile	/^release distrib: web$/
++RELEASELIST	make-src/Makefile	/^RELEASELIST=pot@gnu.org xemacs-review@xemacs.org j/
++ReleaseNameString	pas-src/common.pas	/^procedure ReleaseNameString; (* (var NSP: NameStri/
++RE_LIMITED_OPS	c-src/emacs/src/regex.h	105
++removeexp	prol-src/natded.prolog	/^removeexp(E,E,'NIL'):-!.$/
++RemoveLayer	lua-src/allegro.lua	/^function RemoveLayer ()$/
++RemoveUnderlineControl	pas-src/common.pas	/^function RemoveUnderlineControl; (*($/
++RE_NEWLINE_ALT	c-src/emacs/src/regex.h	109
++RE_NO_BK_BRACES	c-src/emacs/src/regex.h	114
++RE_NO_BK_PARENS	c-src/emacs/src/regex.h	118
++RE_NO_BK_REFS	c-src/emacs/src/regex.h	122
++RE_NO_BK_VBAR	c-src/emacs/src/regex.h	126
++RE_NO_EMPTY_RANGES	c-src/emacs/src/regex.h	132
++RE_NO_GNU_OPS	c-src/emacs/src/regex.h	144
++RE_NO_NEWLINE_ANCHOR	c-src/emacs/src/regex.h	153
++RE_NO_POSIX_BACKTRACKING	c-src/emacs/src/regex.h	140
++RE_NREGS	c-src/emacs/src/regex.h	440
++re_nsub	c-src/emacs/src/regex.h	364
++reorder_modifiers	c-src/emacs/src/keyboard.c	/^reorder_modifiers (Lisp_Object symbol)$/
++re_pattern_buffer	c-src/emacs/src/regex.h	335
++re_pattern_buffer	c-src/h.h	119
++ReprOfChar	pas-src/common.pas	/^function ReprOfChar; (*( ch : char) : NameString;*/
++__repr__	pyt-src/server.py	/^    def __repr__(self):$/
++request	c.c	/^request request (a, b)$/
++requeued_events_pending_p	c-src/emacs/src/keyboard.c	/^requeued_events_pending_p (void)$/
++required_argument	c-src/getopt.h	90
++require	merc-src/accumulator.m	/^:- import_module require.$/
++re_registers	c-src/emacs/src/regex.h	428
++\resetmathfonts	tex-src/texinfo.tex	/^\\def\\resetmathfonts{%$/
++reset-this-command-lengths	c-src/emacs/src/keyboard.c	/^DEFUN ("reset-this-command-lengths", Freset_this_c/
++RE_SHY_GROUPS	c-src/emacs/src/regex.h	150
++restore_getcjmp	c-src/emacs/src/keyboard.c	/^restore_getcjmp (sys_jmp_buf temp)$/
++restore_kboard_configuration	c-src/emacs/src/keyboard.c	/^restore_kboard_configuration (int was_locked)$/
++/restorematrix	ps-src/rfc1245.ps	/^\/restorematrix {$/
++_Restrict_arr_	c-src/emacs/src/regex.h	555
++_Restrict_arr_	c-src/emacs/src/regex.h	557
++_Restrict_	c-src/emacs/src/regex.h	540
++_Restrict_	c-src/emacs/src/regex.h	542
++_Restrict_	c-src/emacs/src/regex.h	544
++\result	tex-src/texinfo.tex	/^\\def\\result{\\leavevmode\\raise.15ex\\hbox to 1em{\\hf/
++\result	tex-src/texinfo.tex	/^\\def\\result{\\realbackslash result}$/
++RESUME_POLLING	c-src/emacs/src/keyboard.c	2170
++RE_SYNTAX_AWK	c-src/emacs/src/regex.h	186
++RE_SYNTAX_ED	c-src/emacs/src/regex.h	216
++RE_SYNTAX_EGREP	c-src/emacs/src/regex.h	206
++RE_SYNTAX_EMACS	c-src/emacs/src/regex.h	183
++RE_SYNTAX_GNU_AWK	c-src/emacs/src/regex.h	193
++RE_SYNTAX_GREP	c-src/emacs/src/regex.h	201
++RE_SYNTAX_POSIX_AWK	c-src/emacs/src/regex.h	197
++RE_SYNTAX_POSIX_BASIC	c-src/emacs/src/regex.h	225
++_RE_SYNTAX_POSIX_COMMON	c-src/emacs/src/regex.h	221
++RE_SYNTAX_POSIX_EGREP	c-src/emacs/src/regex.h	212
++RE_SYNTAX_POSIX_EXTENDED	c-src/emacs/src/regex.h	234
++RE_SYNTAX_POSIX_MINIMAL_BASIC	c-src/emacs/src/regex.h	231
++RE_SYNTAX_POSIX_MINIMAL_EXTENDED	c-src/emacs/src/regex.h	242
++RE_SYNTAX_SED	c-src/emacs/src/regex.h	218
++RE_TRANSLATE_TYPE	c-src/emacs/src/regex.h	332
++return_to_command_loop	c-src/emacs/src/keyboard.c	135
++RETURN_UNGCPRO	c-src/emacs/src/lisp.h	/^#define RETURN_UNGCPRO(expr)			\\$/
++RE_UNMATCHED_RIGHT_PAREN_ORD	c-src/emacs/src/regex.h	136
++reverse	prol-src/natded.prolog	/^reverse([],Ws,Ws).$/
++revert	objc-src/PackInsp.m	/^-revert:sender$/
++re_wchar_t	c-src/emacs/src/regex.h	600
++re_wchar_t	c-src/emacs/src/regex.h	623
++re_wctype	c-src/emacs/src/regex.h	601
++re_wctype_t	c-src/emacs/src/regex.h	599
++re_wctype_t	c-src/emacs/src/regex.h	618
++re_wctype_to_bit	c-src/emacs/src/regex.h	/^# define re_wctype_to_bit(cc) 0$/
++/RF	ps-src/rfc1245.ps	/^\/RF { $/
++right	c-src/etags.c	216
++right_shift	y-src/cccp.y	/^right_shift (a, b)$/
++ring1	c.c	241
++ring2	c.c	242
++rm_eo	c-src/emacs/src/regex.h	450
++rm_so	c-src/emacs/src/regex.h	449
++\rm	tex-src/texinfo.tex	/^\\def\\rm{\\realbackslash rm }%$/
++rng_base	cp-src/Range.h	79
++rng_inc	cp-src/Range.h	81
++rng_limit	cp-src/Range.h	80
++rng_nelem	cp-src/Range.h	83
++rosso	cp-src/c.C	40
++/R	ps-src/rfc1245.ps	/^\/R { $/
++/RR	ps-src/rfc1245.ps	/^\/RR { $/
++RSH	y-src/cccp.c	17
++rsyncfromfly	make-src/Makefile	/^rsyncfromfly:$/
++rsynctofly	make-src/Makefile	/^rsynctofly:$/
++RTE/s	ada-src/2ataspri.adb	/^   package RTE renames Interfaces.C.POSIX_RTE;$/
++\r	tex-src/texinfo.tex	/^\\def\\r##1{\\realbackslash r {##1}}%$/
++\r	tex-src/texinfo.tex	/^\\def\\r##1{\\realbackslash r {##1}}$/
++\r	tex-src/texinfo.tex	/^\\def\\r#1{{\\rm #1}}		% roman font$/
++rtint	c-src/h.h	60
++rtint	c-src/h.h	68
++rtstr	c-src/h.h	61
++rtstr	c-src/h.h	69
++rtunion_def	c-src/h.h	58
++rtunion_def	c-src/h.h	64
++rtx	c-src/h.h	62
++rtxnp	c-src/h.h	71
++rtxp	c-src/h.h	70
++`	ruby-src/test.rb	/^        def `(command)$/
+++	ruby-src/test.rb	/^        def +(y)$/
++<<	ruby-src/test.rb	/^        def <<(y)$/
++<=	ruby-src/test.rb	/^        def <=(y)$/
++<=>	ruby-src/test.rb	/^        def <=>(y)$/
++==	ruby-src/test.rb	/^        def ==(y)$/
++===	ruby-src/test.rb	/^        def ===(y)$/
++[]	ruby-src/test.rb	/^        def [](y)$/
++[]=	ruby-src/test.rb	/^        def []=(y, val)$/
++RUN	make-src/Makefile	/^RUN=$/
++RUN	make-src/Makefile	/^RUN=time --quiet --format '%U + %S: %E'$/
++RXINCLUDE	make-src/Makefile	/^RXINCLUDE=-Iemacs\/src$/
++s1	cp-src/c.C	32
++/s1	ps-src/rfc1245.ps	/^\/s1 1 string def$/
++s2	cp-src/c.C	35
++SAFE_ALLOCA	c-src/emacs/src/lisp.h	/^#define SAFE_ALLOCA(size) ((size) <= sa_avail				\\/
++SAFE_ALLOCA_LISP	c-src/emacs/src/lisp.h	/^#define SAFE_ALLOCA_LISP(buf, nelt)			       \\$/
++SAFE_ALLOCA_STRING	c-src/emacs/src/lisp.h	/^#define SAFE_ALLOCA_STRING(ptr, string)			\\$/
++SAFE_FREE	c-src/emacs/src/lisp.h	/^#define SAFE_FREE()			\\$/
++SAFE_NALLOCA	c-src/emacs/src/lisp.h	/^#define SAFE_NALLOCA(buf, multiplier, nitems)			 \\/
++safe_run_hook_funcall	c-src/emacs/src/keyboard.c	/^safe_run_hook_funcall (ptrdiff_t nargs, Lisp_Objec/
++safe_run_hooks_1	c-src/emacs/src/keyboard.c	/^safe_run_hooks_1 (ptrdiff_t nargs, Lisp_Object *ar/
++safe_run_hooks	c-src/emacs/src/keyboard.c	/^safe_run_hooks (Lisp_Object hook)$/
++safe_run_hooks_error	c-src/emacs/src/keyboard.c	/^safe_run_hooks_error (Lisp_Object error, ptrdiff_t/
++Sample	tex-src/gzip.texi	/^@node Sample, Invoking gzip, Overview, Top$/
++\samp	tex-src/texinfo.tex	/^\\def\\samp##1{\\realbackslash samp {##1}}%$/
++\samp	tex-src/texinfo.tex	/^\\def\\samp##1{\\realbackslash samp {##1}}$/
++\samp	tex-src/texinfo.tex	/^\\def\\samp #1{`\\tclose{#1}'\\null}$/
++/sangle	ps-src/rfc1245.ps	/^\/sangle 1 0 dmatrix defaultmatrix dtransform exch /
++SAVE_FUNCPOINTER	c-src/emacs/src/lisp.h	2049
++save_getcjmp	c-src/emacs/src/keyboard.c	/^save_getcjmp (sys_jmp_buf temp)$/
++SAVE_INTEGER	c-src/emacs/src/lisp.h	2048
++/savematrix	ps-src/rfc1245.ps	/^\/savematrix {$/
++savenstr	c-src/etags.c	/^savenstr (const char *cp, int len)$/
++SAVE_OBJECT	c-src/emacs/src/lisp.h	2051
++SAVE_POINTER	c-src/emacs/src/lisp.h	2050
++save	pyt-src/server.py	/^    def save(self):$/
++SAVE_SLOT_BITS	c-src/emacs/src/lisp.h	2055
++savestr	c-src/etags.c	/^savestr (const char *cp)$/
++SAVE_TYPE_BITS	c-src/emacs/src/lisp.h	2062
++SAVE_TYPE_BITS	c-src/emacs/src/lisp.h	2114
++SAVE_TYPE_BITS	c-src/emacs/src/lisp.h	2123
++save_type	c-src/emacs/src/lisp.h	/^save_type (struct Lisp_Save_Value *v, int n)$/
++SAVE_TYPE_FUNCPTR_PTR_OBJ	c-src/emacs/src/lisp.h	2076
++SAVE_TYPE_INT_INT	c-src/emacs/src/lisp.h	2066
++SAVE_TYPE_INT_INT_INT	c-src/emacs/src/lisp.h	2067
++SAVE_TYPE_MEMORY	c-src/emacs/src/lisp.h	2080
++SAVE_TYPE_OBJ_OBJ	c-src/emacs/src/lisp.h	2069
++SAVE_TYPE_OBJ_OBJ_OBJ	c-src/emacs/src/lisp.h	2070
++SAVE_TYPE_OBJ_OBJ_OBJ_OBJ	c-src/emacs/src/lisp.h	2071
++SAVE_TYPE_PTR_INT	c-src/emacs/src/lisp.h	2073
++SAVE_TYPE_PTR_OBJ	c-src/emacs/src/lisp.h	2074
++SAVE_TYPE_PTR_PTR	c-src/emacs/src/lisp.h	2075
++SAVE_UNUSED	c-src/emacs/src/lisp.h	2047
++SAVE_VALUEP	c-src/emacs/src/lisp.h	/^SAVE_VALUEP (Lisp_Object x)$/
++SAVE_VALUE_SLOTS	c-src/emacs/src/lisp.h	2058
++say	go-src/test.go	/^func say(msg string) {$/
++__sbrk	c-src/emacs/src/gmalloc.c	1513
++SBYTES	c-src/emacs/src/lisp.h	/^SBYTES (Lisp_Object string)$/
++scan_separators	c-src/etags.c	/^scan_separators (char *name)$/
++S	c.c	156
++SCHARS	c-src/emacs/src/lisp.h	/^SCHARS (Lisp_Object string)$/
++Scheme_functions	c-src/etags.c	/^Scheme_functions (FILE *inf)$/
++Scheme_help	c-src/etags.c	667
++Scheme_suffixes	c-src/etags.c	665
++scolonseen	c-src/etags.c	2447
++scratch	c-src/sysdep.h	56
++SCREEN_FP	cp-src/screen.hpp	/^#define SCREEN_FP(x,y) \\$/
++SCREEN_START	cp-src/screen.hpp	33
++scroll_bar_parts	c-src/emacs/src/keyboard.c	5189
++s	c-src/emacs/src/lisp.h	4672
++s	c-src/emacs/src/lisp.h	4678
++\sc	tex-src/texinfo.tex	/^\\def\\sc#1{{\\smallcaps#1}}	% smallcaps font$/
++SDATA	c-src/emacs/src/lisp.h	/^SDATA (Lisp_Object string)$/
++SDTrefGetInteger	pas-src/common.pas	/^function SDTrefGetInteger : integer;$/
++SDTrefIsEnd	pas-src/common.pas	/^function SDTrefIsEnd : Boolean;$/
++SDTrefRecToString	pas-src/common.pas	/^procedure SDTrefRecToString  (* ($/
++SDTrefSkipSpaces	pas-src/common.pas	/^procedure SDTrefSkipSpaces;$/
++SDTrefStringToRec	pas-src/common.pas	/^procedure SDTrefStringToRec (* ($/
++\seccheck	tex-src/texinfo.tex	/^\\def\\seccheck#1{\\if \\pageno<0 %$/
++\secentryfonts	tex-src/texinfo.tex	/^\\def\\secentryfonts{\\textfonts}$/
++\secentry	tex-src/texinfo.tex	/^      \\def\\secentry ##1##2##3##4{}$/
++\secentry	tex-src/texinfo.tex	/^\\def\\secentry#1#2#3#4{\\dosecentry{#2.#3\\labelspace/
++\secfonts	tex-src/texinfo.tex	/^\\def\\secfonts{%$/
++\secheadingbreak	tex-src/texinfo.tex	/^\\def\\secheadingbreak{\\dobreak \\secheadingskip {-10/
++\secheadingi	tex-src/texinfo.tex	/^\\def\\secheadingi #1{{\\advance \\secheadingskip by \\/
++\secheading	tex-src/texinfo.tex	/^\\def\\secheading #1#2#3{\\secheadingi {#2.#3\\enspace/
++\secondary	tex-src/texinfo.tex	/^\\def\\secondary #1#2{$/
++sec=\relax	tex-src/texinfo.tex	/^\\let\\appendixsec=\\relax$/
++section_href	perl-src/htlmify-cystic	/^sub section_href ($)$/
++section_name	perl-src/htlmify-cystic	12
++section_name	perl-src/htlmify-cystic	/^sub section_name ($)$/
++section	perl-src/htlmify-cystic	25
++section=\relax	tex-src/texinfo.tex	/^\\let\\appendixsection=\\relax$/
++section_toc	perl-src/htlmify-cystic	15
++section_url_base	perl-src/htlmify-cystic	/^sub section_url_base ()$/
++section_url_name	perl-src/htlmify-cystic	/^sub section_url_name ()$/
++section_url	perl-src/htlmify-cystic	/^sub section_url ()$/
++\seczzz	tex-src/texinfo.tex	/^\\def\\seczzz #1{\\seccheck{section}%$/
++select_last	prol-src/natded.prolog	/^select_last([X],X,[]).$/
++SelectLayer	lua-src/allegro.lua	/^function SelectLayer (layer)$/
++select	prol-src/natded.prolog	/^select(X,[X|Xs],Xs).$/
++select-tags-table	el-src/emacs/lisp/progmodes/etags.el	/^(defun select-tags-table ()$/
++select-tags-table-mode	el-src/emacs/lisp/progmodes/etags.el	/^(define-derived-mode select-tags-table-mode specia/
++select-tags-table-mode-map	el-src/emacs/lisp/progmodes/etags.el	/^(defvar select-tags-table-mode-map ; Doc string?$/
++select-tags-table-quit	el-src/emacs/lisp/progmodes/etags.el	/^(defun select-tags-table-quit ()$/
++select-tags-table-select	el-src/emacs/lisp/progmodes/etags.el	/^(defun select-tags-table-select (button)$/
++Self/f	ada-src/2ataspri.adb	/^   function Self return TCB_Ptr is$/
++Self/f	ada-src/2ataspri.ads	/^   function Self return TCB_Ptr;$/
++send	objc-src/Subprocess.m	/^- send:(const char *)string$/
++send	objc-src/Subprocess.m	/^- send:(const char *)string withNewline:(BOOL)want/
++separator_names	c-src/emacs/src/keyboard.c	7372
++serializeToVars	php-src/lce_functions.php	/^      function serializeToVars($prefix)$/
++ServerEdit	pyt-src/server.py	/^class ServerEdit(Frame):$/
++Server	pyt-src/server.py	/^class Server:$/
++set_base	cp-src/Range.h	/^  void set_base (double b) { rng_base = b;  }$/
++\setchapternewpage	tex-src/texinfo.tex	/^\\def\\setchapternewpage #1 {\\csname CHAPPAG#1\\endcs/
++\setchapterstyle	tex-src/texinfo.tex	/^\\def\\setchapterstyle #1 {\\csname CHAPF#1\\endcsname/
++set_char_table_contents	c-src/emacs/src/lisp.h	/^set_char_table_contents (Lisp_Object table, ptrdif/
++set_char_table_defalt	c-src/emacs/src/lisp.h	/^set_char_table_defalt (Lisp_Object table, Lisp_Obj/
++set_char_table_extras	c-src/emacs/src/lisp.h	/^set_char_table_extras (Lisp_Object table, ptrdiff_/
++set_char_table_purpose	c-src/emacs/src/lisp.h	/^set_char_table_purpose (Lisp_Object table, Lisp_Ob/
++set	cp-src/conway.hpp	/^    void set(void) { alive = 1; }$/
++setDate	cp-src/functions.cpp	/^void Date::setDate ( int d , int m , int y ){$/
++\setdeffont	tex-src/texinfo.tex	/^\\def\\setdeffont #1 {\\csname DEF#1\\endcsname}$/
++setDelegate	objc-src/Subprocess.m	/^- setDelegate:anObject$/
++\setfilename	tex-src/texinfo.tex	/^\\def\\setfilename{%$/
++set_hash_key_slot	c-src/emacs/src/lisp.h	/^set_hash_key_slot (struct Lisp_Hash_Table *h, ptrd/
++set_hash_value_slot	c-src/emacs/src/lisp.h	/^set_hash_value_slot (struct Lisp_Hash_Table *h, pt/
++set_inc	cp-src/Range.h	/^  void set_inc (double i) { rng_inc = i;   }$/
++set-input-interrupt-mode	c-src/emacs/src/keyboard.c	/^DEFUN ("set-input-interrupt-mode", Fset_input_inte/
++set-input-meta-mode	c-src/emacs/src/keyboard.c	/^DEFUN ("set-input-meta-mode", Fset_input_meta_mode/
++set-input-mode	c-src/emacs/src/keyboard.c	/^DEFUN ("set-input-mode", Fset_input_mode, Sset_inp/
++set_limit	cp-src/Range.h	/^  void set_limit (double l) { rng_limit = l; }$/
++/setmanualfeed	ps-src/rfc1245.ps	/^\/setmanualfeed {$/
++set	merc-src/accumulator.m	/^:- import_module set.$/
++set-output-flow-control	c-src/emacs/src/keyboard.c	/^DEFUN ("set-output-flow-control", Fset_output_flow/
++set_overlay_plist	c-src/emacs/src/lisp.h	/^set_overlay_plist (Lisp_Object overlay, Lisp_Objec/
++Set_Own_Priority/p	ada-src/2ataspri.adb	/^   procedure Set_Own_Priority (Prio : System.Any_P/
++Set_Own_Priority/p	ada-src/2ataspri.ads	/^   procedure Set_Own_Priority (Prio : System.Any_P/
++/setpapername	ps-src/rfc1245.ps	/^\/setpapername { $/
++/setpattern	ps-src/rfc1245.ps	/^\/setpattern {$/
++set_poll_suppress_count	c-src/emacs/src/keyboard.c	/^set_poll_suppress_count (int count)$/
++Set_Priority/p	ada-src/2ataspri.adb	/^   procedure Set_Priority$/
++Set_Priority/p	ada-src/2ataspri.ads	/^   procedure Set_Priority (T : TCB_Ptr; Prio : Sys/
++set_prop	c-src/emacs/src/keyboard.c	/^set_prop (ptrdiff_t idx, Lisp_Object val)$/
++SETPRT	f-src/entry.for	/^       ENTRY  SETPRT ( SHORT, EXPL, LONG, TRACE, D/
++SETPRT	f-src/entry.strange	/^       ENTRY  SETPRT ( SHORT, EXPL, LONG, TRACE, D/
++SETPRT	f-src/entry.strange_suffix	/^       ENTRY  SETPRT ( SHORT, EXPL, LONG, TRACE, D/
++set-quit-char	c-src/emacs/src/keyboard.c	/^DEFUN ("set-quit-char", Fset_quit_char, Sset_quit_/
++\setref	tex-src/texinfo.tex	/^\\def\\setref#1{%$/
++setref	tex-src/texinfo.tex	/^\\expandafter\\expandafter\\expandafter\\appendixsetre/
++setRevertButtonTitle	objc-src/PackInsp.m	/^-setRevertButtonTitle$/
++set_save_integer	c-src/emacs/src/lisp.h	/^set_save_integer (Lisp_Object obj, int n, ptrdiff_/
++set_save_pointer	c-src/emacs/src/lisp.h	/^set_save_pointer (Lisp_Object obj, int n, void *va/
++set_string_intervals	c-src/emacs/src/lisp.h	/^set_string_intervals (Lisp_Object s, INTERVAL i)$/
++set_sub_char_table_contents	c-src/emacs/src/lisp.h	/^set_sub_char_table_contents (Lisp_Object table, pt/
++SET_SYMBOL_BLV	c-src/emacs/src/lisp.h	/^SET_SYMBOL_BLV (struct Lisp_Symbol *sym, struct Li/
++set_symbol_function	c-src/emacs/src/lisp.h	/^set_symbol_function (Lisp_Object sym, Lisp_Object /
++SET_SYMBOL_FWD	c-src/emacs/src/lisp.h	/^SET_SYMBOL_FWD (struct Lisp_Symbol *sym, union Lis/
++set_symbol_next	c-src/emacs/src/lisp.h	/^set_symbol_next (Lisp_Object sym, struct Lisp_Symb/
++set_symbol_plist	c-src/emacs/src/lisp.h	/^set_symbol_plist (Lisp_Object sym, Lisp_Object pli/
++SET_SYMBOL_VAL	c-src/emacs/src/lisp.h	/^# define SET_SYMBOL_VAL(sym, v) lisp_h_SET_SYMBOL_/
++\set	tex-src/texinfo.tex	/^\\def\\set{\\parsearg\\setxxx}$/
++\settitle	tex-src/texinfo.tex	/^\\def\\settitle{\\parsearg\\settitlezzz}$/
++\settitlezzz	tex-src/texinfo.tex	/^\\def\\settitlezzz #1{\\gdef\\thistitle{#1}}$/
++setup	cp-src/c.C	5
++set_upto	merc-src/accumulator.m	/^:- func set_upto(accu_case, int) = set(accu_goal_i/
++set_waiting_for_input	c-src/emacs/src/keyboard.c	/^set_waiting_for_input (struct timespec *time_to_cl/
++\setxxx	tex-src/texinfo.tex	/^\\def\\setxxx #1{$/
++/SF	ps-src/rfc1245.ps	/^\/SF { $/
++\sf	tex-src/texinfo.tex	/^\\def\\sf{\\fam=\\sffam \\tensf}$/
++\sf	tex-src/texinfo.tex	/^\\def\\sf{\\realbackslash sf}%$/
++shift	cp-src/functions.cpp	/^void Date::shift ( void ){\/\/Shift this date to pre/
++\shortchapentry	tex-src/texinfo.tex	/^\\def\\shortchapentry#1#2#3{%$/
++\shortunnumberedentry	tex-src/texinfo.tex	/^\\def\\shortunnumberedentry#1#2{%$/
++should_attempt_accu_transform_2	merc-src/accumulator.m	/^:- pred should_attempt_accu_transform_2(module_inf/
++should_attempt_accu_transform	merc-src/accumulator.m	/^:- pred should_attempt_accu_transform(module_info:/
++shouldLoad	objc-src/PackInsp.m	/^-(BOOL)shouldLoad$/
++should_see_this_array_type	cp-src/c.C	156
++should_see_this_function_pointer	cp-src/c.C	153
++should_see_this_one_enclosed_in_extern_C	cp-src/c.C	149
++show	erl-src/gs_dialog.erl	/^show(Module, Title, Message, Args) ->$/
++showError	objc-src/Subprocess.m	/^showError (const char *errorString, id theDelegate/
++show_help_echo	c-src/emacs/src/keyboard.c	/^show_help_echo (Lisp_Object help, Lisp_Object wind/
++showInfo	objc-src/PackInsp.m	/^-showInfo:sender$/
++sig	c-src/emacs/src/keyboard.c	7238
++signal_handler1	c-src/h.h	83
++signal_handler	c-src/h.h	82
++signal_handler_t	c-src/h.h	94
++SimpleCalc	objcpp-src/SimpleCalc.H	/^@interface SimpleCalc:Object$/
++simulation	html-src/software.html	/^Software that I wrote for supporting my research a/
++\singlecodeindexer	tex-src/texinfo.tex	/^\\def\\singlecodeindexer #1{\\doind{\\indexname}{\\code/
++\singleindexer	tex-src/texinfo.tex	/^\\def\\singleindexer #1{\\doind{\\indexname}{#1}}$/
++single_kboard	c-src/emacs/src/keyboard.c	89
++single_kboard_state	c-src/emacs/src/keyboard.c	/^single_kboard_state ()$/
++SINGLE_LETTER_MOD	c-src/emacs/src/keyboard.c	6212
++SINGLE_LETTER_MOD	c-src/emacs/src/keyboard.c	6763
++SINGLE_LETTER_MOD	c-src/emacs/src/keyboard.c	/^#define SINGLE_LETTER_MOD(BIT)				\\$/
++\singlespace	tex-src/texinfo.tex	/^\\def\\singlespace{%$/
++site	cp-src/conway.hpp	5
++site	cp-src/conway.hpp	/^    site(int xi, int yi): x(xi), y(yi), alive(0) {/
++size	c-src/emacs/src/gmalloc.c	156
++size	c-src/emacs/src/gmalloc.c	163
++size	c-src/emacs/src/gmalloc.c	1862
++size	c-src/emacs/src/lisp.h	1364
++size	c-src/emacs/src/lisp.h	1390
++size	c-src/etags.c	236
++size	c-src/etags.c	2522
++SIZEFORMAT	objc-src/PackInsp.m	57
++skeyseen	c-src/etags.c	2445
++SkipBlanks	pas-src/common.pas	/^function SkipBlanks; (*($/
++SkipChars	pas-src/common.pas	/^function SkipChars; (*($/
++skip_name	c-src/etags.c	/^skip_name (char *cp)$/
++skip_non_spaces	c-src/etags.c	/^skip_non_spaces (char *cp)$/
++skip_spaces	c-src/etags.c	/^skip_spaces (char *cp)$/
++SkipSpaces	pas-src/common.pas	/^procedure SkipSpaces; (* (Str : NameString; var I /
++\sl	tex-src/texinfo.tex	/^\\def\\sl{\\realbackslash sl }%$/
++\smallbook	tex-src/texinfo.tex	/^\\def\\smallbook{$/
++\smalllispx	tex-src/texinfo.tex	/^\\def\\smalllispx{\\aboveenvbreak\\begingroup\\inENV$/
++\smartitalic	tex-src/texinfo.tex	/^\\def\\smartitalic#1{{\\sl #1}\\futurelet\\next\\smartit/
++=\smartitalic	tex-src/texinfo.tex	/^\\let\\cite=\\smartitalic$/
++\smartitalicx	tex-src/texinfo.tex	/^\\def\\smartitalicx{\\ifx\\next,\\else\\ifx\\next-\\else\\i/
++snarf-tag-function	el-src/emacs/lisp/progmodes/etags.el	/^(defvar snarf-tag-function nil$/
++snone	c-src/etags.c	2443
++solutions	merc-src/accumulator.m	/^:- import_module solutions.$/
++some_mouse_moved	c-src/emacs/src/keyboard.c	/^some_mouse_moved (void)$/
++#some-storage	forth-src/test-forth.fth	/^2000 buffer: #some-storage$/
++spacer	c-src/emacs/src/lisp.h	1975
++spacer	c-src/emacs/src/lisp.h	1982
++spacer	c-src/emacs/src/lisp.h	2036
++spacer	c-src/emacs/src/lisp.h	2205
++space	tex-src/texinfo.tex	/^    {#2\\labelspace #1}\\dotfill\\doshortpageno{#3}}%/
++space	tex-src/texinfo.tex	/^  \\dosubsubsecentry{#2.#3.#4.#5\\labelspace#1}{#6}}/
++specbinding	c-src/emacs/src/lisp.h	2955
++specbind_tag	c-src/emacs/src/lisp.h	2943
++specialsymbol	prol-src/natded.prolog	/^specialsymbol(C1,C2,S):-$/
++SPECPDL_BACKTRACE	c-src/emacs/src/lisp.h	2948
++SPECPDL_INDEX	c-src/emacs/src/lisp.h	/^SPECPDL_INDEX (void)$/
++SPECPDL_LET	c-src/emacs/src/lisp.h	2949
++SPECPDL_LET_DEFAULT	c-src/emacs/src/lisp.h	2952
++SPECPDL_LET_LOCAL	c-src/emacs/src/lisp.h	2951
++SPECPDL_UNWIND	c-src/emacs/src/lisp.h	2944
++SPECPDL_UNWIND_INT	c-src/emacs/src/lisp.h	2946
++SPECPDL_UNWIND_PTR	c-src/emacs/src/lisp.h	2945
++SPECPDL_UNWIND_VOID	c-src/emacs/src/lisp.h	2947
++splitexp	prol-src/natded.prolog	/^splitexp(E,E,('NIL','NIL')):-!.$/
++\splitoff	tex-src/texinfo.tex	/^\\def\\splitoff#1#2\\endmark{\\def\\first{#1}\\def\\rest{/
++/S	ps-src/rfc1245.ps	/^\/S { $/
++\sp	tex-src/texinfo.tex	/^\\def\\sp{\\parsearg\\spxxx}$/
++\spxxx	tex-src/texinfo.tex	/^\\def\\spxxx #1{\\par \\vskip #1\\baselineskip}$/
++Square.something:Bar	lua-src/test.lua	/^function Square.something:Bar ()$/
++srclist	make-src/Makefile	/^srclist: Makefile$/
++SRCS	make-src/Makefile	/^SRCS=Makefile ${ADASRC} ${ASRC} ${CSRC} ${CPSRC} $/
++SREF	c-src/emacs/src/lisp.h	/^SREF (Lisp_Object string, ptrdiff_t index)$/
++ss3	c.c	255
++SSDATA	c-src/emacs/src/lisp.h	/^SSDATA (Lisp_Object string)$/
++SSET	c-src/emacs/src/lisp.h	/^SSET (Lisp_Object string, ptrdiff_t index, unsigne/
++sss1	c.c	252
++sss2	c.c	253
++sstab	prol-src/natded.prolog	/^sstab(2,'C',',').$/
++stack	c.c	155
++STACK_CONS	c-src/emacs/src/lisp.h	/^#define STACK_CONS(a, b) \\$/
++stagseen	c-src/etags.c	2446
++standalone	make-src/Makefile	/^standalone:$/
++\startcontents	tex-src/texinfo.tex	/^\\def\\startcontents#1{%$/
++start	c-src/emacs/src/keyboard.c	8753
++start	c-src/emacs/src/lisp.h	2038
++start	c-src/emacs/src/regex.h	431
++StartDay	cp-src/functions.cpp	/^Date StartDay(Date a,int days){\/\/Function to calcu/
++\startenumeration	tex-src/texinfo.tex	/^\\def\\startenumeration#1{%$/
++start	php-src/lce_functions.php	/^      function start($line, $class)$/
++start_polling	c-src/emacs/src/keyboard.c	/^start_polling (void)$/
++=starts-with-equals!	scm-src/test.scm	/^(define =starts-with-equals! #t)$/
++start_up	prol-src/natded.prolog	/^start_up:-$/
++start	y-src/cccp.y	143
++STATE_ABORT	php-src/lce_functions.php	25
++STATE_COMPRESSD	objc-src/PackInsp.m	54
++STATE_INSTALLED	objc-src/PackInsp.m	53
++STATE_LOOP	php-src/lce_functions.php	27
++STATE_OK	php-src/lce_functions.php	26
++state_protected_p	c-src/emacs/src/gmalloc.c	400
++STAT_EQ	objc-src/PackInsp.m	/^#define STAT_EQ(s1, s2)	((s1)->st_ino == (s2)->st_/
++statetable	html-src/algrthms.html	/^Next$/
++STATE_UNINSTALLED	objc-src/PackInsp.m	52
++staticetags	make-src/Makefile	/^staticetags:$/
++st_C_attribute	c-src/etags.c	2209
++st_C_class	c-src/etags.c	2212
++st_C_define	c-src/etags.c	2213
++st_C_enum	c-src/etags.c	2213
++st_C_extern	c-src/etags.c	2213
++st_C_gnumacro	c-src/etags.c	2208
++st_C_ignore	c-src/etags.c	2209
++st_C_javastruct	c-src/etags.c	2210
++st_C_objend	c-src/etags.c	2207
++st_C_objimpl	c-src/etags.c	2207
++st_C_objprot	c-src/etags.c	2207
++st_C_operator	c-src/etags.c	2211
++st_C_struct	c-src/etags.c	2213
++st_C_template	c-src/etags.c	2212
++st_C_typedef	c-src/etags.c	2213
++STDIN	c-src/etags.c	408
++STDIN	c-src/etags.c	411
++step	cp-src/clheir.hpp	/^    virtual void step(void) { }$/
++step	cp-src/conway.hpp	/^    void step(void) { alive = next_alive; }$/
++step_everybody	cp-src/clheir.cpp	/^void step_everybody(void)$/
++st_none	c-src/etags.c	2206
++STOP_POLLING	c-src/emacs/src/keyboard.c	2166
++stop_polling	c-src/emacs/src/keyboard.c	/^stop_polling (void)$/
++stored_goal_plain_call	merc-src/accumulator.m	/^:- inst stored_goal_plain_call for goal_store.stor/
++store_info	merc-src/accumulator.m	/^:- type store_info$/
++store_user_signal_events	c-src/emacs/src/keyboard.c	/^store_user_signal_events (void)$/
++strcaseeq	c-src/etags.c	/^#define strcaseeq(s,t)	(assert ((s)!=NULL && (t)!=/
++streq	c-src/etags.c	/^#define streq(s,t)	(assert ((s)!=NULL || (t)!=NULL/
++str	go-src/test1.go	9
++STRING_BYTES_BOUND	c-src/emacs/src/lisp.h	1261
++STRING_BYTES	c-src/emacs/src/lisp.h	/^STRING_BYTES (struct Lisp_String *s)$/
++string_intervals	c-src/emacs/src/lisp.h	/^string_intervals (Lisp_Object s)$/
++string	merc-src/accumulator.m	/^:- import_module string.$/
++STRING_MULTIBYTE	c-src/emacs/src/lisp.h	/^STRING_MULTIBYTE (Lisp_Object str)$/
++STRING_SET_CHARS	c-src/emacs/src/lisp.h	/^STRING_SET_CHARS (Lisp_Object string, ptrdiff_t ne/
++STRING_SET_MULTIBYTE	c-src/emacs/src/lisp.h	/^#define STRING_SET_MULTIBYTE(STR)			\\$/
++STRING_SET_UNIBYTE	c-src/emacs/src/lisp.h	/^#define STRING_SET_UNIBYTE(STR)				\\$/
++stripLine	php-src/lce_functions.php	/^      function stripLine($line, $class)$/
++stripname	pas-src/common.pas	/^function stripname; (* ($/
++StripPath	pas-src/common.pas	/^function StripPath; (*($/
++strncaseeq	c-src/etags.c	/^#define strncaseeq(s,t,n) (assert ((s)!=NULL && (t/
++strneq	c-src/etags.c	/^#define strneq(s,t,n)	(assert ((s)!=NULL || (t)!=N/
++__str__	pyt-src/server.py	/^    def __str__(self):$/
++structdef	c-src/etags.c	2448
++stuff_buffered_input	c-src/emacs/src/keyboard.c	/^stuff_buffered_input (Lisp_Object stuffstring)$/
++SUB_CHAR_TABLE_OFFSET	c-src/emacs/src/lisp.h	1701
++SUB_CHAR_TABLE_P	c-src/emacs/src/lisp.h	/^SUB_CHAR_TABLE_P (Lisp_Object a)$/
++\subheading	tex-src/texinfo.tex	/^\\def\\subheading{\\parsearg\\subsecheadingi}$/
++subprocessDone	objc-src/PackInsp.m	/^-subprocessDone:(Subprocess *)sender$/
++subprocess	objc-src/PackInsp.m	/^-subprocess:(Subprocess *)sender output:(char *)bu/
++Subprocess	objc-src/Subprocess.h	41
++Subprocess	objc-src/Subprocess.h	/^@interface Subprocess:Object$/
++SUBRP	c-src/emacs/src/lisp.h	/^SUBRP (Lisp_Object a)$/
++\subsecentry	tex-src/texinfo.tex	/^      \\def\\subsecentry ##1##2##3##4##5{}$/
++\subsecentry	tex-src/texinfo.tex	/^\\def\\subsecentry#1#2#3#4#5{\\dosubsecentry{#2.#3.#4/
++\subsecfonts	tex-src/texinfo.tex	/^\\def\\subsecfonts{%$/
++\subsecheadingbreak	tex-src/texinfo.tex	/^\\def\\subsecheadingbreak{\\dobreak \\subsecheadingski/
++\subsecheadingi	tex-src/texinfo.tex	/^\\def\\subsecheadingi #1{{\\advance \\subsecheadingski/
++\subsecheading	tex-src/texinfo.tex	/^\\def\\subsecheading #1#2#3#4{\\subsecheadingi {#2.#3/
++subsec=\relax	tex-src/texinfo.tex	/^\\let\\appendixsubsec=\\relax$/
++subsection_marker	perl-src/htlmify-cystic	161
++subsection	perl-src/htlmify-cystic	26
++subsection=\relax	tex-src/texinfo.tex	/^\\let\\appendixsubsection=\\relax$/
++substitute	c-src/etags.c	/^substitute (char *in, char *out, struct re_registe/
++subst	prol-src/natded.prolog	/^subst(var(Y),var(X),M,N):-$/
++SubString	pas-src/common.pas	/^function SubString; (*($/
++\subsubheading	tex-src/texinfo.tex	/^\\def\\subsubheading{\\parsearg\\subsubsecheadingi}$/
++\subsubsecentry	tex-src/texinfo.tex	/^      \\def\\subsubsecentry ##1##2##3##4##5##6{}$/
++\subsubsecentry	tex-src/texinfo.tex	/^\\def\\subsubsecentry#1#2#3#4#5#6{%$/
++\subsubsecfonts	tex-src/texinfo.tex	/^\\def\\subsubsecfonts{\\subsecfonts} % Maybe this sho/
++\subsubsecheadingi	tex-src/texinfo.tex	/^\\def\\subsubsecheadingi #1{{\\advance \\subsecheading/
++\subsubsecheading	tex-src/texinfo.tex	/^\\def\\subsubsecheading #1#2#3#4#5{\\subsubsecheading/
++subsubsec=\relax	tex-src/texinfo.tex	/^\\let\\appendixsubsubsec=\\relax$/
++subsubsection	perl-src/htlmify-cystic	27
++subsubsection=\relax	tex-src/texinfo.tex	/^\\let\\appendixsubsubsection=\\relax$/
++\subtitlefont	tex-src/texinfo.tex	/^   \\def\\subtitlefont{\\subtitlerm \\normalbaselinesk/
++\subtitle	tex-src/texinfo.tex	/^   \\def\\subtitle{\\parsearg\\subtitlezzz}%$/
++\subtitlezzz	tex-src/texinfo.tex	/^   \\def\\subtitlezzz##1{{\\subtitlefont \\rightline{#/
++subtle	ruby-src/test1.ru	/^                 :tee ; attr_reader :subtle$/
++subtree	prol-src/natded.prolog	/^subtree(T,T).$/
++suffix	c-src/etags.c	186
++suffixes	c-src/etags.c	195
++suggest_asking_for_help	c-src/etags.c	/^suggest_asking_for_help (void)$/
++\summarycontents	tex-src/texinfo.tex	/^\\outer\\def\\summarycontents{%$/
++\supereject	tex-src/texinfo.tex	/^\\def\\supereject{\\par\\penalty -20000\\footnoteno =0 /
++suspend-emacs	c-src/emacs/src/keyboard.c	/^DEFUN ("suspend-emacs", Fsuspend_emacs, Ssuspend_e/
++sval	y-src/cccp.y	116
++swallow_events	c-src/emacs/src/keyboard.c	/^swallow_events (bool do_display)$/
++switch_line_buffers	c-src/etags.c	/^#define switch_line_buffers() (curndx = 1 - curndx/
++sxhash_combine	c-src/emacs/src/lisp.h	/^sxhash_combine (EMACS_UINT x, EMACS_UINT y)$/
++SXHASH_REDUCE	c-src/emacs/src/lisp.h	/^SXHASH_REDUCE (EMACS_UINT x)$/
++SYMBOL_BLV	c-src/emacs/src/lisp.h	/^SYMBOL_BLV (struct Lisp_Symbol *sym)$/
++SYMBOL_CONSTANT_P	c-src/emacs/src/lisp.h	/^# define SYMBOL_CONSTANT_P(sym) lisp_h_SYMBOL_CONS/
++symbol	c-src/emacs/src/lisp.h	2980
++SYMBOL_FORWARDED	c-src/emacs/src/lisp.h	651
++SYMBOL_FWD	c-src/emacs/src/lisp.h	/^SYMBOL_FWD (struct Lisp_Symbol *sym)$/
++SYMBOL_INDEX	c-src/emacs/src/lisp.h	/^#define SYMBOL_INDEX(sym) i##sym$/
++symbol_interned	c-src/emacs/src/lisp.h	639
++SYMBOL_INTERNED	c-src/emacs/src/lisp.h	642
++SYMBOL_INTERNED_IN_INITIAL_OBARRAY	c-src/emacs/src/lisp.h	643
++SYMBOL_INTERNED_IN_INITIAL_OBARRAY_P	c-src/emacs/src/lisp.h	/^SYMBOL_INTERNED_IN_INITIAL_OBARRAY_P (Lisp_Object /
++SYMBOL_INTERNED_P	c-src/emacs/src/lisp.h	/^SYMBOL_INTERNED_P (Lisp_Object sym)$/
++SYMBOL_LOCALIZED	c-src/emacs/src/lisp.h	650
++symbol_name	c-src/emacs/src/lisp.h	1687
++SYMBOL_NAME	c-src/emacs/src/lisp.h	/^SYMBOL_NAME (Lisp_Object sym)$/
++SYMBOLP	c-src/emacs/src/lisp.h	/^# define SYMBOLP(x) lisp_h_SYMBOLP (x)$/
++SYMBOL_PLAINVAL	c-src/emacs/src/lisp.h	648
++symbol_redirect	c-src/emacs/src/lisp.h	646
++SYMBOL_UNINTERNED	c-src/emacs/src/lisp.h	641
++SYMBOL_VAL	c-src/emacs/src/lisp.h	/^# define SYMBOL_VAL(sym) lisp_h_SYMBOL_VAL (sym)$/
++SYMBOL_VARALIAS	c-src/emacs/src/lisp.h	649
++syms_of_abbrev	c-src/abbrev.c	/^syms_of_abbrev ()$/
++syms_of_keyboard	c-src/emacs/src/keyboard.c	/^syms_of_keyboard (void)$/
++sym_type	c-src/etags.c	2204
++synchronize_system_messages_locale	c-src/emacs/src/lisp.h	/^INLINE void synchronize_system_messages_locale (vo/
++synchronize_system_time_locale	c-src/emacs/src/lisp.h	/^INLINE void synchronize_system_time_locale (void) /
++\syncodeindex	tex-src/texinfo.tex	/^\\def\\syncodeindex #1 #2 {%$/
++\synindex	tex-src/texinfo.tex	/^\\def\\synindex #1 #2 {%$/
++syntax	c-src/emacs/src/regex.h	350
++SYSCALL	c-src/machsyscalls.c	/^#define	SYSCALL(name, number, type, args, typed_ar/
++syscall_error	c-src/sysdep.h	34
++sys_jmp_buf	c-src/emacs/src/lisp.h	2906
++sys_jmp_buf	c-src/emacs/src/lisp.h	2910
++sys_jmp_buf	c-src/emacs/src/lisp.h	2916
++sys_longjmp	c-src/emacs/src/lisp.h	/^# define sys_longjmp(j, v) _longjmp (j, v)$/
++sys_longjmp	c-src/emacs/src/lisp.h	/^# define sys_longjmp(j, v) longjmp (j, v)$/
++sys_longjmp	c-src/emacs/src/lisp.h	/^# define sys_longjmp(j, v) siglongjmp (j, v)$/
++sys_setjmp	c-src/emacs/src/lisp.h	/^# define sys_setjmp(j) _setjmp (j)$/
++sys_setjmp	c-src/emacs/src/lisp.h	/^# define sys_setjmp(j) setjmp (j)$/
++sys_setjmp	c-src/emacs/src/lisp.h	/^# define sys_setjmp(j) sigsetjmp (j, 0)$/
++System.Task_Primitives/b	ada-src/2ataspri.adb	/^package body System.Task_Primitives is$/
++System.Task_Primitives/s	ada-src/2ataspri.ads	/^package System.Task_Primitives is$/
++t1	cp-src/c.C	34
++t2	cp-src/c.C	38
++T2	cp-src/fail.C	16
++T3	c.c	163
++tab_count_words	c-src/tab.c	/^int			tab_count_words(char **tab)$/
++tab_delete_first	c-src/tab.c	/^int			tab_delete_first(char **tab)$/
++tab_fill	c-src/tab.c	/^char			**tab_fill(char *str, char delim)$/
++tab_free	c-src/tab.c	/^void			tab_free(char **tab)$/
++\table	tex-src/texinfo.tex	/^\\def\\table{\\begingroup\\inENV\\obeylines\\obeyspaces\\/
++\tablez	tex-src/texinfo.tex	/^\\def\\tablez #1#2#3#4#5#6{%$/
++tag1	c-src/dostorture.c	/^(*tag1 (sig, handler)) ()$/
++tag1	c-src/h.h	110
++tag1	c-src/torture.c	/^(*tag1 (sig, handler)) ()$/
++tag2	c-src/dostorture.c	/^(*tag2 (sig, handler)) ()$/
++tag2	c-src/torture.c	/^(*tag2 (sig, handler)) ()$/
++tag3	c-src/dostorture.c	/^(*tag3 (int sig, void (*handler) (int))) (int)$/
++tag3	c-src/torture.c	/^(*tag3 (int sig, void (*handler) (int))) (int)$/
++tag4	c-src/dostorture.c	/^(*tag4 (int sig, void (*handler) (int))) (int)$/
++tag4	c-src/torture.c	/^(*tag4 (int sig, void (*handler) (int))) (int)$/
++tag5	c-src/dostorture.c	/^tag5 (handler, arg)$/
++tag5	c-src/torture.c	/^tag5 (handler, arg)$/
++tag6	c-src/dostorture.c	/^tag6 (void (*handler) (void *), void *arg)$/
++tag6	c-src/torture.c	/^tag6 (void (*handler) (void *), void *arg)$/
++tag-any-match-p	el-src/emacs/lisp/progmodes/etags.el	/^(defun tag-any-match-p (_tag)$/
++tag-exact-file-name-match-p	el-src/emacs/lisp/progmodes/etags.el	/^(defun tag-exact-file-name-match-p (tag)$/
++tag-exact-match-p	el-src/emacs/lisp/progmodes/etags.el	/^(defun tag-exact-match-p (tag)$/
++tag-file-name-match-p	el-src/emacs/lisp/progmodes/etags.el	/^(defun tag-file-name-match-p (tag)$/
++tag-find-file-of-tag	el-src/emacs/lisp/progmodes/etags.el	/^(defun tag-find-file-of-tag (file) ; Doc string?$/
++tag-find-file-of-tag-noselect	el-src/emacs/lisp/progmodes/etags.el	/^(defun tag-find-file-of-tag-noselect (file)$/
++taggedfname	c-src/etags.c	207
++tag-implicit-name-match-p	el-src/emacs/lisp/progmodes/etags.el	/^(defun tag-implicit-name-match-p (tag)$/
++tag-lines-already-matched	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tag-lines-already-matched nil$/
++tag_or_ch	c-src/emacs/src/lisp.h	3026
++tag-partial-file-name-match-p	el-src/emacs/lisp/progmodes/etags.el	/^(defun tag-partial-file-name-match-p (_tag)$/
++TAG_PTR	c-src/emacs/src/lisp.h	/^#define TAG_PTR(tag, ptr) \\$/
++tag-re-match-p	el-src/emacs/lisp/progmodes/etags.el	/^(defun tag-re-match-p (re)$/
++tags-add-tables	el-src/emacs/lisp/progmodes/etags.el	/^(defcustom tags-add-tables 'ask-user$/
++tags-apropos-additional-actions	el-src/emacs/lisp/progmodes/etags.el	/^(defcustom tags-apropos-additional-actions nil$/
++tags-apropos	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-apropos (regexp)$/
++tags-apropos-function	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-apropos-function nil$/
++tags-apropos-verbose	el-src/emacs/lisp/progmodes/etags.el	/^(defcustom tags-apropos-verbose nil$/
++tags-case-fold-search	el-src/emacs/lisp/progmodes/etags.el	/^(defcustom tags-case-fold-search 'default$/
++tags-complete-tags-table-file	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-complete-tags-table-file (string predi/
++tags-completion-at-point-function	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-completion-at-point-function ()$/
++tags-completion-table	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-completion-table ()$/
++tags-completion-table	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-completion-table nil$/
++tags-completion-table-function	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-completion-table-function nil$/
++tags-compression-info-list	el-src/emacs/lisp/progmodes/etags.el	/^(defcustom tags-compression-info-list$/
++tags-expand-table-name	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-expand-table-name (file)$/
++tags-file-name	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-file-name nil$/
++tags-included-tables	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-included-tables ()$/
++tags-included-tables	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-included-tables nil$/
++tags-included-tables-function	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-included-tables-function nil$/
++tags-lazy-completion-table	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-lazy-completion-table ()$/
++tags-location-ring	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-location-ring (make-ring xref-marker-/
++tags-loop-continue	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-loop-continue (&optional first-time)$/
++tags-loop-eval	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-loop-eval (form)$/
++tags-loop-operate	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-loop-operate nil$/
++tags-loop-revert-buffers	el-src/emacs/lisp/progmodes/etags.el	/^(defcustom tags-loop-revert-buffers nil$/
++tags-loop-scan	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-loop-scan$/
++TAGS	make-src/Makefile	/^TAGS: etags.c$/
++tags	make-src/Makefile	/^tags: TAGS$/
++tags-next-table	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-next-table ()$/
++tags-query-replace	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-query-replace (from to &optional delim/
++tags-recognize-empty-tags-table	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-recognize-empty-tags-table ()$/
++tags-reset-tags-tables	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-reset-tags-tables ()$/
++tags-revert-without-query	el-src/emacs/lisp/progmodes/etags.el	/^(defcustom tags-revert-without-query nil$/
++tags-search	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-search (regexp &optional file-list-for/
++tags-select-tags-table	el-src/emacs/lisp/progmodes/etags.el	/^(define-button-type 'tags-select-tags-table$/
++tags-table-check-computed-list	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-table-check-computed-list ()$/
++tags-table-computed-list	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-table-computed-list nil$/
++tags-table-computed-list-for	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-table-computed-list-for nil$/
++tags-table-extend-computed-list	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-table-extend-computed-list ()$/
++tags-table-files	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-table-files ()$/
++tags-table-files	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-table-files nil$/
++tags-table-files-function	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-table-files-function nil$/
++tags-table-format-functions	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-table-format-functions '(etags-recogn/
++tags-table-including	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-table-including (this-file core-only)$/
++tags-table-list	el-src/emacs/lisp/progmodes/etags.el	/^(defcustom tags-table-list nil$/
++tags-table-list-member	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-table-list-member (file list)$/
++tags-table-list-pointer	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-table-list-pointer nil$/
++tags-table-list-started-at	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-table-list-started-at nil$/
++tags-table-mode	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-table-mode ()$/
++tags-table-set-list	el-src/emacs/lisp/progmodes/etags.el	/^(defvar tags-table-set-list nil$/
++tags-tag-face	el-src/emacs/lisp/progmodes/etags.el	/^(defcustom tags-tag-face 'default$/
++tags-verify-table	el-src/emacs/lisp/progmodes/etags.el	/^(defun tags-verify-table (file)$/
++tags-with-face	el-src/emacs/lisp/progmodes/etags.el	/^(defmacro tags-with-face (face &rest body)$/
++tag-symbol-match-p	el-src/emacs/lisp/progmodes/etags.el	/^(defun tag-symbol-match-p (tag)$/
++TAG_SYMOFFSET	c-src/emacs/src/lisp.h	/^#define TAG_SYMOFFSET(offset)				    \\$/
++tag-word-match-p	el-src/emacs/lisp/progmodes/etags.el	/^(defun tag-word-match-p (tag)$/
++Tapes	tex-src/gzip.texi	/^@node Tapes, Problems, Environment, Top$/
++target_multibyte	c-src/emacs/src/regex.h	407
++TAS_Cell/t	ada-src/2ataspri.ads	/^   type TAS_Cell is$/
++TAS_Cell/t	ada-src/2ataspri.ads	/^   type TAS_Cell is private;$/
++Task_Control_Block/t	ada-src/2ataspri.ads	/^   type Task_Control_Block is record$/
++Task_Storage_Size/t	ada-src/2ataspri.ads	/^   type Task_Storage_Size is new Interfaces.C.size/
++Task_Type/b	ada-src/etags-test-for.ada	/^  task body Task_Type is$/
++Task_Type/b	ada-src/waroquiers.ada	/^  task body Task_Type is$/
++Task_Type/k	ada-src/etags-test-for.ada	/^  task type Task_Type is$/
++Task_Type/k	ada-src/waroquiers.ada	/^  task type Task_Type is$/
++TCB_Ptr/t	ada-src/2ataspri.ads	/^   type TCB_Ptr is access all Task_Control_Block;$/
++TCLFLAGS	make-src/Makefile	/^TCLFLAGS=--lang=none --regex='\/proc[ \\t]+\\([^ \\t]+/
++\tclose	tex-src/texinfo.tex	/^\\def\\tclose##1{\\realbackslash tclose {##1}}%$/
++\tclose	tex-src/texinfo.tex	/^\\def\\tclose##1{\\realbackslash tclose {##1}}$/
++\tclose	tex-src/texinfo.tex	/^\\def\\tclose#1{{\\rm \\tcloserm=\\fontdimen2\\font \\tt /
++tcpdump	html-src/software.html	/^tcpdump$/
++t	cp-src/c.C	52
++T	cp-src/fail.C	14
++teats	cp-src/c.C	127
++tee	ruby-src/test1.ru	/^    attr_accessor :tee$/
++tee=	ruby-src/test1.ru	/^    attr_accessor :tee$/
++temporarily_switch_to_single_kboard	c-src/emacs/src/keyboard.c	/^temporarily_switch_to_single_kboard (struct frame /
++tend	c-src/etags.c	2432
++TERMINALP	c-src/emacs/src/lisp.h	/^TERMINALP (Lisp_Object a)$/
++terminateInput	objc-src/Subprocess.m	/^- terminateInput$/
++terminate	objc-src/Subprocess.m	/^- terminate:sender$/
++term	merc-src/accumulator.m	/^:- import_module term.$/
++test1	rs-src/test.rs	/^fn test1() {$/
++Test_Abort/p	ada-src/2ataspri.adb	/^   procedure Test_Abort is$/
++Test_Abort/p	ada-src/2ataspri.ads	/^   procedure Test_Abort;$/
++Test_And_Set/p	ada-src/2ataspri.adb	/^   procedure Test_And_Set (Cell : in out TAS_Cell;/
++Test_And_Set/p	ada-src/2ataspri.ads	/^   procedure Test_And_Set (Cell : in out TAS_Cell;/
++test-begin	scm-src/test.scm	/^(define-syntax test-begin$/
++test	cp-src/c.C	86
++test	c-src/emacs/src/lisp.h	1871
++test	erl-src/gs_dialog.erl	/^test() ->$/
++test	go-src/test1.go	/^func test(p plus) {$/
++test	make-src/Makefile	/^test:$/
++test.me_22a	lua-src/test.lua	/^   function test.me_22a(one, two)$/
++test.me22b	lua-src/test.lua	/^   local function test.me22b (one)$/
++TEST	php-src/ptest.php	1
++test	php-src/ptest.php	/^test $/
++test_undefined	c-src/emacs/src/keyboard.c	/^test_undefined (Lisp_Object binding)$/
++TEX_clgrp	c-src/etags.c	4922
++TeX_commands	c-src/etags.c	/^TeX_commands (FILE *inf)$/
++TEX_decode_env	c-src/etags.c	/^TEX_decode_env (const char *evarname, const char */
++TEX_defenv	c-src/etags.c	4912
++TEX_esc	c-src/etags.c	4920
++TeX_help	c-src/etags.c	674
++Texinfo_help	c-src/etags.c	688
++Texinfo_nodes	c-src/etags.c	/^Texinfo_nodes (FILE *inf)$/
++Texinfo_suffixes	c-src/etags.c	686
++\texinfoversion	tex-src/texinfo.tex	/^\\def\\texinfoversion{2.73}$/
++TEX_LESC	c-src/etags.c	4986
++TEX_mode	c-src/etags.c	/^TEX_mode (FILE *inf)$/
++TEX_opgrp	c-src/etags.c	4921
++TEX_SESC	c-src/etags.c	4987
++TEXSRC	make-src/Makefile	/^TEXSRC=testenv.tex gzip.texi texinfo.tex nonewline/
++\'	tex-src/texinfo.tex	/^\\def\\'{{'}}$/
++\@	tex-src/texinfo.tex	/^\\def\\@{@}%$/
++\`	tex-src/texinfo.tex	/^\\def\\`{{`}}$/
++\	tex-src/texinfo.tex	/^\\def\\ {{\\fontdimen2\\font=\\tclosesave{} }}%$/
++\*	tex-src/texinfo.tex	/^\\def\\*{\\hfil\\break\\hbox{}\\ignorespaces}$/
++_	tex-src/texinfo.tex	/^\\def_{\\ifusingtt\\normalunderscore\\_}$/
++\_	tex-src/texinfo.tex	/^\\def\\_{\\lvvmode \\kern.06em \\vbox{\\hrule width.3em /
++\_	tex-src/texinfo.tex	/^\\def\\_{{\\realbackslash _}}%$/
++\:	tex-src/texinfo.tex	/^\\def\\:{\\spacefactor=1000 }$/
++\.	tex-src/texinfo.tex	/^\\def\\.{.\\spacefactor=3000 }$/
++\@	tex-src/texinfo.tex	/^\\def\\@{{\\tt \\char '100}}$/
++|	tex-src/texinfo.tex	/^\\def|{{\\tt \\char '174}}$/
++~	tex-src/texinfo.tex	/^\\def~{{\\tt \\char '176}}$/
+++	tex-src/texinfo.tex	/^\\def+{{\\tt \\char 43}}$/
++>	tex-src/texinfo.tex	/^\\def>{{\\tt \\gtr}}$/
++^	tex-src/texinfo.tex	/^\\def^{{\\tt \\hat}}$/
++<	tex-src/texinfo.tex	/^\\def<{{\\tt \\less}}$/
++\	tex-src/texinfo.tex	/^\\gdef\\sepspaces{\\def {\\ }}}$/
++=	tex-src/texinfo.tex	/^\\global\\def={{\\tt \\char 61}}}$/
++=	tex-src/texinfo.tex	/^\\global\\let\\section = \\appendixsec$/
++=	tex-src/texinfo.tex	/^\\global\\let\\section = \\numberedsec$/
++=	tex-src/texinfo.tex	/^\\global\\let\\section = \\unnumberedsec$/
++=	tex-src/texinfo.tex	/^\\global\\let\\subsection = \\appendixsubsec$/
++=	tex-src/texinfo.tex	/^\\global\\let\\subsection = \\numberedsubsec$/
++=	tex-src/texinfo.tex	/^\\global\\let\\subsection = \\unnumberedsubsec$/
++=	tex-src/texinfo.tex	/^\\global\\let\\subsubsection = \\appendixsubsubsec$/
++=	tex-src/texinfo.tex	/^\\global\\let\\subsubsection = \\numberedsubsubsec$/
++=	tex-src/texinfo.tex	/^\\global\\let\\subsubsection = \\unnumberedsubsubsec$/
++TeX_suffixes	c-src/etags.c	672
++\tex	tex-src/texinfo.tex	/^\\def\\tex{\\begingroup$/
++\TeX	tex-src/texinfo.tex	/^\\def\\TeX{\\realbackslash TeX}%$/
++\TeX	tex-src/texinfo.tex	/^\\def\\TeX{\\realbackslash TeX}$/
++\textfonts	tex-src/texinfo.tex	/^\\def\\textfonts{%$/
++TEX_toktab	c-src/etags.c	4908
++texttreelist	prol-src/natded.prolog	/^texttreelist([]).$/
++/TF	ps-src/rfc1245.ps	/^\/TF { $/
++\thearg	tex-src/texinfo.tex	/^  \\def\\thearg{#1}%$/
++\thearg	tex-src/texinfo.tex	/^  \\ifx\\thearg\\empty \\def\\thearg{1}\\fi$/
++there-is-a-=-in-the-middle!	scm-src/test.scm	/^(define (there-is-a-=-in-the-middle!) #t)$/
++\thischaptername	tex-src/texinfo.tex	/^\\def\\thischaptername{No Chapter Title}$/
++\thischapter	tex-src/texinfo.tex	/^\\def\\thischapter{} \\def\\thissection{}$/
++\thischapter	tex-src/texinfo.tex	/^   \\unnumbchapmacro{#1}\\def\\thischapter{}%$/
++this_command_key_count	c-src/emacs/src/keyboard.c	108
++this_command_key_count_reset	c-src/emacs/src/keyboard.c	112
++this_command_keys	c-src/emacs/src/keyboard.c	107
++this-command-keys	c-src/emacs/src/keyboard.c	/^DEFUN ("this-command-keys", Fthis_command_keys, St/
++this-command-keys-vector	c-src/emacs/src/keyboard.c	/^DEFUN ("this-command-keys-vector", Fthis_command_k/
++this	c-src/a/b/b.c	1
++\thisfile	tex-src/texinfo.tex	/^\\def\\thisfile{}$/
++this_file_toc	perl-src/htlmify-cystic	29
++this-single-command-keys	c-src/emacs/src/keyboard.c	/^DEFUN ("this-single-command-keys", Fthis_single_co/
++this_single_command_key_start	c-src/emacs/src/keyboard.c	125
++this-single-command-raw-keys	c-src/emacs/src/keyboard.c	/^DEFUN ("this-single-command-raw-keys", Fthis_singl/
++\thistitle	tex-src/texinfo.tex	/^\\def\\thistitle{No Title}$/
++\tie	tex-src/texinfo.tex	/^\\def\\tie{\\penalty 10000\\ }     % Save plain tex de/
++tignore	c-src/etags.c	2433
++timer_check_2	c-src/emacs/src/keyboard.c	/^timer_check_2 (Lisp_Object timers, Lisp_Object idl/
++timer_check	c-src/emacs/src/keyboard.c	/^timer_check (void)$/
++timer_idleness_start_time	c-src/emacs/src/keyboard.c	335
++timer_last_idleness_start_time	c-src/emacs/src/keyboard.c	340
++timer_resume_idle	c-src/emacs/src/keyboard.c	/^timer_resume_idle (void)$/
++timers_run	c-src/emacs/src/keyboard.c	320
++timer_start_idle	c-src/emacs/src/keyboard.c	/^timer_start_idle (void)$/
++timer_stop_idle	c-src/emacs/src/keyboard.c	/^timer_stop_idle (void)$/
++Time_to_position	c-src/emacs/src/keyboard.c	/^Time_to_position (Time encoded_pos)$/
++tinbody	c-src/etags.c	2431
++\tindex	tex-src/texinfo.tex	/^\\def\\tindex {\\tpindex}$/
++\titlefont	tex-src/texinfo.tex	/^\\def\\titlefont#1{{\\titlerm #1}}$/
++\titlepage	tex-src/texinfo.tex	/^\\def\\titlepage{\\begingroup \\parindent=0pt \\textfon/
++\title	tex-src/texinfo.tex	/^   \\def\\title{\\parsearg\\titlezzz}%$/
++\titlezzz	tex-src/texinfo.tex	/^   \\def\\titlezzz##1{\\leftline{\\titlefont{##1}}$/
++tkeyseen	c-src/etags.c	2429
++tnone	c-src/etags.c	2428
++toc_line	perl-src/htlmify-cystic	/^sub toc_line ($)$/
++\today	tex-src/texinfo.tex	/^\\def\\today{\\number\\day\\space$/
++toggleDescription	objc-src/PackInsp.m	/^-toggleDescription$/
++tok	c-src/etags.c	2491
++token	c-src/etags.c	2508
++tokenizeatom	prol-src/natded.prolog	/^tokenizeatom(Atom,Ws):-$/
++tokenize	prol-src/natded.prolog	/^tokenize([C1,C2,C3|Cs],Xs-Ys,TsResult):-     % spe/
++tokentab2	y-src/cccp.y	442
++token	y-src/cccp.y	437
++token	y-src/cccp.y	439
++To_Lower	pas-src/common.pas	/^function To_Lower;(*(ch:char) : char;*)$/
++tool_bar_item_properties	c-src/emacs/src/keyboard.c	7970
++tool_bar_items	c-src/emacs/src/keyboard.c	/^tool_bar_items (Lisp_Object reuse, int *nitems)$/
++tool_bar_items_vector	c-src/emacs/src/keyboard.c	7965
++toolkit_menubar_in_use	c-src/emacs/src/keyboard.c	/^toolkit_menubar_in_use (struct frame *f)$/
++top_level_1	c-src/emacs/src/keyboard.c	/^top_level_1 (Lisp_Object ignore)$/
++top_level_2	c-src/emacs/src/keyboard.c	/^top_level_2 (void)$/
++top-level	c-src/emacs/src/keyboard.c	/^DEFUN ("top-level", Ftop_level, Stop_level, 0, 0, /
++top_level	merc-src/accumulator.m	/^:- type top_level$/
++Top	tex-src/gzip.texi	/^@node Top, , , (dir)$/
++\top	tex-src/texinfo.tex	/^\\outer\\def\\top{\\parsearg\\unnumberedzzz}$/
++To_Start_Addr/f	ada-src/2ataspri.adb	/^      function To_Start_Addr is new$/
++total_keys	c-src/emacs/src/keyboard.c	97
++TOTAL_KEYWORDS	c-src/etags.c	2325
++totally_unblock_input	c-src/emacs/src/keyboard.c	/^totally_unblock_input (void)$/
++total_size_of_entries	c-src/etags.c	/^total_size_of_entries (register node *np)$/
++total_surrounding	cp-src/conway.cpp	/^int site::total_surrounding(void)$/
++To_TCB_Ptr/f	ada-src/2ataspri.adb	/^   function To_TCB_Ptr is new$/
++To_Upper	pas-src/common.pas	/^function To_Upper;(*(ch:char) : char;*)$/
++To_void_ptr/f	ada-src/2ataspri.adb	/^   function To_void_ptr is new$/
++tpcmd	c-src/h.h	15
++tpcmd	c-src/h.h	8
++/T	ps-src/rfc1245.ps	/^\/T { $/
++tracking_off	c-src/emacs/src/keyboard.c	/^tracking_off (Lisp_Object old_value)$/
++track-mouse	c-src/emacs/src/keyboard.c	/^DEFUN ("internal--track-mouse", Ftrack_mouse, Stra/
++traffic_light	cp-src/conway.cpp	/^void traffic_light(int x, int y)$/
++translate	c-src/emacs/src/regex.h	361
++treats	cp-src/c.C	131
++Truc.Bidule/b	ada-src/etags-test-for.ada	/^package body Truc.Bidule is$/
++Truc.Bidule/b	ada-src/waroquiers.ada	/^package body Truc.Bidule is$/
++Truc.Bidule/s	ada-src/etags-test-for.ada	/^package Truc.Bidule is$/
++Truc.Bidule/s	ada-src/waroquiers.ada	/^package Truc.Bidule is$/
++Truc/s	ada-src/etags-test-for.ada	/^package Truc is$/
++Truc/s	ada-src/waroquiers.ada	/^package Truc is$/
++TSL/s	ada-src/2ataspri.adb	/^   package TSL renames System.Tasking_Soft_Links;$/
++tt=cmtt10	tex-src/texinfo.tex	/^\\font\\deftt=cmtt10 scaled \\magstep1$/
++\t	tex-src/texinfo.tex	/^\\def\\t##1{\\realbackslash r {##1}}%$/
++\t	tex-src/texinfo.tex	/^\\def\\t#1{{\\tt \\exhyphenpenalty=10000\\rawbackslash /
++tt	prol-src/natded.prolog	/^tt:-$/
++\tt	tex-src/texinfo.tex	/^\\def\\tt{\\realbackslash tt}%$/
++\tt	tex-src/texinfo.tex	/^\\def\\tt{\\realbackslash tt}$/
++ttypeseen	c-src/etags.c	2430
++tty_read_avail_input	c-src/emacs/src/keyboard.c	/^tty_read_avail_input (struct terminal *terminal,$/
++\turnoffactive	tex-src/texinfo.tex	/^\\def\\turnoffactive{\\let"=\\normaldoublequote$/
++/two	ps-src/rfc1245.ps	/^\/two \/three \/four \/five \/six \/seven \/eight \/nine \//
++typdef	c-src/etags.c	2434
++type	c-src/emacs/src/gmalloc.c	145
++type	c-src/emacs/src/lisp.h	1973
++type	c-src/emacs/src/lisp.h	1980
++type	c-src/emacs/src/lisp.h	2034
++type	c-src/emacs/src/lisp.h	2112
++type	c-src/emacs/src/lisp.h	2203
++type	c-src/emacs/src/lisp.h	2276
++type	c-src/emacs/src/lisp.h	2286
++type	c-src/emacs/src/lisp.h	2296
++type	c-src/emacs/src/lisp.h	2304
++type	c-src/emacs/src/lisp.h	2364
++type	c-src/emacs/src/lisp.h	3025
++type	c-src/etags.c	2271
++typefunargs	tex-src/texinfo.tex	/^\\deftypefunargs {#3}\\endgroup %$/
++typefunargs	tex-src/texinfo.tex	/^\\deftypefunargs {#4}\\endgroup %$/
++typemargin	tex-src/texinfo.tex	/^\\newskip\\deftypemargin \\deftypemargin=12pt$/
++typemargin	tex-src/texinfo.tex	/^\\rlap{\\rightline{{\\rm #2}\\hskip \\deftypemargin}}}%/
++TYPE_RANGED_INTEGERP	c-src/emacs/src/lisp.h	/^#define TYPE_RANGED_INTEGERP(type, x) \\$/
++Type_Specific_Data/t	ada-src/etags-test-for.ada	/^   type Type_Specific_Data is record$/
++TYPESTOSTAT	objc-src/PackInsp.h	37
++/Uacute	ps-src/rfc1245.ps	/^\/Uacute \/Ucircumflex \/Ugrave \/dotlessi \/circumflex/
++u_any	c-src/emacs/src/lisp.h	2214
++u_boolfwd	c-src/emacs/src/lisp.h	2371
++u_buffer_objfwd	c-src/emacs/src/lisp.h	2373
++UCHAR	c-src/emacs/src/lisp.h	2424
++_UCHAR_T	c-src/emacs/src/lisp.h	2423
++U_CHAR	y-src/cccp.y	38
++u	c-src/emacs/src/lisp.h	2397
++/udieresis	ps-src/rfc1245.ps	/^\/udieresis \/dagger \/.notdef \/cent \/sterling \/secti/
++u_finalizer	c-src/emacs/src/lisp.h	2219
++u_free	c-src/emacs/src/lisp.h	2215
++u_intfwd	c-src/emacs/src/lisp.h	2370
++u_kboard_objfwd	c-src/emacs/src/lisp.h	2374
++u_marker	c-src/emacs/src/lisp.h	2216
++unargs	tex-src/texinfo.tex	/^\\defunargs {#2}\\endgroup %$/
++unargs	tex-src/texinfo.tex	/^\\defunargs {#3}\\endgroup %$/
++UNARY	y-src/cccp.c	18
++unblock_input	c-src/emacs/src/keyboard.c	/^unblock_input (void)$/
++unblock_input_to	c-src/emacs/src/keyboard.c	/^unblock_input_to (int level)$/
++unchar	c-src/h.h	99
++UNDEFINED	c-src/h.h	118
++UNEVALLED	c-src/emacs/src/lisp.h	2834
++unexpand-abbrev	c-src/abbrev.c	/^DEFUN ("unexpand-abbrev", Funexpand_abbrev, Sunexp/
++UNGCPRO	c-src/emacs/src/lisp.h	3202
++UNGCPRO	c-src/emacs/src/lisp.h	3257
++UNGCPRO	c-src/emacs/src/lisp.h	3353
++univ	merc-src/accumulator.m	/^:- import_module univ.$/
++UNLOCK_ALIGNED_BLOCKS	c-src/emacs/src/gmalloc.c	/^#define UNLOCK_ALIGNED_BLOCKS()				\\$/
++UNLOCK_ALIGNED_BLOCKS	c-src/emacs/src/gmalloc.c	/^#define UNLOCK_ALIGNED_BLOCKS()$/
++UNLOCK	c-src/emacs/src/gmalloc.c	/^#define UNLOCK()				\\$/
++UNLOCK	c-src/emacs/src/gmalloc.c	/^#define UNLOCK()$/
++Unlock/p	ada-src/2ataspri.adb	/^   procedure Unlock (L : in out Lock) is$/
++Unlock/p	ada-src/2ataspri.ads	/^   procedure Unlock (L : in out Lock);$/
++\unnchfopen	tex-src/texinfo.tex	/^\\def\\unnchfopen #1{%$/
++\unnchfplain	tex-src/texinfo.tex	/^\\def\\unnchfplain #1{%$/
++\unnumbchapentry	tex-src/texinfo.tex	/^\\def\\unnumbchapentry#1#2{\\dochapentry{#1}{#2}}$/
++\unnumberedsec	tex-src/texinfo.tex	/^\\outer\\def\\unnumberedsec{\\parsearg\\unnumberedseczz/
++\unnumberedseczzz	tex-src/texinfo.tex	/^\\def\\unnumberedseczzz #1{\\seccheck{unnumberedsec}%/
++\unnumberedsubsec	tex-src/texinfo.tex	/^\\outer\\def\\unnumberedsubsec{\\parsearg\\unnumberedsu/
++\unnumberedsubseczzz	tex-src/texinfo.tex	/^\\def\\unnumberedsubseczzz #1{\\seccheck{unnumberedsu/
++\unnumberedsubsubsec	tex-src/texinfo.tex	/^\\outer\\def\\unnumberedsubsubsec{\\parsearg\\unnumbere/
++\unnumberedsubsubseczzz	tex-src/texinfo.tex	/^\\def\\unnumberedsubsubseczzz #1{\\seccheck{unnumbere/
++\unnumbered	tex-src/texinfo.tex	/^\\outer\\def\\unnumbered{\\parsearg\\unnumberedzzz}$/
++\unnumberedzzz	tex-src/texinfo.tex	/^\\def\\unnumberedzzz #1{\\seccheck{unnumbered}%$/
++\unnumbnoderef	tex-src/texinfo.tex	/^\\def\\unnumbnoderef{\\ifx\\lastnode\\relax\\else$/
++\unnumbsecentry	tex-src/texinfo.tex	/^      \\def\\unnumbsecentry ##1##2{}$/
++\unnumbsecentry	tex-src/texinfo.tex	/^\\def\\unnumbsecentry#1#2{\\dosecentry{#1}{#2}}$/
++\unnumbsetref	tex-src/texinfo.tex	/^\\def\\unnumbsetref#1{%$/
++\unnumbsubsecentry	tex-src/texinfo.tex	/^      \\def\\unnumbsubsecentry ##1##2{}$/
++\unnumbsubsecentry	tex-src/texinfo.tex	/^\\def\\unnumbsubsecentry#1#2{\\dosubsecentry{#1}{#2}}/
++\unnumbsubsubsecentry	tex-src/texinfo.tex	/^      \\def\\unnumbsubsubsecentry ##1##2{}$/
++\unnumbsubsubsecentry	tex-src/texinfo.tex	/^\\def\\unnumbsubsubsecentry#1#2{\\dosubsubsecentry{#1/
++unravel_univ	merc-src/accumulator.m	/^:- some [T] pred unravel_univ(univ::in, T::out) is/
++unread_switch_frame	c-src/emacs/src/keyboard.c	204
++UNSIGNED_CMP	c-src/emacs/src/lisp.h	/^#define UNSIGNED_CMP(a, op, b)						\\$/
++unsignedp	y-src/cccp.y	112
++unwind	c-src/emacs/src/lisp.h	2962
++unwind_int	c-src/emacs/src/lisp.h	2972
++unwind_ptr	c-src/emacs/src/lisp.h	2967
++unwind_void	c-src/emacs/src/lisp.h	2976
++u_objfwd	c-src/emacs/src/lisp.h	2372
++u_overlay	c-src/emacs/src/lisp.h	2217
++__up	c.c	160
++update_accumulator_pred	merc-src/accumulator.m	/^:- pred update_accumulator_pred(pred_id::in, proc_/
++\uppercaseenumerate	tex-src/texinfo.tex	/^\\def\\uppercaseenumerate{%$/
++uprintmax_t	c-src/emacs/src/lisp.h	149
++uprintmax_t	c-src/emacs/src/lisp.h	154
++/U	ps-src/rfc1245.ps	/^\/U { $/
++usage	perl-src/yagrip.pl	/^sub usage {$/
++u_save_value	c-src/emacs/src/lisp.h	2218
++usecharno	c-src/etags.c	210
++used	c-src/emacs/src/regex.h	347
++used_syntax	c-src/emacs/src/regex.h	398
++USE_LSB_TAG	c-src/emacs/src/lisp.h	271
++USE_LSB_TAG	c-src/emacs/src/lisp.h	/^DEFINE_GDB_SYMBOL_BEGIN (bool, USE_LSB_TAG)$/
++USE_PTHREAD	c-src/emacs/src/gmalloc.c	25
++user_cmp_function	c-src/emacs/src/lisp.h	1814
++UserEdit	pyt-src/server.py	/^class UserEdit(Frame):$/
++user_error	c-src/emacs/src/keyboard.c	/^user_error (const char *msg)$/
++user_hash_function	c-src/emacs/src/lisp.h	1811
++User	pyt-src/server.py	/^class User:$/
++user_signal_info	c-src/emacs/src/keyboard.c	7235
++user_signals	c-src/emacs/src/keyboard.c	7250
++USE_SAFE_ALLOCA	c-src/emacs/src/lisp.h	4560
++USE_STACK_CONS	c-src/emacs/src/lisp.h	4689
++USE_STACK_LISP_OBJECTS	c-src/emacs/src/lisp.h	4652
++USE_STACK_LISP_OBJECTS	c-src/emacs/src/lisp.h	4658
++USE_STACK_LISP_OBJECTS	c-src/emacs/src/lisp.h	4659
++USE_STACK_STRING	c-src/emacs/src/lisp.h	4691
++usfreelock_ptr/t	ada-src/etags-test-for.ada	/^   type usfreelock_ptr is access$/
++Vabbrev_start_location_buffer	c-src/abbrev.c	66
++Vabbrev_start_location	c-src/abbrev.c	63
++Vabbrev_table_name_list	c-src/abbrev.c	43
++VALBITS	c-src/emacs/src/lisp.h	246
++valcell	c-src/emacs/src/lisp.h	2357
++val	c-src/emacs/src/lisp.h	3027
++val	c-src/emacs/src/lisp.h	691
++val	c-src/getopt.h	84
++validate	php-src/lce_functions.php	/^      function validate($value)$/
++valid	c-src/etags.c	220
++valid	c-src/etags.c	2502
++valloc	c-src/emacs/src/gmalloc.c	/^valloc (size_t size)$/
++VALMASK	c-src/emacs/src/lisp.h	829
++VALMASK	c-src/emacs/src/lisp.h	/^DEFINE_GDB_SYMBOL_BEGIN (EMACS_INT, VALMASK)$/
++VAL_MAX	c-src/emacs/src/lisp.h	263
++val	prol-src/natded.prolog	/^val(X) --> ['['], valseq(X), [']'].$/
++valseq	prol-src/natded.prolog	/^valseq([Val|Vals]) --> val(Val), plusvalseq(Vals)./
++ValToNmStr	pas-src/common.pas	/^function ValToNmStr; (*($/
++value	c-src/emacs/src/lisp.h	687
++value	y-src/cccp.y	112
++varargs	tex-src/texinfo.tex	/^\\defvarargs {#2}\\endgroup %$/
++varargs	tex-src/texinfo.tex	/^\\defvarargs {#3}\\endgroup %$/
++var	c-src/emacs/src/keyboard.c	11023
++var	c-src/emacs/src/lisp.h	3137
++varset	merc-src/accumulator.m	/^:- import_module varset.$/
++\var	tex-src/texinfo.tex	/^\\def\\var##1{\\realbackslash var {##1}}%$/
++\var	tex-src/texinfo.tex	/^\\def\\var##1{\\realbackslash var {##1}}$/
++vcopy	c-src/emacs/src/lisp.h	/^vcopy (Lisp_Object v, ptrdiff_t offset, Lisp_Objec/
++VECSIZE	c-src/emacs/src/lisp.h	/^#define VECSIZE(type)						\\$/
++vectorlike_header	c-src/emacs/src/lisp.h	1343
++VECTORLIKEP	c-src/emacs/src/lisp.h	/^# define VECTORLIKEP(x) lisp_h_VECTORLIKEP (x)$/
++VECTORP	c-src/emacs/src/lisp.h	/^VECTORP (Lisp_Object x)$/
++verde	cp-src/c.C	40
++verify_ascii	c-src/emacs/src/lisp.h	/^# define verify_ascii(str) (str)$/
++verify-tags-table-function	el-src/emacs/lisp/progmodes/etags.el	/^(defvar verify-tags-table-function nil$/
++VERSION	c-src/etags.c	789
++VERSION	erl-src/gs_dialog.erl	/^-define(VERSION, '2001.1101').$/
++VERSION	objc-src/PackInsp.m	34
++Vfundamental_mode_abbrev_table	c-src/abbrev.c	52
++Vglobal_abbrev_table	c-src/abbrev.c	48
++VHDLFLAGS	make-src/Makefile	/^VHDLFLAGS=--language=none --regex='\/[ \\t]*\\(ARCHIT/
++vignore	c-src/etags.c	2417
++\vindex	tex-src/texinfo.tex	/^\\def\\vindex {\\vrindex}$/
++visit-tags-table-buffer	el-src/emacs/lisp/progmodes/etags.el	/^(defun visit-tags-table-buffer (&optional cont)$/
++visit-tags-table	el-src/emacs/lisp/progmodes/etags.el	/^(defun visit-tags-table (file &optional local)$/
++Vlast_abbrev	c-src/abbrev.c	70
++Vlast_abbrev_text	c-src/abbrev.c	75
++Vlispy_mouse_stem	c-src/emacs/src/keyboard.c	5172
++void	c-src/emacs/src/lisp.h	/^INLINE void (check_cons_list) (void) { lisp_h_chec/
++voidfuncptr	c-src/emacs/src/lisp.h	2108
++voidval	y-src/cccp.y	115
++/V	ps-src/rfc1245.ps	/^\/V { $/
++\vritemindex	tex-src/texinfo.tex	/^\\def\\vritemindex #1{\\doind {vr}{\\code{#1}}}%$/
++\vtable	tex-src/texinfo.tex	/^\\def\\vtable{\\begingroup\\inENV\\obeylines\\obeyspaces/
++waiting_for_input	c-src/emacs/src/keyboard.c	150
++WAIT_READING_MAX	c-src/emacs/src/lisp.h	4281
++WAIT_READING_MAX	c-src/emacs/src/lisp.h	4283
++wait_status_ptr_t	c.c	161
++WARNINGS	make-src/Makefile	/^WARNINGS=-pedantic -Wall -Wpointer-arith -Winline /
++warning	y-src/cccp.y	/^warning (msg)$/
++/wbytes	ps-src/rfc1245.ps	/^\/wbytes { $/
++WCHAR_TYPE_SIZE	y-src/cccp.y	99
++weak_alias	c-src/emacs/src/gmalloc.c	/^weak_alias (free, cfree)$/
++weak	c-src/emacs/src/lisp.h	1830
++web ftp publish	make-src/Makefile	/^web ftp publish:$/
++what	c-src/etags.c	252
++wheel_syms	c-src/emacs/src/keyboard.c	4628
++where	cp-src/clheir.hpp	77
++where	c-src/emacs/src/lisp.h	2348
++where	c-src/emacs/src/lisp.h	2980
++where_in_registry	cp-src/clheir.hpp	15
++WHITE	cp-src/screen.hpp	27
++/wh	ps-src/rfc1245.ps	/^\/wh { $/
++WINDOW_CONFIGURATIONP	c-src/emacs/src/lisp.h	/^WINDOW_CONFIGURATIONP (Lisp_Object a)$/
++WINDOWP	c-src/emacs/src/lisp.h	/^WINDOWP (Lisp_Object a)$/
++WINDOWSNT	c-src/etags.c	101
++WINDOWSNT	c-src/etags.c	102
++windowWillClose	objcpp-src/SimpleCalc.M	/^- windowWillClose:sender$/
++wipe_kboard	c-src/emacs/src/keyboard.c	/^wipe_kboard (KBOARD *kb)$/
++womboid	c-src/h.h	63
++womboid	c-src/h.h	75
++word_size	c-src/emacs/src/lisp.h	1473
++WorkingDays	cp-src/functions.cpp	/^int WorkingDays(Date a, Date b){$/
++WORKING	objc-src/PackInsp.m	368
++/W	ps-src/rfc1245.ps	/^\/W { $/
++write1=	ruby-src/test1.ru	/^    attr_reader :read1 , :read2; attr_writer :writ/
++write2=	ruby-src/test1.ru	/^    attr_reader :read1 , :read2; attr_writer :writ/
++write_abbrev	c-src/abbrev.c	/^write_abbrev (sym, stream)$/
++writebreaklex	prol-src/natded.prolog	/^writebreaklex([]).$/
++writebreak	prol-src/natded.prolog	/^writebreak([]).$/
++writecat	prol-src/natded.prolog	/^writecat(np(ind(sng),nm(_)),np,[],[]):-!.$/
++write_classname	c-src/etags.c	/^write_classname (linebuffer *cn, const char *quali/
++write_lex_cat	prol-src/natded.prolog	/^write_lex_cat(File):-$/
++write_lex	prol-src/natded.prolog	/^write_lex(File):-$/
++writelist	prol-src/natded.prolog	/^writelist([der(Ws)|Ws2]):-$/
++writelistsubs	prol-src/natded.prolog	/^writelistsubs([],X):-$/
++Write_Lock/p	ada-src/2ataspri.adb	/^   procedure Write_Lock (L : in out Lock; Ceiling_/
++Write_Lock/p	ada-src/2ataspri.ads	/^   procedure Write_Lock (L : in out Lock; Ceiling_/
++writenamestring	pas-src/common.pas	/^procedure writenamestring;(*($/
++write	php-src/lce_functions.php	/^      function write()$/
++write	php-src/lce_functions.php	/^      function write($save="yes")$/
++writesubs	prol-src/natded.prolog	/^writesubs([]).$/
++writesups	prol-src/natded.prolog	/^writesups([]).$/
++write_xyc	cp-src/screen.cpp	/^void write_xyc(int x, int y, char c)$/
++written	c-src/etags.c	211
++\w	tex-src/texinfo.tex	/^\\def\\w#1{\\leavevmode\\hbox{#1}}$/
++\w	tex-src/texinfo.tex	/^\\def\\w{\\realbackslash w }%$/
++\w	tex-src/texinfo.tex	/^\\def\\w{\\realbackslash w}$/
++XBOOL_VECTOR	c-src/emacs/src/lisp.h	/^XBOOL_VECTOR (Lisp_Object a)$/
++XBUFFER	c-src/emacs/src/lisp.h	/^XBUFFER (Lisp_Object a)$/
++XBUFFER_OBJFWD	c-src/emacs/src/lisp.h	/^XBUFFER_OBJFWD (union Lisp_Fwd *a)$/
++xcar_addr	c-src/emacs/src/lisp.h	/^xcar_addr (Lisp_Object c)$/
++XCAR	c-src/emacs/src/lisp.h	/^# define XCAR(c) lisp_h_XCAR (c)$/
++x	c.c	153
++x	c.c	179
++x	c.c	188
++x	c.c	189
++xcdr_addr	c-src/emacs/src/lisp.h	/^xcdr_addr (Lisp_Object c)$/
++XCDR	c-src/emacs/src/lisp.h	/^# define XCDR(c) lisp_h_XCDR (c)$/
++XCHAR_TABLE	c-src/emacs/src/lisp.h	/^XCHAR_TABLE (Lisp_Object a)$/
++XCHG_0	c-src/sysdep.h	47
++XCHG_1	c-src/sysdep.h	48
++XCHG_2	c-src/sysdep.h	49
++XCHG_3	c-src/sysdep.h	50
++XCHG_4	c-src/sysdep.h	51
++XCHG_5	c-src/sysdep.h	52
++XCONS	c-src/emacs/src/lisp.h	/^# define XCONS(a) lisp_h_XCONS (a)$/
++x	cp-src/c.C	53
++x	cp-src/c.C	80
++x	cp-src/clheir.hpp	49
++x	cp-src/clheir.hpp	58
++x	cp-src/conway.hpp	7
++x	cp-src/fail.C	10
++x	cp-src/fail.C	44
++X	c-src/h.h	100
++XDEFUN	c.c	/^XDEFUN ("x-get-selection-internal", Fx_get_selecti/
++xdiff	make-src/Makefile	/^xdiff: ETAGS EXTAGS ${infiles}$/
++XFASTINT	c-src/emacs/src/lisp.h	/^#  define XFASTINT(a) lisp_h_XFASTINT (a)$/
++XFASTINT	c-src/emacs/src/lisp.h	/^XFASTINT (Lisp_Object a)$/
++XFINALIZER	c-src/emacs/src/lisp.h	/^XFINALIZER (Lisp_Object a)$/
++XFLOAT	c-src/emacs/src/lisp.h	/^XFLOAT (Lisp_Object a)$/
++XFLOAT_DATA	c-src/emacs/src/lisp.h	/^XFLOAT_DATA (Lisp_Object f)$/
++XFLOATINT	c-src/emacs/src/lisp.h	/^XFLOATINT (Lisp_Object n)$/
++XFWDTYPE	c-src/emacs/src/lisp.h	/^XFWDTYPE (union Lisp_Fwd *a)$/
++x-get-selection-internal	c.c	/^DEFUN ("x-get-selection-internal", Fx_get_selectio/
++x-get-selection-internal	c.c	/^       Fx_get_selection_internal, Sx_get_selection/
++XHASH	c-src/emacs/src/lisp.h	/^# define XHASH(a) lisp_h_XHASH (a)$/
++XHASH_TABLE	c-src/emacs/src/lisp.h	/^XHASH_TABLE (Lisp_Object a)$/
++XIL	c-src/emacs/src/lisp.h	/^# define XIL(i) lisp_h_XIL (i)$/
++XINT	c-src/emacs/src/lisp.h	/^#  define XINT(a) lisp_h_XINT (a)$/
++XINT	c-src/emacs/src/lisp.h	/^XINT (Lisp_Object a)$/
++XINTPTR	c-src/emacs/src/lisp.h	/^XINTPTR (Lisp_Object a)$/
++\xitem	tex-src/texinfo.tex	/^\\def\\xitem{\\errmessage{@xitem while not in a table/
++\xitemx	tex-src/texinfo.tex	/^\\def\\xitemx{\\errmessage{@xitemx while not in a tab/
++\xitemzzz	tex-src/texinfo.tex	/^\\def\\xitemzzz #1{\\dosubind {kw}{\\code{#1}}{for {\\b/
++\xkey	tex-src/texinfo.tex	/^\\def\\xkey{\\key}$/
++XLI_BUILTIN_LISPSYM	c-src/emacs/src/lisp.h	/^#define XLI_BUILTIN_LISPSYM(iname) TAG_SYMOFFSET (/
++XLI	c-src/emacs/src/lisp.h	/^# define XLI(o) lisp_h_XLI (o)$/
++xmalloc	c-src/etags.c	/^xmalloc (size_t size)$/
++XMARKER	c-src/emacs/src/lisp.h	/^XMARKER (Lisp_Object a)$/
++XMISCANY	c-src/emacs/src/lisp.h	/^XMISCANY (Lisp_Object a)$/
++XMISC	c-src/emacs/src/lisp.h	/^XMISC (Lisp_Object a)$/
++XMISCTYPE	c-src/emacs/src/lisp.h	/^XMISCTYPE (Lisp_Object a)$/
++xnew	c-src/etags.c	/^#define xnew(n, Type)      ((Type *) xmalloc ((n) /
++XOVERLAY	c-src/emacs/src/lisp.h	/^XOVERLAY (Lisp_Object a)$/
++XPNTR	c-src/emacs/src/lisp.h	/^# define XPNTR(a) lisp_h_XPNTR (a)$/
++XPROCESS	c-src/emacs/src/lisp.h	/^XPROCESS (Lisp_Object a)$/
++/X	ps-src/rfc1245.ps	/^\/X { $/
++\xrdef	tex-src/texinfo.tex	/^\\def\\xrdef #1#2{$/
++xrealloc	c-src/etags.c	/^xrealloc (void *ptr, size_t size)$/
++xref-etags-location	el-src/emacs/lisp/progmodes/etags.el	/^(defclass xref-etags-location (xref-location)$/
++xref-location-line	el-src/emacs/lisp/progmodes/etags.el	/^(cl-defmethod xref-location-line ((l xref-etags-lo/
++xref-location-marker	el-src/emacs/lisp/progmodes/etags.el	/^(cl-defmethod xref-location-marker ((l xref-etags-/
++xref-make-etags-location	el-src/emacs/lisp/progmodes/etags.el	/^(defun xref-make-etags-location (tag-info file)$/
++\xref	tex-src/texinfo.tex	/^\\def\\xref#1{See \\xrefX[#1,,,,,,,]}$/
++\xrefX[	tex-src/texinfo.tex	/^\\def\\xrefX[#1,#2,#3,#4,#5,#6]{\\begingroup%$/
++xrnew	c-src/etags.c	/^#define xrnew(op, n, Type) ((op) = (Type *) xreall/
++XSAVE_FUNCPOINTER	c-src/emacs/src/lisp.h	/^XSAVE_FUNCPOINTER (Lisp_Object obj, int n)$/
++XSAVE_INTEGER	c-src/emacs/src/lisp.h	/^XSAVE_INTEGER (Lisp_Object obj, int n)$/
++XSAVE_OBJECT	c-src/emacs/src/lisp.h	/^XSAVE_OBJECT (Lisp_Object obj, int n)$/
++XSAVE_POINTER	c-src/emacs/src/lisp.h	/^XSAVE_POINTER (Lisp_Object obj, int n)$/
++XSAVE_VALUE	c-src/emacs/src/lisp.h	/^XSAVE_VALUE (Lisp_Object a)$/
++XSETBOOL_VECTOR	c-src/emacs/src/lisp.h	/^#define XSETBOOL_VECTOR(a, b) (XSETPSEUDOVECTOR (a/
++XSETBUFFER	c-src/emacs/src/lisp.h	/^#define XSETBUFFER(a, b) (XSETPSEUDOVECTOR (a, b, /
++XSETCDR	c-src/emacs/src/lisp.h	/^XSETCDR (Lisp_Object c, Lisp_Object n)$/
++XSETCHAR_TABLE	c-src/emacs/src/lisp.h	/^#define XSETCHAR_TABLE(a, b) (XSETPSEUDOVECTOR (a,/
++XSETCOMPILED	c-src/emacs/src/lisp.h	/^#define XSETCOMPILED(a, b) (XSETPSEUDOVECTOR (a, b/
++XSETCONS	c-src/emacs/src/lisp.h	/^#define XSETCONS(a, b) ((a) = make_lisp_ptr (b, Li/
++XSETFASTINT	c-src/emacs/src/lisp.h	/^#define XSETFASTINT(a, b) ((a) = make_natnum (b))$/
++XSETFLOAT	c-src/emacs/src/lisp.h	/^#define XSETFLOAT(a, b) ((a) = make_lisp_ptr (b, L/
++XSET_HASH_TABLE	c-src/emacs/src/lisp.h	/^#define XSET_HASH_TABLE(VAR, PTR) \\$/
++XSETINT	c-src/emacs/src/lisp.h	/^#define XSETINT(a, b) ((a) = make_number (b))$/
++XSETMISC	c-src/emacs/src/lisp.h	/^#define XSETMISC(a, b) ((a) = make_lisp_ptr (b, Li/
++XSETPROCESS	c-src/emacs/src/lisp.h	/^#define XSETPROCESS(a, b) (XSETPSEUDOVECTOR (a, b,/
++XSETPSEUDOVECTOR	c-src/emacs/src/lisp.h	/^#define XSETPSEUDOVECTOR(a, b, code) \\$/
++XSETPVECTYPE	c-src/emacs/src/lisp.h	/^#define XSETPVECTYPE(v, code)						\\$/
++XSETPVECTYPESIZE	c-src/emacs/src/lisp.h	/^#define XSETPVECTYPESIZE(v, code, lispsize, restsi/
++XSETSTRING	c-src/emacs/src/lisp.h	/^#define XSETSTRING(a, b) ((a) = make_lisp_ptr (b, /
++XSETSUB_CHAR_TABLE	c-src/emacs/src/lisp.h	/^#define XSETSUB_CHAR_TABLE(a, b) (XSETPSEUDOVECTOR/
++XSETSUBR	c-src/emacs/src/lisp.h	/^#define XSETSUBR(a, b) (XSETPSEUDOVECTOR (a, b, PV/
++XSETSYMBOL	c-src/emacs/src/lisp.h	/^#define XSETSYMBOL(a, b) ((a) = make_lisp_symbol (/
++XSETTERMINAL	c-src/emacs/src/lisp.h	/^#define XSETTERMINAL(a, b) (XSETPSEUDOVECTOR (a, b/
++XSETTYPED_PSEUDOVECTOR	c-src/emacs/src/lisp.h	/^#define XSETTYPED_PSEUDOVECTOR(a, b, size, code)		/
++XSETVECTOR	c-src/emacs/src/lisp.h	/^#define XSETVECTOR(a, b) ((a) = make_lisp_ptr (b, /
++XSETWINDOW_CONFIGURATION	c-src/emacs/src/lisp.h	/^#define XSETWINDOW_CONFIGURATION(a, b) \\$/
++XSETWINDOW	c-src/emacs/src/lisp.h	/^#define XSETWINDOW(a, b) (XSETPSEUDOVECTOR (a, b, /
++XSTRING	c-src/emacs/src/lisp.h	/^XSTRING (Lisp_Object a)$/
++XSUB_CHAR_TABLE	c-src/emacs/src/lisp.h	/^XSUB_CHAR_TABLE (Lisp_Object a)$/
++XSUBR	c-src/emacs/src/lisp.h	/^XSUBR (Lisp_Object a)$/
++XSYMBOL	c-src/emacs/src/lisp.h	/^#  define XSYMBOL(a) lisp_h_XSYMBOL (a)$/
++XSYMBOL	c-src/emacs/src/lisp.h	/^XSYMBOL (Lisp_Object a)$/
++XTERMINAL	c-src/emacs/src/lisp.h	/^XTERMINAL (Lisp_Object a)$/
++x	tex-src/texinfo.tex	/^\\refx{#1-snt}{} [\\printednodename], page\\tie\\refx{/
++XTYPE	c-src/emacs/src/lisp.h	/^#  define XTYPE(a) lisp_h_XTYPE (a)$/
++XTYPE	c-src/emacs/src/lisp.h	/^XTYPE (Lisp_Object a)$/
++XUNTAG	c-src/emacs/src/lisp.h	/^#  define XUNTAG(a, type) lisp_h_XUNTAG (a, type)$/
++XUNTAG	c-src/emacs/src/lisp.h	/^XUNTAG (Lisp_Object a, int type)$/
++XWINDOW	c-src/emacs/src/lisp.h	/^XWINDOW (Lisp_Object a)$/
++XX	cp-src/x.cc	1
++xx	make-src/Makefile	/^xx="this line is here because of a fontlock bug$/
++xyz	ruby-src/test1.ru	/^    alias_method :xyz,$/
++Xyzzy	ruby-src/test1.ru	13
++YACC	c-src/etags.c	2199
++Yacc_entries	c-src/etags.c	/^Yacc_entries (FILE *inf)$/
++Yacc_help	c-src/etags.c	693
++Yacc_suffixes	c-src/etags.c	691
++\Yappendixletterandtype	tex-src/texinfo.tex	/^\\def\\Yappendixletterandtype{%$/
++y	cp-src/clheir.hpp	49
++y	cp-src/clheir.hpp	58
++y	cp-src/conway.hpp	7
++Y	c-src/h.h	100
++YELLOW	cp-src/screen.hpp	26
++/yen	ps-src/rfc1245.ps	/^\/yen \/.notdef \/.notdef \/.notdef \/.notdef \/.notdef /
++y-get-selection-internal	c.c	/^      Fy_get_selection_internal, Sy_get_selection_/
++\Ynothing	tex-src/texinfo.tex	/^\\def\\Ynothing{}$/
++\Ypagenumber	tex-src/texinfo.tex	/^\\def\\Ypagenumber{\\folio}$/
++/Y	ps-src/rfc1245.ps	/^\/Y { $/
++\Ysectionnumberandtype	tex-src/texinfo.tex	/^\\def\\Ysectionnumberandtype{%$/
++YSRC	make-src/Makefile	/^YSRC=parse.y parse.c atest.y cccp.c cccp.y$/
++\Ytitle	tex-src/texinfo.tex	/^\\def\\Ytitle{\\thischapter}$/
++YYABORT	/usr/share/bison/bison.simple	153
++YYABORT	/usr/share/bison/bison.simple	154
++YYACCEPT	/usr/share/bison/bison.simple	152
++YYACCEPT	/usr/share/bison/bison.simple	153
++yyalloc	/usr/share/bison/bison.simple	83
++yyalloc	/usr/share/bison/bison.simple	84
++YYBACKUP	/usr/share/bison/bison.simple	/^#define YYBACKUP(Token, Value)					\\$/
++YYBISON	y-src/cccp.c	4
++YYBISON	y-src/parse.c	4
++yyclearin	/usr/share/bison/bison.simple	149
++yyclearin	/usr/share/bison/bison.simple	150
++yydebug	/usr/share/bison/bison.simple	237
++yydebug	/usr/share/bison/bison.simple	238
++YY_DECL_NON_LSP_VARIABLES	/usr/share/bison/bison.simple	374
++YY_DECL_VARIABLES	/usr/share/bison/bison.simple	385
++YY_DECL_VARIABLES	/usr/share/bison/bison.simple	391
++YYDPRINTF	/usr/share/bison/bison.simple	/^# define YYDPRINTF(Args)			\\$/
++YYDPRINTF	/usr/share/bison/bison.simple	/^# define YYDPRINTF(Args)$/
++YYEMPTY	/usr/share/bison/bison.simple	150
++YYEMPTY	/usr/share/bison/bison.simple	151
++YYEOF	/usr/share/bison/bison.simple	151
++YYEOF	/usr/share/bison/bison.simple	152
++YYERRCODE	/usr/share/bison/bison.simple	178
++YYERRCODE	/usr/share/bison/bison.simple	179
++yyerrhandle	/usr/share/bison/bison.simple	848
++yyerrlab1	/usr/share/bison/bison.simple	823
++yyerrok	/usr/share/bison/bison.simple	148
++yyerrok	/usr/share/bison/bison.simple	149
++YYERROR	/usr/share/bison/bison.simple	154
++YYERROR	/usr/share/bison/bison.simple	155
++yyerror	y-src/cccp.y	/^yyerror (s)$/
++yyerrstatus	/usr/share/bison/bison.simple	846
++YYFAIL	/usr/share/bison/bison.simple	158
++YYFAIL	/usr/share/bison/bison.simple	159
++YYFPRINTF	/usr/share/bison/bison.simple	225
++YYFPRINTF	/usr/share/bison/bison.simple	226
++YYINITDEPTH	/usr/share/bison/bison.simple	244
++YYINITDEPTH	/usr/share/bison/bison.simple	245
++YYLEX	/usr/share/bison/bison.simple	200
++YYLEX	/usr/share/bison/bison.simple	201
++YYLEX	/usr/share/bison/bison.simple	202
++YYLEX	/usr/share/bison/bison.simple	203
++YYLEX	/usr/share/bison/bison.simple	206
++YYLEX	/usr/share/bison/bison.simple	207
++YYLEX	/usr/share/bison/bison.simple	208
++YYLEX	/usr/share/bison/bison.simple	209
++YYLEX	/usr/share/bison/bison.simple	212
++YYLEX	/usr/share/bison/bison.simple	213
++yylex	y-src/cccp.y	/^yylex ()$/
++YYLLOC_DEFAULT	/usr/share/bison/bison.simple	/^# define YYLLOC_DEFAULT(Current, Rhs, N)       	\\$/
++yylsp	/usr/share/bison/bison.simple	748
++yylsp	/usr/share/bison/bison.simple	921
++yyls	/usr/share/bison/bison.simple	88
++yyls	/usr/share/bison/bison.simple	89
++YYMAXDEPTH	/usr/share/bison/bison.simple	255
++YYMAXDEPTH	/usr/share/bison/bison.simple	256
++YYMAXDEPTH	/usr/share/bison/bison.simple	259
++YYMAXDEPTH	/usr/share/bison/bison.simple	260
++yymemcpy	/usr/share/bison/bison.simple	264
++yymemcpy	/usr/share/bison/bison.simple	265
++yymemcpy	/usr/share/bison/bison.simple	/^yymemcpy (char *yyto, const char *yyfrom, YYSIZE_T/
++yynewstate	/usr/share/bison/bison.simple	763
++yynewstate	/usr/share/bison/bison.simple	925
++yyn	/usr/share/bison/bison.simple	755
++yyn	/usr/share/bison/bison.simple	861
++yyn	/usr/share/bison/bison.simple	895
++yyn	/usr/share/bison/bison.simple	903
++YYPARSE_PARAM_ARG	/usr/share/bison/bison.simple	351
++YYPARSE_PARAM_ARG	/usr/share/bison/bison.simple	354
++YYPARSE_PARAM_ARG	/usr/share/bison/bison.simple	358
++YYPARSE_PARAM_DECL	/usr/share/bison/bison.simple	352
++YYPARSE_PARAM_DECL	/usr/share/bison/bison.simple	355
++YYPARSE_PARAM_DECL	/usr/share/bison/bison.simple	359
++yyparse	/usr/share/bison/bison.simple	/^yyparse (YYPARSE_PARAM_ARG)$/
++YYPOPSTACK	/usr/share/bison/bison.simple	445
++YYPOPSTACK	/usr/share/bison/bison.simple	447
++YYRECOVERING	/usr/share/bison/bison.simple	/^#define YYRECOVERING()  (!!yyerrstatus)$/
++yyresult	/usr/share/bison/bison.simple	932
++yyresult	/usr/share/bison/bison.simple	939
++yyresult	/usr/share/bison/bison.simple	947
++yyreturn	/usr/share/bison/bison.simple	933
++yyreturn	/usr/share/bison/bison.simple	940
++YYSIZE_T	/usr/share/bison/bison.simple	128
++YYSIZE_T	/usr/share/bison/bison.simple	129
++YYSIZE_T	/usr/share/bison/bison.simple	131
++YYSIZE_T	/usr/share/bison/bison.simple	132
++YYSIZE_T	/usr/share/bison/bison.simple	136
++YYSIZE_T	/usr/share/bison/bison.simple	137
++YYSIZE_T	/usr/share/bison/bison.simple	140
++YYSIZE_T	/usr/share/bison/bison.simple	141
++YYSIZE_T	/usr/share/bison/bison.simple	145
++YYSIZE_T	/usr/share/bison/bison.simple	146
++YYSIZE_T	/usr/share/bison/bison.simple	51
++YYSIZE_T	/usr/share/bison/bison.simple	52
++YYSIZE_T	/usr/share/bison/bison.simple	56
++YYSIZE_T	/usr/share/bison/bison.simple	57
++YYSIZE_T	/usr/share/bison/bison.simple	71
++YYSIZE_T	/usr/share/bison/bison.simple	72
++YYSIZE_T	/usr/share/bison/bison.simple	75
++YYSIZE_T	/usr/share/bison/bison.simple	76
++yyss	/usr/share/bison/bison.simple	85
++yyss	/usr/share/bison/bison.simple	86
++YYSTACK_ALLOC	/usr/share/bison/bison.simple	50
++YYSTACK_ALLOC	/usr/share/bison/bison.simple	51
++YYSTACK_ALLOC	/usr/share/bison/bison.simple	55
++YYSTACK_ALLOC	/usr/share/bison/bison.simple	56
++YYSTACK_ALLOC	/usr/share/bison/bison.simple	59
++YYSTACK_ALLOC	/usr/share/bison/bison.simple	60
++YYSTACK_ALLOC	/usr/share/bison/bison.simple	78
++YYSTACK_ALLOC	/usr/share/bison/bison.simple	79
++YYSTACK_BYTES	/usr/share/bison/bison.simple	/^#  define YYSTACK_BYTES(N) \\$/
++YYSTACK_FREE	/usr/share/bison/bison.simple	79
++YYSTACK_FREE	/usr/share/bison/bison.simple	80
++YYSTACK_FREE	/usr/share/bison/bison.simple	/^#  define YYSTACK_FREE(Ptr) do { \/* empty *\/; } wh/
++YYSTACK_GAP_MAX	/usr/share/bison/bison.simple	93
++YYSTACK_GAP_MAX	/usr/share/bison/bison.simple	94
++YYSTACK_RELOCATE	/usr/share/bison/bison.simple	548
++YYSTACK_RELOCATE	/usr/share/bison/bison.simple	/^# define YYSTACK_RELOCATE(Type, Stack)					\\$/
++yystate	/usr/share/bison/bison.simple	757
++yystate	/usr/share/bison/bison.simple	761
++yystate	/usr/share/bison/bison.simple	875
++yystate	/usr/share/bison/bison.simple	924
++YYSTD	/usr/share/bison/bison.simple	/^# define YYSTD(x) std::x$/
++YYSTD	/usr/share/bison/bison.simple	/^# define YYSTD(x) x$/
++yystpcpy	/usr/share/bison/bison.simple	316
++yystpcpy	/usr/share/bison/bison.simple	317
++yystpcpy	/usr/share/bison/bison.simple	/^yystpcpy (char *yydest, const char *yysrc)$/
++yystrlen	/usr/share/bison/bison.simple	293
++yystrlen	/usr/share/bison/bison.simple	294
++yystrlen	/usr/share/bison/bison.simple	/^yystrlen (const char *yystr)$/
++YYSTYPE	y-src/parse.y	72
++YYSTYPE	y-src/parse.y	73
++YYTERROR	/usr/share/bison/bison.simple	177
++YYTERROR	/usr/share/bison/bison.simple	178
++yyvsp	/usr/share/bison/bison.simple	746
++yyvsp	/usr/share/bison/bison.simple	919
++yyvs	/usr/share/bison/bison.simple	86
++yyvs	/usr/share/bison/bison.simple	87
++z	c.c	144
++z	c.c	164
++z	cp-src/clheir.hpp	49
++z	cp-src/clheir.hpp	58
++Z	c-src/h.h	100
++/Z	ps-src/rfc1245.ps	/^\/Z {$/
+diff --git a/test/manual/etags/Makefile b/test/manual/etags/Makefile
+index b3a82fdba8..24d8397f16 100644
+--- a/test/manual/etags/Makefile
++++ b/test/manual/etags/Makefile
+@@ -60,6 +60,7 @@ check:
+ 	@$(MAKE) OPTIONS='nonexistent --members --declarations --regex=@regexfile' ediff_5
+ 	@$(MAKE) OPTIONS='--class-qualify --members --declarations --regex=@regexfile' ediff_6
+ 	@$(MAKE) cdiff
++	@$(MAKE) ctags_update
+ 
+ ediff%: ETAGS.good% ETAGS ${infiles}
+ 	diff -u --suppress-common-lines --width=80 ETAGS.good$* ETAGS
+@@ -67,6 +68,16 @@ ediff%:
+ cdiff: CTAGS.good CTAGS ${infiles}
+ 	diff -u --suppress-common-lines --width=80 CTAGS.good CTAGS
+ 
++ctags_update: CTAGS.good_update ${infiles}
++	head -n 100 CTAGS.good_update > CTAGS
++	tail -n 100 CTAGS.good_update >> CTAGS
++	${RUN} ${CTAGS_PROG} -o CTAGS -u ${ARGS}
++	diff -u --suppress-common-lines --width=80 CTAGS.good_update CTAGS
++
++	cp crlf CTAGS
++	${RUN} ${CTAGS_PROG} -o CTAGS -u ${ARGS}
++	diff -u --suppress-common-lines --width=80 CTAGS.good_crlf CTAGS
++
+ ETAGS: ${infiles}
+ 	${RUN} ${ETAGS_PROG} ${OPTIONS} -o $@ ${ARGS}
+ 
+diff --git a/test/manual/etags/crlf b/test/manual/etags/crlf
+new file mode 100644
+index 0000000000..d677595f01
+--- /dev/null
++++ b/test/manual/etags/crlf
+@@ -0,0 +1,2 @@
++test_crlf1	test_crlf.c	/^void test_crlf1()$/
++test_crlf2	tset_crlf.c	/^void test_crlf2()$/
+-- 
+2.30.2
+

--- a/metainfo-releases.patch
+++ b/metainfo-releases.patch
@@ -11,11 +11,12 @@ diff --git a/etc/emacs.metainfo.xml b/etc/emacs.metainfo.xml
 index 11df8a7159..65234f87f4 100644
 --- a/etc/emacs.metainfo.xml
 +++ b/etc/emacs.metainfo.xml
-@@ -45,4 +45,12 @@
+@@ -45,4 +45,13 @@
    </screenshot>
   </screenshots>
   <update_contact>emacs-devel_AT_gnu.org</update_contact>
 + <releases>
++   <release date="2022-09-12" version="28.2"/>
 +   <release date="2022-04-04" version="28.1"/>
 +   <release date="2021-03-25" version="27.2"/>
 +   <release date="2020-08-11" version="27.1"/>

--- a/org.gnu.emacs.json
+++ b/org.gnu.emacs.json
@@ -50,6 +50,10 @@
                 },
                 {
                     "type": "patch",
+                    "path": "emacs-fixed-ctags-local-command-execute-vulnerability.patch"
+                },
+                {
+                    "type": "patch",
                     "path": "emacs.desktop-exec-wrapper.patch"
                 },
                 {

--- a/org.gnu.emacs.json
+++ b/org.gnu.emacs.json
@@ -45,8 +45,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://ftp.gnu.org/gnu/emacs/emacs-28.1.tar.xz",
-                    "sha256": "28b1b3d099037a088f0a4ca251d7e7262eab5ea1677aabffa6c4426961ad75e1"
+                    "url": "https://ftp.gnu.org/gnu/emacs/emacs-28.2.tar.xz",
+                    "sha256": "ee21182233ef3232dc97b486af2d86e14042dbb65bbc535df562c3a858232488"
                 },
                 {
                     "type": "patch",


### PR DESCRIPTION
It seems that Emacs 28.2 had also gone missing, but here it finally is