### PR TITLE
Update runtime to version 25.08

### DIFF
--- a/metainfo-vcs-browser.patch
+++ b/metainfo-vcs-browser.patch
@@ -1,0 +1,10 @@
+--- ./etc/emacs.metainfo.xml.orig	2026-03-31 21:42:42.134168939 +0200
++++ ./etc/emacs.metainfo.xml	2026-03-31 21:43:31.503586070 +0200
+@@ -33,6 +33,7 @@
+  <url type="help">https://www.gnu.org/software/emacs/documentation.html</url>
+  <url type="donation">https://my.fsf.org/donate/</url>
+  <url type="contact">https://lists.gnu.org/mailman/listinfo/emacs-devel/</url>
++ <url type="vcs-browser">https://cgit.git.savannah.gnu.org/cgit/emacs.git</url>
+  <launchable type="desktop-id">org.gnu.emacs.desktop</launchable>
+  <launchable type="service">emacs.service</launchable>
+  <project_group>GNU</project_group>

--- a/org.gnu.emacs.json
+++ b/org.gnu.emacs.json
@@ -76,6 +76,10 @@
                 {
                     "type": "patch",
                     "path": "metainfo-caption-point.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "metainfo-vcs-browser.patch"
                 }
             ],
             "cleanup": [

--- a/org.gnu.emacs.json
+++ b/org.gnu.emacs.json
@@ -29,7 +29,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/tree-sitter/tree-sitter.git",
-                    "tag": "v0.25.10"
+                    "tag": "v0.25.10",
+                    "commit": "da6fe9beb4f7f67beb75914ca8e0d48ae48d6406"
                 }
             ],
             "cleanup": [

--- a/org.gnu.emacs.json
+++ b/org.gnu.emacs.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnu.emacs",
     "runtime": "org.freedesktop.Sdk",
-    "runtime-version": "24.08",
+    "runtime-version": "25.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "emacs-wrapper",
     "rename-icon": "emacs",

--- a/org.gnu.emacs.json
+++ b/org.gnu.emacs.json
@@ -97,7 +97,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/flathub-infra/ide-flatpak-wrapper.git",
-                    "commit": "3314b55ccd4ece8810715787e246f8407e20caab"
+                    "commit": "2881abaf9efc6e14923b8a0bb085275aaf2fbddf"
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
Bumped flatpak-ide-wrapper because older versions had issues with SDK 25.08 (see https://github.com/flathub-infra/ide-flatpak-wrapper/issues/30)

Also indulged the linter by adding tree sitter commit SHA and by adding Emacs repo url in metainfo.xml