### PR TITLE
migrate to use flatpak to pull ide-flatpak-wrapper directly

### DIFF
--- a/org.gnu.emacs.json
+++ b/org.gnu.emacs.json
@@ -85,8 +85,9 @@
             "buildsystem": "meson",
             "sources": [
                 {
-                    "type": "dir",
-                    "path": "wrapper"
+                    "type": "git",
+                    "url": "https://github.com/flathub/ide-flatpak-wrapper.git",
+                    "commit": "e42aba9acceceb234216e60bb690705992517907"
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
Uses the git source to automatically pull in the wrapper from https://github.com/flathub-infra/ide-flatpak-wrapper

The advantage of this methodology is that it is easy to visibly pin the ide-flatpak-wrapper version to a specific commit, and we can update the version to use by simply updating the commit line in the flatpak manifest.