### PR TITLE
Update SDK & runtime to 23.08

### DIFF
--- a/org.gnu.emacs.json
+++ b/org.gnu.emacs.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnu.emacs",
     "runtime": "org.freedesktop.Sdk",
-    "runtime-version": "22.08",
+    "runtime-version": "23.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "emacs-wrapper",
     "rename-icon": "emacs",


### PR DESCRIPTION
A new version of the runtime was recently released, see [here](https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/releases/freedesktop-sdk-23.08.0).