### PR TITLE
add native compilation support

### DIFF
--- a/mpfr-config-warning.patch
+++ b/mpfr-config-warning.patch
@@ -1,0 +1,24 @@
+From 23f59757ee255cea6fcda3dcf718de4f44dad30b Mon Sep 17 00:00:00 2001
+From: Jeff Walsh <fejfighter@gmail.com>
+Date: Wed, 21 Sep 2022 20:07:45 +1000
+Subject: [PATCH] No error on warning
+
+---
+ autogen.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/autogen.sh b/autogen.sh
+index dc68516..52fca3c 100755
+--- a/autogen.sh
++++ b/autogen.sh
+@@ -24,7 +24,7 @@ for i in $files; do rm -f -- "$i.$$.tmp"; done
+ trap cleanup $signals
+ for i in $files; do mv -f -- "$i" "$i.$$.tmp"; done
+ 
+-autoreconf -v -f -i --warnings=all,error
++autoreconf -v -f -i --warnings=all
+ status=$?
+ 
+ rm -rf autom4te.cache
+-- 
+2.37.3

--- a/org.gnu.emacs.json
+++ b/org.gnu.emacs.json
@@ -59,11 +59,117 @@
 
         },
         {
+            "name": "libgccjit",
+            "buildsystem": "autotools",
+            "config-opts": [
+                "--with-linker-hash-style=gnu",
+                "--enable-checking=release",
+                "--enable-host-shared",
+                "--enable-languages=jit",
+                "--disable-bootstrap",
+                "--disable-gcov",
+                "--disable-libada",
+                "--disable-libgomp",
+                "--disable-liboffloadmic",
+                "--disable-libquadmath",
+                "--disable-libquadmath-support",
+                "--disable-libsanitizer",
+                "--disable-libssp",
+                "--disable-libstdcxx",
+                "--disable-libvtv",
+                "--disable-lto",
+                "--disable-multilib"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gcc.gnu.org/git/gcc.git",
+                    "tag": "releases/gcc-13.2.0"
+                }
+            ],
+            "cleanup": [
+                "/include",
+                "/lib/debug",
+                "/share",
+                "/libexec",
+                "*.la",
+                "*.h"
+            ],
+            "modules": [
+                {
+                    "name": "gmp",
+                    "buildsystem": "autotools",
+                    "config-opts": [
+                        "--enable-static",
+                        "--disable-shared",
+                        "CFLAGS=-fPIC"
+                    ],
+                    "sources": [
+                        {
+                            "type": "archive",
+                            "url": "https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz",
+                            "sha256": "a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898"
+                        }
+                    ],
+                    "cleanup": [
+                        "*"
+                    ]
+                },
+                {
+                    "name": "mpfr",
+                    "buildsystem": "autotools",
+                    "config-opts": [
+                        "--enable-static",
+                        "--disable-shared",
+                        "CFLAGS=-fPIC"
+                    ],
+                    "sources": [
+                        {
+                            "type": "git",
+                            "url": "https://gitlab.inria.fr/mpfr/mpfr.git",
+                            "tag": "4.2.1"
+                        },
+                        {
+                            "type": "patch",
+                            "path": "mpfr-config-warning.patch"
+                        }
+                    ],
+                    "cleanup": [
+                        "*"
+                    ]
+                },
+                {
+                    "name": "mpc",
+                    "buildsystem": "autotools",
+                    "config-opts": [
+                        "--enable-static",
+                        "--disable-shared",
+                        "CFLAGS=-fPIC"
+                    ],
+                    "sources": [
+                        {
+                            "type": "git",
+                            "url": "https://gitlab.inria.fr/mpc/mpc.git",
+                            "tag": "1.3.1"
+                        },
+                        {
+                            "type": "script",
+                            "commands": [ "autoreconf -fi" ]
+                        }
+                    ],
+                    "cleanup": [
+                        "*"
+                    ]
+                }
+            ]
+        },
+        {
             "name": "emacs",
             "buildsystem": "autotools",
             "config-opts": [
                 "--with-gnutls",
-                "--with-tree-sitter"
+                "--with-tree-sitter",
+                "--with-native-compilation"
             ],
             "sources": [
                 {


### PR DESCRIPTION
> Unlike byte-compiled code, natively-compiled Lisp code is executed directly by the machine’s hardware, and therefore runs at full speed that the host CPU can provide. The resulting speedup generally depends on what the Lisp code does, but is usually 2.5 to 5 times faster than the corresponding byte-compiled code. 

[Compilation of Lisp to Native Code](https://www.gnu.org/software/emacs/manual/html_node/elisp/Native-Compilation.html), GNU Emacs Lisp Reference Manual (2024).

Changes adapted from https://github.com/fejfighter/pgtk-emacs-flatpak/tree/master

Addresses #49 